### PR TITLE
fix: snapshot runtime model architecture profiles (ISSUE-022)

### DIFF
--- a/data/config/models/Qwen3-235B-A22B.json
+++ b/data/config/models/Qwen3-235B-A22B.json
@@ -15,6 +15,7 @@
   "max_position_embeddings": 40960,
   "max_window_layers": 94,
   "mlp_only_layers": [],
+  "model_architecture_profile": "generic",
   "model_type": "qwen3_moe",
   "moe_intermediate_size": 1536,
   "norm_topk_prob": true,

--- a/data/config/models/llama3.3-70b.json
+++ b/data/config/models/llama3.3-70b.json
@@ -13,6 +13,7 @@
     "intermediate_size": 28672,
     "max_position_embeddings": 131072,
     "mlp_bias": false,
+    "model_architecture_profile": "generic",
     "model_type": "llama",
     "num_attention_heads": 64,
     "num_hidden_layers": 80,

--- a/frontier/config/model_config.py
+++ b/frontier/config/model_config.py
@@ -9,7 +9,10 @@ from frontier.attention.ops import AttentionMemoryLayout
 from frontier.config.base_fixed_config import BaseFixedConfig
 from frontier.config.precision_type import PrecisionType
 from frontier.logger import init_logger
-from frontier.model_architectures import get_model_architecture_profile
+from frontier.model_architectures import (
+    MODEL_ARCHITECTURE_REGISTRY,
+    get_model_architecture_profile,
+)
 from frontier.types import ActivationType, NormType
 
 logger = init_logger(__name__)
@@ -315,7 +318,10 @@ class BaseModelConfig(BaseFixedConfig):
                 f"Invalid model_arch '{self.model_arch}'. "
                 f"Must be one of: {ModelArch.VALID_ARCHS}"
             )
-        architecture_profile = self.get_model_architecture_profile()
+        architecture_profile = get_model_architecture_profile(self)
+        self._resolved_model_architecture_profile_id: str = (
+            architecture_profile.profile_id
+        )
 
         # Validate torch_dtype
         PrecisionType.from_torch_dtype(self.torch_dtype)
@@ -448,8 +454,10 @@ class BaseModelConfig(BaseFixedConfig):
         return self.model_arch
 
     def get_model_architecture_profile(self):
-        """Return plugin-style model architecture semantics for this config."""
-        return get_model_architecture_profile(self)
+        """Return this runtime config's construction-time profile snapshot."""
+        return MODEL_ARCHITECTURE_REGISTRY.get(
+            self._resolved_model_architecture_profile_id
+        )
 
     def supports_share_expert(self) -> bool:
         """Check if the model uses share_expert in the FFN path."""

--- a/frontier/model_architectures.py
+++ b/frontier/model_architectures.py
@@ -421,6 +421,10 @@ for _profile in (
 
 
 def get_model_architecture_profile(config: Any) -> ModelArchitectureProfile:
-    """Resolve the model architecture profile for a runtime/profiling config."""
+    """Resolve a profile from the config's current declarative state.
+
+    Runtime ``BaseModelConfig`` consumers use the config-owned accessor so one
+    simulation instance retains its construction-time resolved identity.
+    """
 
     return MODEL_ARCHITECTURE_REGISTRY.resolve(config)

--- a/frontier/scheduler/cluster_scheduler/base_cluster_scheduler.py
+++ b/frontier/scheduler/cluster_scheduler/base_cluster_scheduler.py
@@ -17,7 +17,7 @@ from frontier.execution_time_predictor import (
 )
 from frontier.model_architectures import (
     ExpertParallelCollective,
-    get_model_architecture_profile,
+    ModelArchitectureProfile,
 )
 from frontier.scheduler.replica_scheduler.replica_scheduler_registry import (
     ReplicaSchedulerRegistry,
@@ -39,13 +39,24 @@ def resolve_ep_collective_kind(
     cluster_type: ClusterType,
     expected_ep_size: int,
 ) -> ExpertParallelCollective:
-    """Resolve the EP collective policy from the model architecture profile."""
+    """Resolve EP policy from the runtime config's profile snapshot."""
 
     if model_config is None:
         raise ValueError(
             "EP collective resolution requires replica_config.model_config"
         )
-    profile = get_model_architecture_profile(model_config)
+    profile_getter = getattr(model_config, "get_model_architecture_profile", None)
+    if not callable(profile_getter):
+        raise TypeError(
+            "EP collective resolution requires "
+            "model_config.get_model_architecture_profile()"
+        )
+    profile = profile_getter()
+    if not isinstance(profile, ModelArchitectureProfile):
+        raise TypeError(
+            "model_config.get_model_architecture_profile() must return "
+            "ModelArchitectureProfile"
+        )
     if profile.uses_expert_parallel_alltoall(cluster_type, expected_ep_size):
         return ExpertParallelCollective.ALLTOALL
     return ExpertParallelCollective.ALLGATHER

--- a/frontier/training/attention_trainer.py
+++ b/frontier/training/attention_trainer.py
@@ -29,7 +29,6 @@ from frontier.execution_time_predictor.attention_tp_policy import (
     resolve_effective_attention_tp_size,
 )
 from frontier.logger import init_logger
-from frontier.model_architectures import get_model_architecture_profile
 from frontier.training.base_trainer import BaseTrainer
 
 logger = init_logger(__name__)
@@ -378,7 +377,7 @@ class AttentionTrainer(BaseTrainer):
         if not self.model_config.uses_fused_add_norm:
             required_columns.append("time_stats.add.median")
 
-        architecture_profile = get_model_architecture_profile(self.model_config)
+        architecture_profile = self.model_config.get_model_architecture_profile()
         for op_name in architecture_profile.linear_attention.sharded_ops:
             column_name = f"time_stats.{op_name}.median"
             if column_name not in required_columns:

--- a/tests/unit/test_model_architecture_registry.py
+++ b/tests/unit/test_model_architecture_registry.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+import ast
+import copy
+import json
 import logging
+import pickle
+from contextlib import contextmanager
+from dataclasses import asdict, fields, replace
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Iterator
 
 import pytest
 
 from frontier.config.model_config import BaseModelConfig, MoEModelConfig, ModelArch
+from frontier.config.utils import dataclass_to_dict
 from frontier.model_architectures import (
     ExpertParallelCollective,
     LinearAttentionImplementation,
     LinearAttentionProfile,
+    MODEL_ARCHITECTURE_REGISTRY,
     ModelArchitectureProfile,
     ModelArchitectureRegistry,
     ResidualAddPolicy,
@@ -20,6 +29,105 @@ from frontier.model_architectures import (
 from frontier.profiling.common.model_config import ModelConfig as ProfilingModelConfig
 from frontier.profiling.linear_op.profiling_plan import build_profiling_plan
 from frontier.types import ActivationType, ClusterType, NormType
+
+
+class _LogRecordCollector(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@contextmanager
+def _capture_model_architecture_warnings() -> Iterator[list[logging.LogRecord]]:
+    target_logger = logging.getLogger("frontier.model_architectures")
+    collector = _LogRecordCollector()
+    previous_level = target_logger.level
+    target_logger.addHandler(collector)
+    target_logger.setLevel(logging.WARNING)
+    try:
+        yield collector.records
+    finally:
+        target_logger.removeHandler(collector)
+        target_logger.setLevel(previous_level)
+
+
+def _generic_fallback_records(
+    records: list[logging.LogRecord],
+) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in records
+        if record.name == "frontier.model_architectures"
+        and record.getMessage().startswith(
+            "Model architecture profile fallback selected generic"
+        )
+    ]
+
+
+class _RawProfileResolutionCallCollector(ast.NodeVisitor):
+    def __init__(
+        self,
+        *,
+        function_aliases: set[str],
+        module_aliases: set[str],
+        registry_aliases: set[str],
+    ) -> None:
+        self._function_aliases = function_aliases
+        self._module_aliases = module_aliases
+        self._registry_aliases = registry_aliases
+        self._scope: list[str] = []
+        self.call_counts: dict[tuple[str, str], int] = {}
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._scope.append(name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_kind: str | None = None
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self._function_aliases
+        ):
+            call_kind = "helper"
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_model_architecture_profile"
+            and ast.unparse(node.func.value) in self._module_aliases
+        ):
+            call_kind = "helper"
+        elif isinstance(node.func, ast.Attribute) and node.func.attr == "resolve":
+            registry_expression = node.func.value
+            if (
+                isinstance(registry_expression, ast.Name)
+                and registry_expression.id in self._registry_aliases
+            ):
+                call_kind = "registry.resolve"
+            elif (
+                isinstance(registry_expression, ast.Attribute)
+                and registry_expression.attr == "MODEL_ARCHITECTURE_REGISTRY"
+                and ast.unparse(registry_expression.value) in self._module_aliases
+            ):
+                call_kind = "registry.resolve"
+
+        if call_kind is not None:
+            scope = ".".join(self._scope) or "<module>"
+            key = (scope, call_kind)
+            self.call_counts[key] = self.call_counts.get(key, 0) + 1
+
+        self.generic_visit(node)
 
 
 def _profiling_config(**overrides):
@@ -198,6 +306,360 @@ def test_unknown_model_uses_generic_profile_with_warning(caplog) -> None:
     assert "generic" in caplog.text
 
 
+def test_runtime_model_config_resolves_implicit_profile_once() -> None:
+    with _capture_model_architecture_warnings() as records:
+        cfg = _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile=None,
+        )
+        assert len(_generic_fallback_records(records)) == 1
+
+        profiles = [cfg.get_model_architecture_profile() for _ in range(5)]
+        share_expert_results = [cfg.supports_share_expert() for _ in range(5)]
+
+        assert len(_generic_fallback_records(records)) == 1
+
+    generic_profile = MODEL_ARCHITECTURE_REGISTRY.get("generic")
+    assert cfg.model_architecture_profile is None
+    assert all(profile is generic_profile for profile in profiles)
+    assert share_expert_results == [True] * 5
+
+
+def test_ep_collective_resolver_reuses_runtime_resolved_identity() -> None:
+    from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
+        resolve_ep_collective_kind,
+    )
+
+    with _capture_model_architecture_warnings() as records:
+        cfg = _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile=None,
+        )
+        assert len(_generic_fallback_records(records)) == 1
+
+        collectives = [
+            resolve_ep_collective_kind(
+                cfg,
+                ClusterType.MONOLITHIC,
+                expected_ep_size=2,
+            )
+            for _ in range(5)
+        ]
+
+        assert len(_generic_fallback_records(records)) == 1
+
+    assert collectives == [ExpertParallelCollective.ALLGATHER] * 5
+
+
+def test_ep_collective_resolver_uses_runtime_snapshot_after_identity_mutation() -> None:
+    from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
+        resolve_ep_collective_kind,
+    )
+
+    cfg = _runtime_model_config(
+        model_type="unit_unknown_transformer",
+        model_architecture_profile=None,
+    )
+    generic_profile = MODEL_ARCHITECTURE_REGISTRY.get("generic")
+    step3_profile = MODEL_ARCHITECTURE_REGISTRY.get("step3_text")
+
+    assert cfg.get_model_architecture_profile() is generic_profile
+    assert get_model_architecture_profile(cfg) is generic_profile
+
+    cfg.model_type = "step3_text"
+    collective_after_mutation = resolve_ep_collective_kind(
+        cfg,
+        ClusterType.MONOLITHIC,
+        expected_ep_size=2,
+    )
+    reclassified = replace(cfg, **_step3_mfa_overrides())
+
+    assert cfg.get_model_architecture_profile() is generic_profile
+    assert get_model_architecture_profile(cfg) is step3_profile
+    assert collective_after_mutation is ExpertParallelCollective.ALLGATHER
+    assert reclassified.get_model_architecture_profile() is step3_profile
+    assert get_model_architecture_profile(reclassified) is step3_profile
+
+
+def test_ep_collective_resolver_requires_runtime_profile_accessor() -> None:
+    from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
+        resolve_ep_collective_kind,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=r"model_config\.get_model_architecture_profile\(\)",
+    ):
+        resolve_ep_collective_kind(
+            _profiling_config(model_architecture_profile="generic"),
+            ClusterType.MONOLITHIC,
+            expected_ep_size=2,
+        )
+
+
+def test_ep_collective_resolver_rejects_invalid_runtime_profile() -> None:
+    from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
+        resolve_ep_collective_kind,
+    )
+
+    model_config = SimpleNamespace(
+        model_type="unit_invalid_runtime_profile",
+        model_arch="generic",
+        model_architecture_profile="generic",
+        get_model_architecture_profile=lambda: object(),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=r"get_model_architecture_profile\(\) must return",
+    ):
+        resolve_ep_collective_kind(
+            model_config,
+            ClusterType.MONOLITHIC,
+            expected_ep_size=2,
+        )
+
+
+def test_attention_trainer_reuses_runtime_resolved_identity() -> None:
+    from frontier.training.attention_trainer import AttentionTrainer
+
+    with _capture_model_architecture_warnings() as records:
+        model_config = _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile=None,
+        )
+        trainer = AttentionTrainer.__new__(AttentionTrainer)
+        trainer.model_config = model_config
+
+        required_column_sets = [
+            trainer._get_required_compute_dataset_columns() for _ in range(5)
+        ]
+
+        assert len(_generic_fallback_records(records)) == 1
+
+    assert all(columns == required_column_sets[0] for columns in required_column_sets)
+
+
+def test_raw_model_profile_resolution_callsites_are_allowlisted() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    expected_call_counts = {
+        # Construction binds the runtime snapshot from declarative config state.
+        ("frontier/config/model_config.py", "BaseModelConfig.__post_init__", "helper"): 1,
+        # Config-like prediction adapters may not own a BaseModelConfig snapshot.
+        (
+            "frontier/execution_time_predictor/shared_prediction_model_manager.py",
+            "_resolve_model_architecture_profile",
+            "helper",
+        ): 1,
+        (
+            "frontier/execution_time_predictor/sklearn_disaggregation_execution_time_predictor.py",
+            "SklearnDisaggregationExecutionTimePredictor._resolve_model_architecture_profile_for_config",
+            "helper",
+        ): 1,
+        # Metrics accepts both runtime and structural/profiling config-like objects.
+        (
+            "frontier/metrics/capability_context.py",
+            "CapabilityContext.from_replica_config",
+            "helper",
+        ): 1,
+        # This is the single implementation boundary for raw registry resolution.
+        (
+            "frontier/model_architectures.py",
+            "get_model_architecture_profile",
+            "registry.resolve",
+        ): 1,
+        # Operator binding accepts structural/profiling config-like objects.
+        (
+            "frontier/operators/binding.py",
+            "_get_model_architecture_profile",
+            "helper",
+        ): 1,
+        # Profiling configs intentionally resolve their current declarative state.
+        (
+            "frontier/profiling/common/model_config.py",
+            "ModelConfig.get_model_architecture_profile",
+            "helper",
+        ): 1,
+        (
+            "frontier/profiling/linear_op/linear_op_impl.py",
+            "build_linear_op_attention_module",
+            "helper",
+        ): 1,
+        (
+            "frontier/profiling/linear_op/profiling_plan.py",
+            "build_profiling_plan",
+            "helper",
+        ): 1,
+        (
+            "frontier/profiling/utils/confirmation.py",
+            "build_linear_op_config_sections",
+            "helper",
+        ): 1,
+        # The MTP adapter wraps a profiling config rather than runtime state.
+        (
+            "frontier/spec_decode/mtp_runtime.py",
+            "StructuralModelConfigAdapter.get_model_architecture_profile",
+            "helper",
+        ): 1,
+    }
+    observed_call_counts: dict[tuple[str, str, str], int] = {}
+
+    for path in (repo_root / "frontier").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        function_aliases: set[str] = set()
+        module_aliases: set[str] = set()
+        registry_aliases: set[str] = (
+            {"MODEL_ARCHITECTURE_REGISTRY"}
+            if path == repo_root / "frontier" / "model_architectures.py"
+            else set()
+        )
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "frontier.model_architectures"
+            ):
+                function_aliases.update(
+                    imported.asname or imported.name
+                    for imported in node.names
+                    if imported.name == "get_model_architecture_profile"
+                )
+                registry_aliases.update(
+                    imported.asname or imported.name
+                    for imported in node.names
+                    if imported.name == "MODEL_ARCHITECTURE_REGISTRY"
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module == "frontier":
+                module_aliases.update(
+                    imported.asname or imported.name
+                    for imported in node.names
+                    if imported.name == "model_architectures"
+                )
+            elif isinstance(node, ast.Import):
+                module_aliases.update(
+                    imported.asname or imported.name
+                    for imported in node.names
+                    if imported.name == "frontier.model_architectures"
+                )
+
+        collector = _RawProfileResolutionCallCollector(
+            function_aliases=function_aliases,
+            module_aliases=module_aliases,
+            registry_aliases=registry_aliases,
+        )
+        collector.visit(tree)
+        relative_path = str(path.relative_to(repo_root))
+        for (scope, call_kind), call_count in collector.call_counts.items():
+            observed_call_counts[(relative_path, scope, call_kind)] = call_count
+
+    assert observed_call_counts == expected_call_counts
+
+
+def test_runtime_model_config_replace_re_resolves_implicit_identity() -> None:
+    with _capture_model_architecture_warnings() as records:
+        cfg = _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile=None,
+        )
+        reclassified = replace(
+            cfg,
+            model_type="step3_text",
+            **_step3_mfa_overrides(),
+        )
+        profile = reclassified.get_model_architecture_profile()
+
+    assert len(_generic_fallback_records(records)) == 1
+    assert profile is MODEL_ARCHITECTURE_REGISTRY.get("step3_text")
+    assert cfg.model_architecture_profile is None
+    assert reclassified.model_architecture_profile is None
+
+
+@pytest.mark.parametrize("model_name", ["Qwen3-235B-A22B", "llama3.3-70b"])
+def test_benchmark_model_metadata_declares_generic_profile(model_name: str) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    payload = json.loads(
+        (repo_root / "data" / "config" / "models" / f"{model_name}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert payload["model_architecture_profile"] == "generic"
+
+
+@pytest.mark.parametrize("model_name", ["Qwen3-235B-A22B", "llama3.3-70b"])
+def test_known_generic_model_config_avoids_fallback_warning(
+    model_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo_root)
+
+    with _capture_model_architecture_warnings() as records:
+        cfg = BaseModelConfig.create_from_name(model_name)
+        profile = cfg.get_model_architecture_profile()
+        supports_share_expert = cfg.supports_share_expert()
+
+    assert _generic_fallback_records(records) == []
+    assert cfg.model_architecture_profile == "generic"
+    assert profile is MODEL_ARCHITECTURE_REGISTRY.get("generic")
+    assert supports_share_expert is False
+
+
+def test_runtime_model_profile_cache_preserves_copy_protocols() -> None:
+    with _capture_model_architecture_warnings() as records:
+        cfg = _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile=None,
+        )
+        round_tripped = pickle.loads(pickle.dumps(cfg))
+        copied = copy.deepcopy(cfg)
+        replaced = replace(cfg)
+
+        configs = (cfg, round_tripped, copied, replaced)
+        profiles = [config.get_model_architecture_profile() for config in configs]
+
+    assert len(_generic_fallback_records(records)) == 2
+    assert all(config.model_architecture_profile is None for config in configs)
+    assert all(
+        profile is MODEL_ARCHITECTURE_REGISTRY.get("generic")
+        for profile in profiles
+    )
+
+
+def test_runtime_model_profile_cache_stays_out_of_dataclass_schema() -> None:
+    cfg = _runtime_model_config(model_architecture_profile="generic")
+    internal_name = "_resolved_model_architecture_profile_id"
+
+    assert internal_name not in {field.name for field in fields(BaseModelConfig)}
+    assert internal_name not in asdict(cfg)
+    assert internal_name not in dataclass_to_dict(cfg)
+    assert cfg.get_model_architecture_profile() is MODEL_ARCHITECTURE_REGISTRY.get(
+        "generic"
+    )
+
+
+def test_profiling_model_config_from_known_model_ignores_runtime_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo_root)
+
+    cfg = ProfilingModelConfig.from_model_name("Qwen3-235B-A22B")
+
+    assert cfg.model_architecture_profile == "generic"
+    assert cfg.get_model_architecture_profile() is MODEL_ARCHITECTURE_REGISTRY.get(
+        "generic"
+    )
+
+
+def test_runtime_config_explicit_unknown_profile_fails_fast() -> None:
+    with pytest.raises(ValueError, match="Unknown model architecture profile"):
+        _runtime_model_config(
+            model_type="unit_unknown_transformer",
+            model_architecture_profile="typo_step3_text",
+        )
+
+
 def test_explicit_unknown_profile_fails_fast_without_generic_downgrade() -> None:
     cfg = SimpleNamespace(
         model_type="unit_unknown_transformer",
@@ -270,11 +732,12 @@ def test_ep_collective_resolver_uses_profile_not_step3_model_type() -> None:
         resolve_ep_collective_kind,
     )
 
-    step3_alias_cfg = _profiling_config(
+    step3_alias_cfg = _runtime_model_config(
         model_type="unit_new_step3_like",
         model_architecture_profile="step3_text",
+        **_step3_mfa_overrides(),
     )
-    generic_named_step3_cfg = _profiling_config(
+    generic_named_step3_cfg = _runtime_model_config(
         model_type="step3_text",
         model_architecture_profile="generic",
     )

--- a/tests/unit/test_pdaf_cluster_scheduler_invariants.py
+++ b/tests/unit/test_pdaf_cluster_scheduler_invariants.py
@@ -17,6 +17,7 @@ from frontier.events.ep_alltoall_dispatch_collective_event import (
 )
 from frontier.events.m2n_transfer_end_event import M2NTransferEndEvent
 from frontier.events.global_batch_end_event import GlobalBatchEndEvent
+from frontier.model_architectures import MODEL_ARCHITECTURE_REGISTRY
 from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
     BaseClusterScheduler,
 )
@@ -5586,6 +5587,9 @@ def _ep_scheduler(
                 embedding_dim=4096,
                 model_architecture_profile="step3_text",
                 model_type="step3_text",
+                get_model_architecture_profile=lambda: (
+                    MODEL_ARCHITECTURE_REGISTRY.get("step3_text")
+                ),
             ),
         )
     )

--- a/tests/unit/test_pdaf_step3_combine_payload.py
+++ b/tests/unit/test_pdaf_step3_combine_payload.py
@@ -8,6 +8,7 @@ import pytest
 from frontier.events.ep_alltoall_combine_collective_event import (
     EPAllToAllCombineCollectiveEvent,
 )
+from frontier.model_architectures import MODEL_ARCHITECTURE_REGISTRY
 from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import (
     BaseClusterScheduler,
 )
@@ -45,6 +46,9 @@ def _build_scheduler(
                 model_architecture_profile=architecture_profile,
                 model_type=architecture_profile,
                 embedding_dim=4096,
+                get_model_architecture_profile=lambda: (
+                    MODEL_ARCHITECTURE_REGISTRY.get(architecture_profile)
+                ),
             ),
             moe_expert_parallel_size=2,
         )


### PR DESCRIPTION
# ISSUE-022 PR Record

## Modification History

| Date | Summary of Changes |
|---|---|
| 2026-08-09 | Prepared the standalone GitHub PR body with RCA, TDD, verification, and review evidence. |

> **Integration status: do not merge yet.** This PR is intentionally standalone from PR #10. Merge only after the PR-head evidence and repository review state are inspected on GitHub.

## Summary

This PR fixes ISSUE-022 at its source: runtime model-architecture identity was repeatedly re-resolved instead of being retained by the constructed `BaseModelConfig`. It also removes two confirmed runtime ownership bypasses and explicitly classifies the two downstream benchmark model records.

The change does **not** modify parallel cluster scheduling, pipeline-parallel accounting, event ordering, simulator termination, warning levels, retry behavior, or any timing/scaling factor.

## RCA

### Root cause

`BaseModelConfig.__post_init__()` resolved a `ModelArchitectureProfile` for structural validation and then discarded it. Later runtime access called the raw module-level resolver again.

That was incorrect ownership:

- raw module-level resolution answers what the config's **current declarative fields** imply;
- runtime execution needs the profile snapshot selected when the validated config was **constructed**.

Two additional consumers bypassed the config-owned runtime contract:

- EP collective resolution called raw resolution for completed EP groups;
- `AttentionTrainer` called raw resolution despite owning a real `BaseModelConfig`.

### Consequences

- Unknown implicit MoE models emitted the same generic-fallback warning repeatedly in event/EP paths.
- The warning count and registry work scaled with accesses/events rather than constructed config instances.
- Repeated log I/O inflated absolute sequential and parallel simulator wall-clock.
- A partial fix at `supports_share_expert()` alone would leave the EP/trainer bypasses active.

### Root fix

- Resolve once during `BaseModelConfig.__post_init__()`.
- Retain only the canonical profile ID as ordinary typed instance state:
  `_resolved_model_architecture_profile_id: str`.
- Keep that state outside dataclass fields, flat CLI schema, `asdict()`, `dataclass_to_dict()`, and emitted `config.json`.
- Make the instance getter return the registry singleton by retained ID.
- Keep the module helper raw/current for construction, profiling, config-like adapters, and audits.
- Require EP and trainer runtime owners to use the instance getter; missing/wrong EP interfaces fail fast with `TypeError`, with no raw fallback.
- Explicitly set Qwen3-235B-A22B and llama3.3-70b metadata to `generic`.
- Guard all production raw resolution with an exact file + owning scope + call-kind allowlist, including direct `MODEL_ARCHITECTURE_REGISTRY.resolve(...)`.

## Rejected approaches

- **Store the full profile object:** rejected because profile callables/lambdas are not pickle-safe, leak through dataclass serialization, and lose registry identity under deepcopy.
- **Write inferred identity into the public input field:** rejected because `dataclasses.replace()` then carries stale inferred state as an explicit override.
- **Use an `init=False` dataclass cache field:** rejected because it still appears in `fields()`, `asdict()`, flat schemas, and generated config JSON.
- **Make the global helper cache-aware:** rejected because it reverses ownership and conflates raw/current resolution with runtime snapshot semantics.
- **Suppress/rate-limit warnings:** rejected as a symptom workaround that hides unknown-profile diagnostics.

## TDD evidence

| Cycle | RED evidence | GREEN contract |
|---|---|---|
| Runtime warning ownership | `11 != 1` warnings | one warning per implicit config construction |
| Replace semantics | `generic is not step3_text` | a new config re-resolves declarative identity |
| Schema exclusion | internal ID present in dataclass schema | ordinary instance ID is absent from all public schemas |
| EP/trainer ownership | warning `6 != 1`; `ALLTOALL != ALLGATHER`; missing `TypeError`; forbidden callers | strict config-owned snapshot use |
| Direct registry guard (Claude M1) | legal registry boundary missing from scan | direct/imported/module-qualified global registry calls counted |
| Scoped allowlist (Claude M2) | 11 file-only identities differed from scoped expectations | 11 exact file/scope/kind identities with ownership reasons |

## Fresh verification

Reviewed commit: `4f71d685`  
Reviewed diff SHA-256: `4496077068eca412dfac83e6185b79a63208fa27cedc8745c8f00ce64424bf3d`

| Gate | Result |
|---|---|
| Focused/reviewer set | `461 passed` |
| Affected Attention/metrics/PD-AF/ParamCounter | `176 passed, 1 xfailed` |
| Branch simulator inventory | `1883 passed, 15 failed, 6 skipped, 1 xfailed` |
| Pristine main inventory | `1867 passed, 15 failed, 6 skipped, 1 xfailed` |
| Baseline comparison | exact same 15 failing node IDs; +16 passes equals 16 new tests |
| CPU-torch partition | `16 passed` |
| Exact FlashInfer partition | `25 passed, 3 skipped` |
| Compile / JSON parse / whitespace / 9-file scope | PASS |
| Serialized internal cache keys | `0` in all fresh inspected configs |

The 15 broad-suite failures are pre-existing on pristine main: two logger/caplog capture nodes, ten removed legacy debug/config-optimizer contract nodes, and three FlashInfer CLI nodes under the intentionally wrong simulator-only interpreter. The corresponding dependency-specific partitions pass.

### Fresh system-level E2E metrics

| Architecture/model | Requests | Prefill/decode | Fallback warnings | E2E (ms) | TTFT (ms) | TPOT (ms) |
|---|---:|---:|---:|---:|---:|---:|
| Co-location Qwen3 | 1/1 | 16/2 | 0 | 2644.165871 | 1510.000000 | 1134.165871 |
| Sequential PDD Qwen3 EP2 | 1/1 | 16/2 | 0 | 808.704083 | 20.000000 | 394.040438 |
| Sequential PD-AF Qwen3 EP2 | 1/1 | 16/2 | 0 | 1442.579085 | 20.000000 | 1422.579085 |
| Sequential PD-AF implicit Phi-MoE EP2 | 1/1 | 16/2 | 4 | 504.580572 | 20.000000 | 484.580572 |
| Sequential PD-AF implicit Phi-MoE EP2 | 1/1 | 16/4 | 4 | 1472.657829 | 20.000000 | 484.219276 |

The implicit warning count remains exactly four at both decode lengths because PD-AF constructs four model-config snapshots. It no longer grows with EP/decode event count.

## Independent review

| Review lane | Verdict | Key result |
|---|---|---|
| Local code/spec exact-diff reviewer | APPROVE | 0 findings; independently ran 461 tests |
| Local architecture exact-diff reviewer | CLEAR | 0 WATCH/BLOCK; independently ran 461 tests |
| First StepCode Claude Opus 5/max | APPROVE | found M1/M2; both accepted and remediated through separate RED/GREEN cycles |
| Second adversarial StepCode Claude Opus 5/max | APPROVE | independently confirmed M1/M2 closure, branch/main equivalence, and one construction resolve + zero across 600 accesses |

## Scope and sequencing

- Standalone ISSUE-022 fix only; PR #10 commits are absent.
- No parallel scheduler, PP accounting, event-ordering, or termination change.
- `.codex/` review artifacts and local `task_memory/` records are not part of the commit.
- After this PR is deliberately integrated, rerun the identical native-schema five-pair ABBA sequential/parallel matrix on clean integration bytes before updating wall-clock conclusions.

