### PR TITLE
fix: close profiling envelope and MoE EP domain

### DIFF
--- a/examples/profiling/profile_attention_chunked_prefill.sh
+++ b/examples/profiling/profile_attention_chunked_prefill.sh
@@ -17,6 +17,7 @@ MODEL="${MODEL:-qwen2_dense_test}"
 DEVICE="${DEVICE:-rtx_pro_6000}"
 NUM_GPUS="${NUM_GPUS:-1}"
 MAX_SEQ_LEN="${MAX_SEQ_LEN:-128}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"
 TP_SIZES="${TP_SIZES:-1}"
 PP_SIZES="${PP_SIZES:-1}"
 ATTENTION_BACKEND="${ATTENTION_BACKEND:-NO_OP}"
@@ -73,6 +74,7 @@ while [[ $# -gt 0 ]]; do
     --device) require_cli_value "$1" "${2-}"; DEVICE="$2"; shift 2 ;;
     --num-gpus) require_cli_value "$1" "${2-}"; NUM_GPUS="$2"; shift 2 ;;
     --max-seq-len) require_cli_value "$1" "${2-}"; MAX_SEQ_LEN="$2"; shift 2 ;;
+    --max-model-len) require_cli_value "$1" "${2-}"; MAX_MODEL_LEN="$2"; shift 2 ;;
     --tp-sizes) require_cli_value "$1" "${2-}"; TP_SIZES="$2"; shift 2 ;;
     --pp-sizes) require_cli_value "$1" "${2-}"; PP_SIZES="$2"; shift 2 ;;
     --attention-backend) require_cli_value "$1" "${2-}"; ATTENTION_BACKEND="$2"; shift 2 ;;
@@ -85,6 +87,10 @@ while [[ $# -gt 0 ]]; do
     *) echo "ERROR: unknown option: $1" >&2; exit 2 ;;
   esac
 done
+
+if [ -z "$MAX_MODEL_LEN" ]; then
+  MAX_MODEL_LEN="$MAX_SEQ_LEN"
+fi
 
 require_bool "DRY_RUN" "$DRY_RUN"
 require_bool "ENABLE_CHUNKED_PREFILL_GRID_SEARCH" "$ENABLE_CHUNKED_PREFILL_GRID_SEARCH"
@@ -109,6 +115,7 @@ CMD=(
   --models "$MODEL"
   --num_gpus "$NUM_GPUS"
   --max_seq_len "$MAX_SEQ_LEN"
+  --max_model_len "$MAX_MODEL_LEN"
   --num_tensor_parallel_workers "${TP_SIZE_ARGS[@]}"
   --max_pipeline_parallel_size "${PP_SIZE_ARGS[@]}"
   --attention_backend "$ATTENTION_BACKEND"
@@ -138,6 +145,8 @@ Output taxonomy: data/profiling/compute/<device>/<model>/attention.csv
 Resolved output: $DATA_DIR_BASE/compute/$DEVICE/$MODEL/attention.csv
 Model: $MODEL
 Device: $DEVICE
+Max sequence length: $MAX_SEQ_LEN
+Max model length: $MAX_MODEL_LEN
 TP sizes: $TP_SIZES
 Chunked prefill fixed size: $FIXED_CHUNKED_PREFILL_SIZE
 Chunked prefill grid search: $ENABLE_CHUNKED_PREFILL_GRID_SEARCH

--- a/frontier/profiling/README.md
+++ b/frontier/profiling/README.md
@@ -1,5 +1,11 @@
 # Frontier Profiling Module
 
+## Modification History
+
+| Date       | Summary of Changes |
+|------------|--------------------|
+| 2026-08-22 | Documented the standard attention profiling envelope and runtime KV boundary. |
+
 ## Overview
 
 The `frontier/profiling` module is the hardware profiling subsystem of the Frontier LLM inference simulator. It collects timing data for various LLM operations on real GPU hardware, which is then used to train ML-based execution time predictors for accurate simulation.
@@ -462,6 +468,12 @@ bash examples/profiling/smoke_simulator_moe_csv.sh
 
 Advanced users can call the package entrypoints directly. Direct CLI usage follows the same taxonomy and should pass `--output_dir data/profiling`:
 
+For standard attention, `max_seq_len` bounds automatically generated profiling
+axes. `max_model_len` is the runtime context boundary: an explicit decode KV
+value may exceed `max_seq_len` when it remains at most
+`max_model_len - 1`. The attention wrapper still enforces the available
+physical KV-block capacity during measurement.
+
 ```bash
 # Profile attention operations directly
 python -m frontier.profiling.attention.main \
@@ -470,6 +482,7 @@ python -m frontier.profiling.attention.main \
     --disable_ray \
     --profile_method cuda_event \
     --max_seq_len 4096 \
+    --max_model_len 4096 \
     --num_tensor_parallel_workers 1 2 4 \
     --output_dir data/profiling
 

--- a/frontier/profiling/attention/README_MIXED_BATCH.md
+++ b/frontier/profiling/attention/README_MIXED_BATCH.md
@@ -4,6 +4,7 @@
 
 | Date       | Summary of Changes |
 |------------|--------------------|
+| 2026-08-22 | Documented automatic true-mixed profiling anchors/endpoints and the max_model_len physical-capacity contract |
 | 2026-06-06 | Replaced private checkout path with a repo-relative profiling example; refreshed legacy CSV naming note for release docs |
 | 2026-02-22 | Added true mixed (`--enable_true_mixed`) full CLI parameter set, output files, and mixed dataset fail-fast input contract notes |
 | 2025-12-06 | Added multi-GPU mode documentation; updated CSV naming from legacy MLP naming to `linear_op.csv`; added --disable_ray usage; documented optional --compute_dataset_path |
@@ -20,6 +21,26 @@
 ## 概述
 
 支持混合长度 batch 的 attention prefill profiling 和预测，更贴近真实 serving 场景。
+
+### True-mixed sampling envelope
+
+当 `--true_mixed_prefill_chunk_sizes` 或
+`--true_mixed_decode_kv_cache_sizes` 省略时，采样器按 `max_seq_len`
+构造 profiling envelope：
+
+1. 保留不超过配置 endpoint 的 canonical anchors；
+2. 保留配置 endpoint（prefill 为
+   `max_seq_len - prefill_kv_cache_size`，decode 为 `max_seq_len - 1`）；
+3. 追加 endpoint 上方第一个仍落在 `max_model_len` 物理容量内的 canonical
+   anchor；当该 anchor 超出物理容量时，追加 physical boundary；
+4. 显式传入的 chunk/KV 值与自动轴合并，并只按 `max_model_len` 校验物理
+   execution capacity，因此显式值可以超过 `max_seq_len`，但不能超过
+   `max_model_len`（prefill 还要计入 `prefill_kv_cache_size`，decode 还要
+   为当前 token 预留 1 个位置）。
+
+`max_seq_len` 与 `max_model_len` 的关系必须满足
+`max_model_len >= max_seq_len`。自动候选超出物理容量时会跳过；用户显式
+提供的物理非法值会立即 fail fast。
 
 ## 核心特性
 
@@ -53,9 +74,7 @@ python -m frontier.profiling.attention.main \
     --max_mixed_batch_size 8 \
     --mixed_num_samples 3 \
     --true_mixed_prefill_batch_sizes 1 2 4 \
-    --true_mixed_prefill_chunk_sizes 64 128 256 512 1024 \
     --true_mixed_decode_batch_sizes 1 2 4 8 \
-    --true_mixed_decode_kv_cache_sizes 128 256 512 1024 2048 \
     --true_mixed_prefill_kv_cache_size 0 \
     --models "meta-llama/Llama-2-7b-hf" \
     --num_gpus 1 \
@@ -121,10 +140,12 @@ python -m frontier.training.cli attention \
 | `--mixed_num_samples` | 3 | Random 模式样本数 |
 | `--enable_true_mixed` | False | 启用 true mixed profiling（prefill+decode 同批） |
 | `--true_mixed_prefill_batch_sizes` | `1 2 4` | true mixed 中 prefill 序列数 |
-| `--true_mixed_prefill_chunk_sizes` | `64 128 256 512 1024` | true mixed 中 prefill chunk size |
+| `--true_mixed_prefill_chunk_sizes` | 自动 | 省略时按 `max_seq_len` 派生 canonical anchors、配置 endpoint 和上方首个合法 anchor；若下一个 anchor 超容量则使用 physical boundary；显式值只按 `max_model_len` 校验 |
 | `--true_mixed_decode_batch_sizes` | `1 2 4 8` | true mixed 中 decode 序列数 |
-| `--true_mixed_decode_kv_cache_sizes` | `128 256 512 1024 2048` | true mixed 中 decode KV cache size |
+| `--true_mixed_decode_kv_cache_sizes` | 自动 | 省略时按 `max_seq_len - 1` 配置 endpoint 和上方首个合法 canonical anchor 派生；若下一个 anchor 超容量则使用 physical boundary；显式值可超过 `max_seq_len`，但必须满足 `max_model_len - 1` |
 | `--true_mixed_prefill_kv_cache_size` | 0 | true mixed 中 prefill 侧 KV cache size |
+| `--max_seq_len` | 4096 | 自动 profiling envelope 的最大长度 |
+| `--max_model_len` | 4096 | 物理 execution 上限；必须满足 `max_model_len >= max_seq_len` |
 | `--max_pipeline_parallel_size` | 8 | Pipeline 并行度（影响内存计算） |
 
 ## CSV 字段

--- a/frontier/profiling/attention/README_MIXED_BATCH.md
+++ b/frontier/profiling/attention/README_MIXED_BATCH.md
@@ -4,7 +4,7 @@
 
 | Date       | Summary of Changes |
 |------------|--------------------|
-| 2026-08-22 | Documented automatic true-mixed profiling anchors/endpoints and the max_model_len physical-capacity contract |
+| 2026-08-22 | Documented profiling-envelope versus runtime-context semantics for mixed and true-mixed sampling |
 | 2026-06-06 | Replaced private checkout path with a repo-relative profiling example; refreshed legacy CSV naming note for release docs |
 | 2026-02-22 | Added true mixed (`--enable_true_mixed`) full CLI parameter set, output files, and mixed dataset fail-fast input contract notes |
 | 2025-12-06 | Added multi-GPU mode documentation; updated CSV naming from legacy MLP naming to `linear_op.csv`; added --disable_ray usage; documented optional --compute_dataset_path |
@@ -22,7 +22,16 @@
 
 支持混合长度 batch 的 attention prefill profiling 和预测，更贴近真实 serving 场景。
 
-### True-mixed sampling envelope
+### Mixed sampling envelope
+
+`max_seq_len` 是 profiling envelope；`max_model_len` 是 runtime context
+limit（prompt 与 output 的总长度边界）。物理 KV block / batch token 容量由
+实际执行配置独立约束。
+
+Legacy mixed 和 true mixed 使用同一边界契约：序列轴默认落在
+`max_seq_len` 内，显式 KV / chunk 可以超过该 profiling envelope，但每个
+完整序列必须满足 `max_model_len`。没有 runtime-legal 配对的显式值会
+fail fast。
 
 当 `--true_mixed_prefill_chunk_sizes` 或
 `--true_mixed_decode_kv_cache_sizes` 省略时，采样器按 `max_seq_len`
@@ -31,16 +40,16 @@
 1. 保留不超过配置 endpoint 的 canonical anchors；
 2. 保留配置 endpoint（prefill 为
    `max_seq_len - prefill_kv_cache_size`，decode 为 `max_seq_len - 1`）；
-3. 追加 endpoint 上方第一个仍落在 `max_model_len` 物理容量内的 canonical
-   anchor；当该 anchor 超出物理容量时，追加 physical boundary；
-4. 显式传入的 chunk/KV 值与自动轴合并，并只按 `max_model_len` 校验物理
-   execution capacity，因此显式值可以超过 `max_seq_len`，但不能超过
-   `max_model_len`（prefill 还要计入 `prefill_kv_cache_size`，decode 还要
-   为当前 token 预留 1 个位置）。
+3. 追加 endpoint 上方第一个仍落在 `max_model_len` runtime 边界内的
+   canonical anchor；当该 anchor 超出 runtime 边界时，追加 boundary；
+4. 显式传入的 chunk/KV 值与自动轴合并，并按 `max_model_len` 校验
+   runtime 合法性，因此显式值可以超过 `max_seq_len`；完整 workload
+   仍需满足 `max_model_len`（prefill 还要计入 `prefill_kv_cache_size`，
+   decode 还要为当前 token 预留 1 个位置）。
 
 `max_seq_len` 与 `max_model_len` 的关系必须满足
-`max_model_len >= max_seq_len`。自动候选超出物理容量时会跳过；用户显式
-提供的物理非法值会立即 fail fast。
+`max_model_len >= max_seq_len`。自动候选超出 runtime 边界时会跳过；用户
+显式提供的 runtime 非法值会立即 fail fast。
 
 ## 核心特性
 
@@ -138,6 +147,7 @@ python -m frontier.training.cli attention \
 | `--mixed_mode` | even | even/random/both |
 | `--max_mixed_batch_size` | 8 | 混合 batch 最大大小 |
 | `--mixed_num_samples` | 3 | Random 模式样本数 |
+| `--mixed_kv_cache_size_list` | `0` | 显式 KV；可超过 `max_seq_len`，但每个生成序列必须满足 `max_model_len` |
 | `--enable_true_mixed` | False | 启用 true mixed profiling（prefill+decode 同批） |
 | `--true_mixed_prefill_batch_sizes` | `1 2 4` | true mixed 中 prefill 序列数 |
 | `--true_mixed_prefill_chunk_sizes` | 自动 | 省略时按 `max_seq_len` 派生 canonical anchors、配置 endpoint 和上方首个合法 anchor；若下一个 anchor 超容量则使用 physical boundary；显式值只按 `max_model_len` 校验 |
@@ -145,7 +155,7 @@ python -m frontier.training.cli attention \
 | `--true_mixed_decode_kv_cache_sizes` | 自动 | 省略时按 `max_seq_len - 1` 配置 endpoint 和上方首个合法 canonical anchor 派生；若下一个 anchor 超容量则使用 physical boundary；显式值可超过 `max_seq_len`，但必须满足 `max_model_len - 1` |
 | `--true_mixed_prefill_kv_cache_size` | 0 | true mixed 中 prefill 侧 KV cache size |
 | `--max_seq_len` | 4096 | 自动 profiling envelope 的最大长度 |
-| `--max_model_len` | 4096 | 物理 execution 上限；必须满足 `max_model_len >= max_seq_len` |
+| `--max_model_len` | 4096 | runtime context limit；必须满足 `max_model_len >= max_seq_len` |
 | `--max_pipeline_parallel_size` | 8 | Pipeline 并行度（影响内存计算） |
 
 ## CSV 字段

--- a/frontier/profiling/attention/attention_input.py
+++ b/frontier/profiling/attention/attention_input.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class AttentionInput:
     def __init__(
         self,
@@ -11,7 +14,12 @@ class AttentionInput:
         self.batch_size = batch_size
         self.is_prefill = is_prefill
 
-    def is_valid(self, max_seq_len: int): 
+    def is_valid(
+        self,
+        max_seq_len: int,
+        max_model_len: Optional[int] = None,
+    ):
+        runtime_max_len = max_seq_len if max_model_len is None else max_model_len
         if self.is_prefill:
             if self.batch_size != 1:
                 return False
@@ -19,12 +27,14 @@ class AttentionInput:
                 return False
             elif self.prefill_chunk_size + self.kv_cache_size > max_seq_len:
                 return False
+            elif self.prefill_chunk_size + self.kv_cache_size > runtime_max_len:
+                return False
         else:
             if self.prefill_chunk_size > 0:
                 return False
             elif self.kv_cache_size < 0:
                 return False
-            elif self.kv_cache_size + 1 > max_seq_len:
+            elif self.kv_cache_size + 1 > runtime_max_len:
                 return False
         return True
 

--- a/frontier/profiling/attention/attention_input.py
+++ b/frontier/profiling/attention/attention_input.py
@@ -24,7 +24,7 @@ class AttentionInput:
                 return False
             elif self.kv_cache_size < 0:
                 return False
-            elif self.kv_cache_size > max_seq_len:
+            elif self.kv_cache_size + 1 > max_seq_len:
                 return False
         return True
 

--- a/frontier/profiling/attention/attention_input.py
+++ b/frontier/profiling/attention/attention_input.py
@@ -29,8 +29,9 @@ class AttentionInput:
         return True
 
     def is_under_memory_limit(self, max_num_tokens: int):
+        current_tokens = self.prefill_chunk_size if self.is_prefill else 1
         return (
-            self.batch_size * (self.kv_cache_size + self.prefill_chunk_size)
+            self.batch_size * (self.kv_cache_size + current_tokens)
             <= max_num_tokens
         )
 

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -456,7 +456,8 @@ def parse_args():
         default=None,
         help=(
             "Optional explicit decode KV-cache sizes to profile. "
-            "When provided, this overrides the default decode sequence-length grid."
+            "When provided, this overrides the default decode sequence-length grid "
+            "and may exceed max_seq_len when each value is <= max_model_len - 1."
         ),
     )
     parser.add_argument(
@@ -1684,6 +1685,7 @@ def main():
         decode_kv_cache_size_list=args.decode_kv_cache_size_list,
         enable_chunked_prefill_grid_search=args.enable_chunked_prefill_grid_search,
         fixed_chunked_prefill_size=args.fixed_chunked_prefill_size,
+        max_model_len=args.max_model_len,
     )
 
     # Generate mixed-length prefill input combinations if enabled

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -32,8 +32,9 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from concurrent.futures import ProcessPoolExecutor, as_completed
 import multiprocessing as mp
 
@@ -822,6 +823,91 @@ def _validate_cli_conflicts(args: argparse.Namespace) -> None:
             raise ValueError(
                 "--vllm_mla_cuda_op_log cannot be combined with mixed profiling modes."
             )
+
+
+def _filter_standard_attention_inputs_by_memory(
+    input_combinations: List[AttentionInput],
+    max_num_tokens: int,
+    model: str,
+    tensor_parallel_size: int,
+    explicit_decode_kv_cache_sizes: Optional[List[int]] = None,
+) -> Tuple[List[AttentionInput], Set[int]]:
+    """Filter standard attention inputs and report target-local explicit drops.
+
+    Automatic profiling points are allowed to disappear when a selected
+    model/tensor-parallel target has insufficient physical KV capacity. Explicit
+    decode KV points follow the same per-target filtering policy, but every
+    discarded explicit point is surfaced as a warning so that the resulting CSV
+    coverage is visible to the caller.
+    """
+    explicit_kv_values = {
+        int(value) for value in (explicit_decode_kv_cache_sizes or [])
+    }
+    filtered_inputs: List[AttentionInput] = []
+    retained_explicit_kv: Set[int] = set()
+    discarded_explicit_inputs: List[AttentionInput] = []
+
+    for input_combination in input_combinations:
+        under_memory_limit = input_combination.is_under_memory_limit(max_num_tokens)
+        if under_memory_limit:
+            filtered_inputs.append(input_combination)
+
+        if (
+            not input_combination.is_prefill
+            and input_combination.kv_cache_size in explicit_kv_values
+        ):
+            if under_memory_limit:
+                retained_explicit_kv.add(input_combination.kv_cache_size)
+            else:
+                discarded_explicit_inputs.append(input_combination)
+
+    if discarded_explicit_inputs:
+        discarded_values = sorted(
+            {item.kv_cache_size for item in discarded_explicit_inputs}
+        )
+        retained_values = sorted(retained_explicit_kv)
+        warnings.warn(
+            "Standard attention memory filtering discarded "
+            f"{len(discarded_explicit_inputs)} combination(s) for explicit "
+            f"decode KV values={discarded_values}; model={model!r}, "
+            f"tensor_parallel_size={tensor_parallel_size}, "
+            f"physical_capacity={max_num_tokens} tokens. "
+            f"Retained explicit KV values for this target={retained_values}. "
+            "The discarded rows were omitted for this target; other selected "
+            "targets may retain them.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    return filtered_inputs, retained_explicit_kv
+
+
+def _validate_explicit_decode_kv_coverage(
+    explicit_decode_kv_cache_sizes: Optional[List[int]],
+    retained_explicit_kv: Set[int],
+    target_capacities: Dict[Tuple[str, int], int],
+) -> None:
+    """Fail only when no selected target can profile an explicit KV value."""
+    if not explicit_decode_kv_cache_sizes:
+        return
+
+    requested_values = {int(value) for value in explicit_decode_kv_cache_sizes}
+    missing_values = sorted(requested_values - set(retained_explicit_kv))
+    if not missing_values:
+        return
+
+    capacity_details = ", ".join(
+        f"{model!r}/TP={tensor_parallel_size}: {capacity} tokens"
+        for (model, tensor_parallel_size), capacity in sorted(
+            target_capacities.items(),
+            key=lambda item: (item[0][0], item[0][1]),
+        )
+    )
+    raise ValueError(
+        "no physically legal pairing for explicit decode KV values "
+        f"{missing_values} across the selected model/TP targets; "
+        f"target capacities: {capacity_details or '<none>'}."
+    )
 
 
 def _attach_attention_output_metadata(
@@ -1850,6 +1936,8 @@ def main():
     # Filter standard combinations by memory
     total_combos = {}
     max_num_blocks_dict = {}
+    explicit_decode_kv_retained: Set[int] = set()
+    standard_target_capacities: Dict[Tuple[str, int], int] = {}
     for model in args.models:
         model_config = model_configs[model]
         dtype = model_dtypes[model]
@@ -1864,15 +1952,37 @@ def main():
                 dtype,
                 max_pipeline_parallel_size=args.max_pipeline_parallel_size,
             )
-            max_num_blocks_dict[(model, num_tensor_parallel_workers)] = max_num_blocks
-            total_combos[(model, num_tensor_parallel_workers)] = list(
-                filter(
-                    lambda input_combination: input_combination.is_under_memory_limit(
-                        max_num_blocks * args.block_size
-                    ),
-                    input_combinations,
-                )
+            target_key = (model, num_tensor_parallel_workers)
+            target_capacity = max_num_blocks * args.block_size
+            max_num_blocks_dict[target_key] = max_num_blocks
+            standard_target_capacities[target_key] = target_capacity
+            (
+                total_combos[target_key],
+                retained_target_explicit_kv,
+            ) = _filter_standard_attention_inputs_by_memory(
+                input_combinations,
+                max_num_tokens=target_capacity,
+                model=model,
+                tensor_parallel_size=num_tensor_parallel_workers,
+                explicit_decode_kv_cache_sizes=args.decode_kv_cache_size_list,
             )
+            explicit_decode_kv_retained.update(retained_target_explicit_kv)
+
+    _validate_explicit_decode_kv_coverage(
+        explicit_decode_kv_cache_sizes=args.decode_kv_cache_size_list,
+        retained_explicit_kv=explicit_decode_kv_retained,
+        target_capacities=standard_target_capacities,
+    )
+    if args.decode_kv_cache_size_list is not None:
+        requested_explicit_kv = sorted(
+            {int(value) for value in args.decode_kv_cache_size_list}
+        )
+        print(
+            "Standard attention explicit decode KV coverage after physical "
+            f"filtering: requested={requested_explicit_kv}, "
+            f"retained={sorted(explicit_decode_kv_retained)}, "
+            f"target_capacities={standard_target_capacities}"
+        )
 
     # Calculate total work for progress bar
     total_work = sum(len(v) for v in total_combos.values())

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -629,7 +629,8 @@ def parse_args():
         default=[0],
         help=(
             "Explicit KV cache sizes to profile for mixed prefill inputs. "
-            "Defaults to 0 to preserve existing behavior."
+            "Defaults to 0 to preserve existing behavior. Values may exceed "
+            "max_seq_len when the complete sequence fits max_model_len."
         ),
     )
     parser.add_argument(
@@ -1719,6 +1720,7 @@ def main():
             print(f"KV cache sizes: {args.mixed_kv_cache_size_list}")
             mixed_input_combinations = get_mixed_prefill_input_combinations(
                 max_seq_len=args.max_seq_len,
+                max_model_len=args.max_model_len,
                 min_batch_size=2,  # At least 2 sequences for mixed batch
                 max_batch_size=args.max_mixed_batch_size,
                 mode=args.mixed_mode,

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -602,7 +602,7 @@ def parse_args():
         default=None,
         help=(
             "Optional explicit batch sizes for online_grid mixed profiling. "
-            "When provided, this overrides mixed_batch_size_min/max."
+            "When provided, these values extend the configured batch-size range."
         ),
     )
     parser.add_argument(
@@ -612,7 +612,7 @@ def parse_args():
         default=None,
         help=(
             "Optional explicit total-token values for online_grid mixed profiling. "
-            "When provided, this overrides mixed_total_tokens_min/max."
+            "When provided, these values extend the configured total-token range."
         ),
     )
     parser.add_argument(

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -80,6 +80,7 @@ from frontier.profiling.utils import (
     normalize_profile_method,
     profile_method_to_measurement_type,
     require_profiling_dependencies,
+    _resolve_profile_max_model_len,
 )
 
 
@@ -654,10 +655,12 @@ def parse_args():
         "--true_mixed_prefill_chunk_sizes",
         type=int,
         nargs="+",
-        default=[64, 128, 256, 512, 1024],
+        default=None,
         help=(
-            "Prefill chunk sizes for true mixed-batch profiling. "
-            "These values extend the automatic max-context endpoint."
+            "Optional explicit prefill chunk sizes for true mixed-batch profiling. "
+            "When omitted, canonical anchors and the max_seq_len endpoint are "
+            "derived automatically. Explicit values are checked only against "
+            "max_model_len."
         ),
     )
     parser.add_argument(
@@ -671,10 +674,12 @@ def parse_args():
         "--true_mixed_decode_kv_cache_sizes",
         type=int,
         nargs="+",
-        default=[128, 256, 512, 1024, 2048],
+        default=None,
         help=(
-            "Decode KV cache sizes for true mixed-batch profiling. "
-            "These values extend the automatic max-context endpoint."
+            "Optional explicit decode KV cache sizes for true mixed-batch profiling. "
+            "When omitted, canonical anchors and the max_seq_len endpoint are "
+            "derived automatically. Explicit values are checked only against "
+            "max_model_len."
         ),
     )
     parser.add_argument(
@@ -779,6 +784,8 @@ def _resolve_fp8_settings(
 
 def _validate_cli_conflicts(args: argparse.Namespace) -> None:
     """Validate unsupported argument combinations with fail-fast behavior."""
+    if hasattr(args, "max_seq_len") and hasattr(args, "max_model_len"):
+        _resolve_profile_max_model_len(args.max_seq_len, args.max_model_len)
     if args.profile_only_prefill and args.profile_only_decode:
         raise ValueError(
             "profile_only_prefill and profile_only_decode cannot both be enabled."
@@ -1696,6 +1703,7 @@ def main():
             )
             mixed_input_combinations = get_online_grid_mixed_prefill_input_combinations(
                 max_seq_len=args.max_seq_len,
+                max_model_len=args.max_model_len,
                 min_batch_size=args.mixed_batch_size_min,
                 max_batch_size=args.mixed_batch_size_max,
                 min_total_tokens=args.mixed_total_tokens_min,
@@ -1734,6 +1742,7 @@ def main():
         )
         true_mixed_input_combinations = get_true_mixed_attention_input_combinations(
             max_seq_len=args.max_seq_len,
+            max_model_len=args.max_model_len,
             prefill_batch_sizes=args.true_mixed_prefill_batch_sizes,
             prefill_chunk_sizes=args.true_mixed_prefill_chunk_sizes,
             decode_batch_sizes=args.true_mixed_decode_batch_sizes,

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -655,7 +655,10 @@ def parse_args():
         type=int,
         nargs="+",
         default=[64, 128, 256, 512, 1024],
-        help="Prefill chunk sizes for true mixed-batch profiling.",
+        help=(
+            "Prefill chunk sizes for true mixed-batch profiling. "
+            "These values extend the automatic max-context endpoint."
+        ),
     )
     parser.add_argument(
         "--true_mixed_decode_batch_sizes",
@@ -669,7 +672,10 @@ def parse_args():
         type=int,
         nargs="+",
         default=[128, 256, 512, 1024, 2048],
-        help="Decode KV cache sizes for true mixed-batch profiling.",
+        help=(
+            "Decode KV cache sizes for true mixed-batch profiling. "
+            "These values extend the automatic max-context endpoint."
+        ),
     )
     parser.add_argument(
         "--true_mixed_prefill_kv_cache_size",

--- a/frontier/profiling/moe/load_distribution.py
+++ b/frontier/profiling/moe/load_distribution.py
@@ -43,26 +43,31 @@ def generate_expert_routing(
         topk_ids: Selected expert indices [num_tokens, top_k]
     
     Raises:
-        ValueError: If load_distribution is not recognized
+        ValueError: If dimensions are non-positive or load_distribution is not recognized
     
     Examples:
         >>> weights, ids = generate_expert_routing(1024, 8, 2, "uniform", seed=42)
         >>> weights.shape, ids.shape
         (torch.Size([1024, 2]), torch.Size([1024, 2]))
     """
-    if seed is not None:
-        torch.manual_seed(seed)
-        np.random.seed(seed)
-    
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    
-    # check top_k
+    if num_tokens <= 0:
+        raise ValueError(f"num_tokens must be positive, got {num_tokens}.")
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}.")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}.")
     if top_k > num_experts:
         raise ValueError(
             f"top_k ({top_k}) cannot exceed num_experts ({num_experts}). "
             f"This typically happens when EP is too large. "
             f"Reduce EP so that num_experts_per_device >= router_topk."
         )
+
+    if seed is not None:
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     
     if load_distribution == "uniform":
         # Uniform distribution: each expert has equal probability of being selected

--- a/frontier/profiling/moe/load_distribution.py
+++ b/frontier/profiling/moe/load_distribution.py
@@ -76,9 +76,10 @@ def generate_expert_routing(
         
     elif load_distribution == "skewed":
         # Skewed distribution: some experts are more popular (power law)
-        # Use sqrt(expert_id) as probability weight - earlier experts are more likely
+        # Use a positive offset so every expert remains reachable while higher
+        # IDs remain more likely.
         expert_probs = torch.pow(
-            torch.arange(num_experts, dtype=torch.float, device=device), 
+            torch.arange(num_experts, dtype=torch.float, device=device) + 1.0,
             0.5  # Power factor: 0.5 gives moderate skew
         )
         expert_probs = expert_probs / expert_probs.sum()
@@ -97,7 +98,10 @@ def generate_expert_routing(
     elif load_distribution == "extremely_skewed":
         # Extremely skewed: 80% of tokens use only a small subset of experts
         # This simulates scenarios where certain experts become "hot"
-        popular_experts = min(num_experts // 4, 8)  # Use at most 1/4 of experts or 8
+        popular_experts = min(
+            num_experts,
+            max(top_k, min(num_experts // 4, 8)),
+        )
         
         # 80% of tokens use popular experts, 20% use all experts
         use_popular = torch.rand(num_tokens, device=device) < 0.8
@@ -255,4 +259,3 @@ if __name__ == "__main__":
         print(f"  Gini: {stats['gini']:.3f}")
         print(f"  Entropy: {stats['entropy']:.3f}")
         print(f"  Utilization: {stats['utilization']:.3f}")
-

--- a/frontier/profiling/moe/main.py
+++ b/frontier/profiling/moe/main.py
@@ -540,6 +540,116 @@ def _validate_canonical_moe_result_df(df: pd.DataFrame, *, model: str) -> None:
     )
 
 
+def _get_moe_cases_per_parallel_point(args: argparse.Namespace) -> int:
+    if not args.enable_load_imbalance:
+        return 1
+    return len(args.load_distributions) * args.num_samples_per_distribution
+
+
+def _count_moe_configurations(
+    *,
+    num_tokens_count: int,
+    tensor_parallel_count: int,
+    expert_parallel_count: int,
+    cases_per_parallel_point: int,
+) -> int:
+    return (
+        num_tokens_count
+        * tensor_parallel_count
+        * expert_parallel_count
+        * cases_per_parallel_point
+    )
+
+
+def _build_moe_confirmation_sections(
+    *,
+    args: argparse.Namespace,
+    model_configs: Dict[str, ModelConfig],
+    resolved_ep_sizes_by_model: Dict[str, List[int]],
+    num_tokens_count: int,
+    use_vllm_kernel: bool,
+):
+    from frontier.profiling.utils.confirmation import build_moe_config_sections
+
+    first_model = args.models[0]
+    first_model_config = model_configs[first_model]
+    torch_dtype, precision_str = _resolve_precision_for_model(
+        first_model_config,
+        args.precision,
+        first_model,
+    )
+    confirmation_args = argparse.Namespace(**vars(args))
+    confirmation_args.expert_parallel_sizes = resolved_ep_sizes_by_model[
+        first_model
+    ]
+    sections = build_moe_config_sections(
+        args=confirmation_args,
+        model_config=first_model_config,
+        num_tokens_count=num_tokens_count,
+        use_vllm_kernel=use_vllm_kernel,
+        precision_str=precision_str,
+        torch_dtype=torch_dtype,
+    )
+
+    cases_per_parallel_point = _get_moe_cases_per_parallel_point(args)
+    per_model_rows = []
+    total_configurations = 0
+    for model in args.models:
+        model_config = model_configs[model]
+        ep_sizes = resolved_ep_sizes_by_model[model]
+        model_configurations = _count_moe_configurations(
+            num_tokens_count=num_tokens_count,
+            tensor_parallel_count=len(args.num_tensor_parallel_workers),
+            expert_parallel_count=len(ep_sizes),
+            cases_per_parallel_point=cases_per_parallel_point,
+        )
+        total_configurations += model_configurations
+        _, model_precision = _resolve_precision_for_model(
+            model_config,
+            args.precision,
+            model,
+        )
+        per_model_rows.append(
+            (
+                model,
+                f"{model_config.num_experts} experts; EP={ep_sizes}; "
+                f"precision={model_precision}; "
+                f"{model_configurations:,} configurations",
+            )
+        )
+
+    load_distribution_index = next(
+        (
+            index
+            for index, (section_name, _) in enumerate(sections)
+            if section_name == "Load Distribution"
+        ),
+        len(sections),
+    )
+    sections.insert(
+        load_distribution_index,
+        ("Resolved Model Profiling Domains", per_model_rows),
+    )
+
+    for section_index, (section_name, rows) in enumerate(sections):
+        if section_name != "Profiling Matrix":
+            continue
+        updated_rows = []
+        for key, value in rows:
+            if key == "Total Configurations":
+                value = (
+                    f"~{total_configurations:,}\n"
+                    f"    ({len(args.models)} models with per-model EP domains)"
+                )
+            updated_rows.append((key, value))
+        sections[section_index] = (section_name, updated_rows)
+        break
+    else:
+        raise RuntimeError("MoE confirmation sections are missing Profiling Matrix.")
+
+    return sections
+
+
 def profile_model(
     args: argparse.Namespace, model: str, num_tokens_to_profile: List[int], pbar: Any, use_vllm_kernel: bool
 ):
@@ -578,6 +688,7 @@ def profile_model(
 
     all_results = []
     measurement_type = profile_method_to_measurement_type(args.profile_method).value
+    cases_per_parallel_point = _get_moe_cases_per_parallel_point(args)
 
     # Determine available GPUs for non-Ray mode
     available_gpus = _get_available_gpus(args.num_gpus)
@@ -612,7 +723,14 @@ def profile_model(
     for num_tensor_parallel_workers in args.num_tensor_parallel_workers:
         if model_config.no_tensor_parallel and num_tensor_parallel_workers > 1:
             # Skip TP > 1 for models that don't support tensor parallelism
-            pbar.update(len(expert_parallel_sizes) * len(num_tokens_to_profile))
+            pbar.update(
+                _count_moe_configurations(
+                    num_tokens_count=len(num_tokens_to_profile),
+                    tensor_parallel_count=1,
+                    expert_parallel_count=len(expert_parallel_sizes),
+                    cases_per_parallel_point=cases_per_parallel_point,
+                )
+            )
             continue
 
         def _collect_result(result):
@@ -929,28 +1047,14 @@ def main():
         # Interactive confirmation before profiling
         from frontier.profiling.utils.confirmation import (
             confirm_profiling_execution,
-            build_moe_config_sections,
         )
 
-        # Load first model config for confirmation display
-        first_model = args.models[0]
-        first_model_config = model_configs[first_model]
-        torch_dtype, precision_str = _resolve_precision_for_model(
-            first_model_config, args.precision, first_model
-        )
-
-        confirmation_args = argparse.Namespace(**vars(args))
-        confirmation_args.expert_parallel_sizes = resolved_ep_sizes_by_model[
-            first_model
-        ]
-
-        config_sections = build_moe_config_sections(
-            args=confirmation_args,
-            model_config=first_model_config,
+        config_sections = _build_moe_confirmation_sections(
+            args=args,
+            model_configs=model_configs,
+            resolved_ep_sizes_by_model=resolved_ep_sizes_by_model,
             num_tokens_count=len(num_tokens_to_profile),
             use_vllm_kernel=use_vllm_kernel_default,
-            precision_str=precision_str,
-            torch_dtype=torch_dtype,
         )
 
         if not confirm_profiling_execution(
@@ -961,16 +1065,14 @@ def main():
             sys.exit(0)
 
         # Calculate total combinations using each model's resolved EP domain.
-        cases_per_parallel_point = 1
-        if args.enable_load_imbalance:
-            cases_per_parallel_point = (
-                len(args.load_distributions) * args.num_samples_per_distribution
-            )
+        cases_per_parallel_point = _get_moe_cases_per_parallel_point(args)
         total_combos = sum(
-            len(num_tokens_to_profile)
-            * len(args.num_tensor_parallel_workers)
-            * len(resolved_ep_sizes_by_model[model])
-            * cases_per_parallel_point
+            _count_moe_configurations(
+                num_tokens_count=len(num_tokens_to_profile),
+                tensor_parallel_count=len(args.num_tensor_parallel_workers),
+                expert_parallel_count=len(resolved_ep_sizes_by_model[model]),
+                cases_per_parallel_point=cases_per_parallel_point,
+            )
             for model in args.models
         )
         pbar = tqdm(total=total_combos)

--- a/frontier/profiling/moe/main.py
+++ b/frontier/profiling/moe/main.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import os
 import sys
 import argparse
-import itertools
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -67,6 +66,7 @@ from frontier.profiling.utils import (
     profile_method_to_measurement_type,
     require_profiling_dependencies,
 )
+from frontier.profiling.moe.moe_input import resolve_moe_expert_parallel_sizes
 
 MoEWrapper = None
 
@@ -209,10 +209,10 @@ def parse_args():
         "--expert_parallel_sizes",
         type=int,
         nargs="+",
-        default=[1],
+        default=None,
         help="Expert parallel sizes to profile (distribution parameter, not compute parameter). "
-             "For each EP size, num_experts_per_device = num_experts / expert_parallel_size. "
-             "Example: --expert_parallel_sizes 1 2 4 8",
+             "When omitted, profile every positive divisor of each model's num_experts. "
+             "For each EP size, num_experts_per_device = num_experts / expert_parallel_size.",
     )
     parser.add_argument(
         "--max_tokens",
@@ -571,6 +571,11 @@ def profile_model(
     if not model_config.is_moe:
         raise ValueError(f"Model {model} is not a MoE model (is_moe=False)")
 
+    expert_parallel_sizes = resolve_moe_expert_parallel_sizes(
+        model_config.num_experts,
+        args.expert_parallel_sizes,
+    )
+
     all_results = []
     measurement_type = profile_method_to_measurement_type(args.profile_method).value
 
@@ -607,7 +612,7 @@ def profile_model(
     for num_tensor_parallel_workers in args.num_tensor_parallel_workers:
         if model_config.no_tensor_parallel and num_tensor_parallel_workers > 1:
             # Skip TP > 1 for models that don't support tensor parallelism
-            pbar.update(len(args.expert_parallel_sizes) * len(num_tokens_to_profile))
+            pbar.update(len(expert_parallel_sizes) * len(num_tokens_to_profile))
             continue
 
         def _collect_result(result):
@@ -616,7 +621,7 @@ def profile_model(
             result["measurement_type"] = measurement_type
             all_results.append(result)
 
-        for expert_parallel_size in args.expert_parallel_sizes:
+        for expert_parallel_size in expert_parallel_sizes:
             # Validate EP size
             if model_config.num_experts % expert_parallel_size != 0:
                 raise ValueError(
@@ -895,15 +900,31 @@ def main():
         device_dir = Path(args.output_dir) / "compute" / args.device
         device_dir.mkdir(parents=True, exist_ok=True)
 
-        # Save config to device directory
-        with (device_dir / "moe_config.yaml").open("w", encoding="utf-8") as config_file:
-            yaml.dump(vars(args), config_file)
-
         num_tokens_to_profile = get_num_tokens_to_profile(
             args.max_tokens,
             extra_num_tokens=args.extra_num_tokens,
             num_tokens_list=args.num_tokens_list,
         )
+
+        model_configs = {
+            model: ModelConfig.from_model_name(model) for model in args.models
+        }
+        resolved_ep_sizes_by_model = {}
+        for model, model_config in model_configs.items():
+            if not model_config.is_moe:
+                raise ValueError(f"Model {model} is not a MoE model (is_moe=False)")
+            resolved_ep_sizes_by_model[model] = resolve_moe_expert_parallel_sizes(
+                model_config.num_experts,
+                args.expert_parallel_sizes,
+            )
+
+        # Save both the requested selector and the concrete per-model domain.
+        config_payload = vars(args).copy()
+        config_payload[
+            "resolved_expert_parallel_sizes_by_model"
+        ] = resolved_ep_sizes_by_model
+        with (device_dir / "moe_config.yaml").open("w", encoding="utf-8") as config_file:
+            yaml.dump(config_payload, config_file)
 
         # Interactive confirmation before profiling
         from frontier.profiling.utils.confirmation import (
@@ -913,13 +934,18 @@ def main():
 
         # Load first model config for confirmation display
         first_model = args.models[0]
-        first_model_config = ModelConfig.from_model_name(first_model)
+        first_model_config = model_configs[first_model]
         torch_dtype, precision_str = _resolve_precision_for_model(
             first_model_config, args.precision, first_model
         )
 
+        confirmation_args = argparse.Namespace(**vars(args))
+        confirmation_args.expert_parallel_sizes = resolved_ep_sizes_by_model[
+            first_model
+        ]
+
         config_sections = build_moe_config_sections(
-            args=args,
+            args=confirmation_args,
             model_config=first_model_config,
             num_tokens_count=len(num_tokens_to_profile),
             use_vllm_kernel=use_vllm_kernel_default,
@@ -934,31 +960,24 @@ def main():
         ):
             sys.exit(0)
 
-        # Calculate total combinations: models x num_tokens x TP x EP
-
+        # Calculate total combinations using each model's resolved EP domain.
+        cases_per_parallel_point = 1
         if args.enable_load_imbalance:
-            total_combos = itertools.product(
-                args.models,
-                num_tokens_to_profile,
-                args.num_tensor_parallel_workers,
-                args.expert_parallel_sizes,
-                args.load_distributions,
-                range(args.num_samples_per_distribution),
+            cases_per_parallel_point = (
+                len(args.load_distributions) * args.num_samples_per_distribution
             )
-
-        else:
-            total_combos = itertools.product(
-                args.models,
-                num_tokens_to_profile,
-                args.num_tensor_parallel_workers,
-                args.expert_parallel_sizes,
-            )
-
-        pbar = tqdm(total=len(list(total_combos)))
+        total_combos = sum(
+            len(num_tokens_to_profile)
+            * len(args.num_tensor_parallel_workers)
+            * len(resolved_ep_sizes_by_model[model])
+            * cases_per_parallel_point
+            for model in args.models
+        )
+        pbar = tqdm(total=total_combos)
 
         for model in args.models:
             # Load model config for metadata
-            model_config = ModelConfig.from_model_name(model)
+            model_config = model_configs[model]
             _, precision_str = _resolve_precision_for_model(model_config, args.precision, model)
             result_df = profile_model(
                 args,

--- a/frontier/profiling/moe/moe_input.py
+++ b/frontier/profiling/moe/moe_input.py
@@ -60,7 +60,9 @@ def get_default_moe_profiling_config(
         + list(range(2 * 1024, max_tokens + 1, 32))
     )
     num_tokens_list = [t for t in num_tokens_list if t <= max_tokens]
-    num_tokens_list.sort()
+    if max_tokens > 0:
+        num_tokens_list.append(max_tokens)
+    num_tokens_list = sorted(set(num_tokens_list))
     
     # Expert configurations
     num_experts_list = [num_experts]  # Typically fixed per model
@@ -88,4 +90,3 @@ def get_default_moe_profiling_config(
         expert_hidden_dim=expert_hidden_dim,
         tensor_parallel_size_list=tensor_parallel_size_list,
     )
-

--- a/frontier/profiling/moe/moe_input.py
+++ b/frontier/profiling/moe/moe_input.py
@@ -6,8 +6,10 @@ Following the design principle: EP (expert_parallel_size) is a distribution para
 not a compute parameter, so we use num_experts_per_device instead.
 """
 
+import math
+import operator
 from dataclasses import dataclass
-from typing import List
+from typing import Iterable, List, Optional
 
 from frontier.moe_load_imbalance import MoELoadImbalanceInput
 
@@ -30,6 +32,73 @@ class MoEProfilingConfig:
     
     # Parallelism
     tensor_parallel_size_list: List[int]
+
+
+def get_runtime_legal_expert_parallel_sizes(num_experts: int) -> List[int]:
+    """Return every positive EP divisor accepted by the runtime topology check."""
+    if isinstance(num_experts, bool):
+        raise ValueError("num_experts must be a positive integer")
+    try:
+        normalized_num_experts = operator.index(num_experts)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("num_experts must be a positive integer") from exc
+    if normalized_num_experts <= 0:
+        raise ValueError(
+            f"num_experts must be a positive integer, got {normalized_num_experts}"
+        )
+
+    divisors = set()
+    for candidate in range(1, math.isqrt(normalized_num_experts) + 1):
+        if normalized_num_experts % candidate != 0:
+            continue
+        divisors.add(candidate)
+        divisors.add(normalized_num_experts // candidate)
+    return sorted(divisors)
+
+
+def resolve_moe_expert_parallel_sizes(
+    num_experts: int,
+    requested_sizes: Optional[Iterable[int]] = None,
+) -> List[int]:
+    """Resolve an optional EP selection against the runtime-legal domain."""
+    legal_sizes = get_runtime_legal_expert_parallel_sizes(num_experts)
+    if requested_sizes is None:
+        return legal_sizes
+
+    try:
+        requested_values = list(requested_sizes)
+    except TypeError as exc:
+        raise ValueError(
+            "expert_parallel_sizes must be an iterable of positive integer divisors"
+        ) from exc
+
+    if not requested_values:
+        raise ValueError(
+            "expert_parallel_sizes must contain at least one positive integer divisor"
+        )
+
+    resolved_sizes = []
+    for value in requested_values:
+        if isinstance(value, bool):
+            raise ValueError(
+                "expert_parallel_sizes must contain positive integer divisors; "
+                f"got {value!r}"
+            )
+        try:
+            normalized_value = operator.index(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "expert_parallel_sizes must contain positive integer divisors; "
+                f"got {value!r}"
+            ) from exc
+        if normalized_value not in legal_sizes:
+            raise ValueError(
+                f"expert_parallel_size={normalized_value} must be a positive divisor "
+                f"of num_experts={num_experts}; legal values are {legal_sizes}"
+            )
+        resolved_sizes.append(normalized_value)
+
+    return list(dict.fromkeys(resolved_sizes))
 
 
 def get_default_moe_profiling_config(
@@ -68,15 +137,12 @@ def get_default_moe_profiling_config(
     num_experts_list = [num_experts]  # Typically fixed per model
     router_topk_list = [router_topk]  # Typically fixed per model
     
-    # Number of experts per device (simulates different EP configurations)
-    # EP=1: all experts on one device
-    # EP=2: half experts per device
-    # EP=4: quarter experts per device
-    # EP=8: 1/8 experts per device
-    num_experts_per_device_list = []
-    for divisor in [1, 2, 4, 8]:
-        if num_experts % divisor == 0:
-            num_experts_per_device_list.append(num_experts // divisor)
+    # Include every runtime-legal EP divisor so the profiling envelope is a
+    # superset of the runtime topology domain.
+    num_experts_per_device_list = [
+        num_experts // expert_parallel_size
+        for expert_parallel_size in get_runtime_legal_expert_parallel_sizes(num_experts)
+    ]
     
     # Tensor parallelism configurations
     tensor_parallel_size_list = [1, 2, 4, 8]

--- a/frontier/profiling/moe/moe_wrapper.py
+++ b/frontier/profiling/moe/moe_wrapper.py
@@ -4,6 +4,7 @@ MoE profiling wrapper.
 This module wraps MoE operations for profiling, following the same pattern as the linear-op wrapper.
 """
 
+import operator
 import os
 from typing import List, Optional
 
@@ -294,8 +295,9 @@ class MoEWrapper:
                 load_distribution=load_distribution,
                 seed=seed,
             )
-            if expert_token_counts is None:
-                expert_token_counts = self._compute_local_expert_token_counts(topk_ids)
+            generated_expert_token_counts = self._compute_local_expert_token_counts(
+                topk_ids
+            )
             profiling_global_num_experts = self.num_experts
             profiling_expert_map = self._build_local_expert_map(topk_ids.device)
         else:
@@ -306,11 +308,56 @@ class MoEWrapper:
                 load_distribution=load_distribution,
                 seed=seed,
             )
-            if expert_token_counts is None:
-                expert_token_counts = compute_expert_token_counts(
-                    topk_ids,
-                    self.num_experts_per_device,
+            generated_expert_token_counts = compute_expert_token_counts(
+                topk_ids,
+                self.num_experts_per_device,
+            )
+
+        if expert_token_counts is None:
+            expert_token_counts = generated_expert_token_counts
+        else:
+            try:
+                supplied_counts = list(expert_token_counts)
+            except TypeError as exc:
+                raise ValueError(
+                    "expert_token_counts must be an iterable of non-negative integers."
+                ) from exc
+
+            if len(supplied_counts) != len(generated_expert_token_counts):
+                raise ValueError(
+                    "expert_token_counts length does not match the local expert "
+                    f"width: expected {len(generated_expert_token_counts)}, "
+                    f"got {len(supplied_counts)}."
                 )
+
+            normalized_counts = []
+            for expert_id, count in enumerate(supplied_counts):
+                if isinstance(count, bool):
+                    raise ValueError(
+                        "expert_token_counts must contain non-negative integers; "
+                        f"expert {expert_id} has boolean value {count!r}."
+                    )
+                try:
+                    normalized_count = operator.index(count)
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise ValueError(
+                        "expert_token_counts must contain non-negative integers; "
+                        f"expert {expert_id} has value {count!r}."
+                    ) from exc
+                if normalized_count < 0:
+                    raise ValueError(
+                        "expert_token_counts must contain non-negative integers; "
+                        f"expert {expert_id} has value {count!r}."
+                    )
+                normalized_counts.append(normalized_count)
+
+            if normalized_counts != generated_expert_token_counts:
+                raise ValueError(
+                    "expert_token_counts must match the counts derived from the "
+                    f"generated routing IDs: supplied={normalized_counts}, "
+                    f"generated={generated_expert_token_counts}."
+                )
+            expert_token_counts = normalized_counts
 
         return {
             "topk_weights": topk_weights,

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -41,6 +41,8 @@ EXPORTABLE_PROFILE_METHOD_CHOICES = [
 ]
 
 _MAX_MIXED_ATTENTION_BATCH_SIZE = 128
+_TRUE_MIXED_PREFILL_CHUNK_ANCHORS = (64, 128, 256, 512, 1024)
+_TRUE_MIXED_DECODE_KV_ANCHORS = (128, 256, 512, 1024, 2048)
 
 
 def normalize_profile_method(profile_method: str) -> str:
@@ -586,7 +588,6 @@ def get_mixed_prefill_input_combinations(
             "kv_cache_sizes values must be <= max_seq_len - 1, "
             f"got {oversized_kv_cache_sizes}."
         )
-
     input_combinations = []
     seen_inputs = set()
 
@@ -771,7 +772,7 @@ def _validate_online_grid_seq_lens(
     seq_lens: List[int],
     batch_size: int,
     total_tokens: int,
-    max_seq_len: int,
+    max_model_len: int,
     kv_cache_size: int = 0,
 ) -> None:
     if len(seq_lens) != batch_size:
@@ -784,17 +785,17 @@ def _validate_online_grid_seq_lens(
         )
     if min(seq_lens) <= 0:
         raise RuntimeError("All seq_lens values must be positive.")
-    if max(seq_lens) > max_seq_len:
+    if max(seq_lens) > max_model_len:
         raise RuntimeError(
-            f"Invalid seq_lens max: {max(seq_lens)} exceeds max_seq_len={max_seq_len}."
+            f"Invalid seq_lens max: {max(seq_lens)} exceeds max_model_len={max_model_len}."
         )
     if kv_cache_size < 0:
         raise RuntimeError("kv_cache_size must be non-negative.")
-    if max(seq_lens) + kv_cache_size > max_seq_len:
+    if max(seq_lens) + kv_cache_size > max_model_len:
         raise RuntimeError(
             "Invalid seq_lens + kv_cache_size: "
             f"max(seq_lens) + kv_cache_size = {max(seq_lens) + kv_cache_size} "
-            f"exceeds max_seq_len={max_seq_len}."
+            f"exceeds max_model_len={max_model_len}."
         )
 
 
@@ -819,6 +820,53 @@ def _normalize_positive_int_list(
     return sorted(normalized)
 
 
+def _resolve_profile_max_model_len(
+    max_seq_len: int,
+    max_model_len: Optional[int],
+) -> int:
+    if max_seq_len <= 0:
+        raise ValueError("max_seq_len must be positive.")
+    resolved_max_model_len = (
+        max_seq_len if max_model_len is None else int(max_model_len)
+    )
+    if resolved_max_model_len <= 0:
+        raise ValueError("max_model_len must be positive.")
+    if resolved_max_model_len < max_seq_len:
+        raise ValueError(
+            "max_model_len must be >= max_seq_len, got "
+            f"max_model_len={resolved_max_model_len}, max_seq_len={max_seq_len}."
+        )
+    return resolved_max_model_len
+
+
+def _derive_axis_with_headroom(
+    *,
+    anchors: tuple[int, ...],
+    config_max: int,
+    physical_max: int,
+    minimum: int,
+) -> List[int]:
+    """Build an automatic axis through the first legal point above config_max."""
+    values = [
+        anchor
+        for anchor in sorted(anchors)
+        if minimum <= anchor <= config_max
+    ]
+    if config_max >= minimum:
+        values.append(config_max)
+
+    next_anchor = next(
+        (anchor for anchor in sorted(anchors) if anchor > config_max),
+        None,
+    )
+    headroom_value = (
+        next_anchor if next_anchor is not None and next_anchor <= physical_max else physical_max
+    )
+    if headroom_value > config_max and headroom_value >= minimum:
+        values.append(headroom_value)
+    return sorted(set(values))
+
+
 def get_online_grid_mixed_prefill_input_combinations(
     max_seq_len: int,
     min_batch_size: int,
@@ -829,6 +877,7 @@ def get_online_grid_mixed_prefill_input_combinations(
     kv_cache_sizes: Optional[List[int]] = None,
     batch_size_list: Optional[List[int]] = None,
     total_tokens_list: Optional[List[int]] = None,
+    max_model_len: Optional[int] = None,
 ):
     """
     Generate deterministic mixed prefill inputs for online serving coverage.
@@ -840,8 +889,7 @@ def get_online_grid_mixed_prefill_input_combinations(
     """
     from frontier.profiling.attention.mixed_attention_input import MixedAttentionInput
 
-    if max_seq_len <= 0:
-        raise ValueError("max_seq_len must be positive.")
+    max_model_len = _resolve_profile_max_model_len(max_seq_len, max_model_len)
     if min_batch_size < 2:
         raise ValueError("min_batch_size must be >= 2.")
     if max_batch_size < min_batch_size:
@@ -857,22 +905,12 @@ def get_online_grid_mixed_prefill_input_combinations(
         raise ValueError("max_total_tokens must be >= min_total_tokens.")
     if shapes_per_point not in (1, 2):
         raise ValueError("shapes_per_point must be 1 or 2.")
-    if kv_cache_sizes is None:
-        kv_cache_sizes = [0]
-    if not kv_cache_sizes:
-        raise ValueError("kv_cache_sizes cannot be empty.")
-    if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
-        raise ValueError("All kv_cache_sizes must be non-negative.")
-    oversized_kv_cache_sizes = [
-        kv_cache_size
-        for kv_cache_size in kv_cache_sizes
-        if kv_cache_size >= max_seq_len
-    ]
-    if oversized_kv_cache_sizes:
-        raise ValueError(
-            "kv_cache_sizes values must be <= max_seq_len - 1, "
-            f"got {oversized_kv_cache_sizes}."
-        )
+    explicit_kv_cache_sizes = kv_cache_sizes is not None
+    kv_cache_sizes = _normalize_positive_int_list(
+        "kv_cache_sizes",
+        [0] if kv_cache_sizes is None else kv_cache_sizes,
+        minimum=0,
+    )
 
     batch_size_extensions = _normalize_positive_int_list(
         "batch_size_list",
@@ -903,68 +941,139 @@ def get_online_grid_mixed_prefill_input_combinations(
     if total_token_extensions is not None:
         total_tokens_values.update(total_token_extensions)
     total_tokens_values = sorted(total_tokens_values)
+    explicit_batch_sizes = set(batch_size_extensions or ())
+    explicit_total_tokens = set(total_token_extensions or ())
+    explicit_kv_sizes = set(kv_cache_sizes if explicit_kv_cache_sizes else ())
 
     input_combinations = []
+    valid_batch_sizes = set()
+    valid_total_tokens = set()
+    valid_kv_sizes = set()
     for batch_size in batch_sizes:
         for total_tokens in total_tokens_values:
+            point_is_explicit = (
+                batch_size in explicit_batch_sizes
+                and total_tokens in explicit_total_tokens
+            )
             if total_tokens < batch_size:
-                raise ValueError(
-                    f"Invalid grid point: total_tokens={total_tokens} < batch_size={batch_size}."
-                )
-            if total_tokens > batch_size * max_seq_len:
-                raise ValueError(
-                    f"Invalid grid point: total_tokens={total_tokens} exceeds "
-                    f"batch_capacity={batch_size * max_seq_len}."
-                )
+                if point_is_explicit:
+                    raise ValueError(
+                        f"Invalid grid point: total_tokens={total_tokens} < "
+                        f"batch_size={batch_size}."
+                    )
+                continue
+            if total_tokens > batch_size * max_model_len:
+                if point_is_explicit:
+                    raise ValueError(
+                        f"Invalid grid point: total_tokens={total_tokens} exceeds "
+                        f"batch_capacity={batch_size * max_model_len}."
+                    )
+                continue
 
             balanced_seq_lens = _build_balanced_seq_lens(
                 batch_size=batch_size,
                 total_tokens=total_tokens,
             )
             skewed_seq_lens = None
-            if shapes_per_point == 2:
-                skewed_seq_lens = _build_skewed_seq_lens(
-                    batch_size=batch_size,
-                    total_tokens=total_tokens,
-                    max_seq_len=max_seq_len,
-                )
-                if skewed_seq_lens == balanced_seq_lens:
-                    raise RuntimeError(
-                        "Balanced and skewed seq_lens are identical; cannot satisfy "
-                        "shapes_per_point=2."
-                    )
-
-            for kv_cache_size in kv_cache_sizes:
-                _validate_online_grid_seq_lens(
-                    seq_lens=balanced_seq_lens,
-                    batch_size=batch_size,
-                    total_tokens=total_tokens,
-                    max_seq_len=max_seq_len,
-                    kv_cache_size=kv_cache_size,
-                )
-                input_combinations.append(
-                    MixedAttentionInput(
-                        seq_lens=balanced_seq_lens,
-                        kv_cache_size=kv_cache_size,
-                        mode="online_grid_balanced",
-                    )
-                )
-
-                if skewed_seq_lens is not None:
-                    _validate_online_grid_seq_lens(
-                        seq_lens=skewed_seq_lens,
+            try:
+                if shapes_per_point == 2:
+                    skewed_seq_lens = _build_skewed_seq_lens(
                         batch_size=batch_size,
                         total_tokens=total_tokens,
-                        max_seq_len=max_seq_len,
+                        max_seq_len=max_model_len,
+                    )
+                    if skewed_seq_lens == balanced_seq_lens:
+                        raise RuntimeError(
+                            "Balanced and skewed seq_lens are identical; cannot satisfy "
+                            "shapes_per_point=2."
+                        )
+            except (RuntimeError, ValueError) as exc:
+                if point_is_explicit:
+                    raise ValueError(
+                        f"Invalid explicit online_grid point "
+                        f"(batch_size={batch_size}, total_tokens={total_tokens}): {exc}"
+                    ) from exc
+                continue
+
+            point_inputs = []
+            valid_point_kv_sizes = set()
+            for kv_cache_size in kv_cache_sizes:
+                kv_has_valid_shape = False
+                try:
+                    _validate_online_grid_seq_lens(
+                        seq_lens=balanced_seq_lens,
+                        batch_size=batch_size,
+                        total_tokens=total_tokens,
+                        max_model_len=max_model_len,
                         kv_cache_size=kv_cache_size,
                     )
-                    input_combinations.append(
+                    point_inputs.append(
                         MixedAttentionInput(
-                            seq_lens=skewed_seq_lens,
+                            seq_lens=balanced_seq_lens,
                             kv_cache_size=kv_cache_size,
-                            mode="online_grid_skewed",
+                            mode="online_grid_balanced",
                         )
                     )
+                    kv_has_valid_shape = True
+                except RuntimeError as exc:
+                    if point_is_explicit:
+                        raise ValueError(
+                            f"Invalid explicit online_grid point "
+                            f"(batch_size={batch_size}, total_tokens={total_tokens}, "
+                            f"kv_cache_size={kv_cache_size}): {exc}"
+                        ) from exc
+
+                if skewed_seq_lens is not None:
+                    try:
+                        _validate_online_grid_seq_lens(
+                            seq_lens=skewed_seq_lens,
+                            batch_size=batch_size,
+                            total_tokens=total_tokens,
+                            max_model_len=max_model_len,
+                            kv_cache_size=kv_cache_size,
+                        )
+                        point_inputs.append(
+                            MixedAttentionInput(
+                                seq_lens=skewed_seq_lens,
+                                kv_cache_size=kv_cache_size,
+                                mode="online_grid_skewed",
+                            )
+                        )
+                        kv_has_valid_shape = True
+                    except RuntimeError as exc:
+                        if point_is_explicit:
+                            raise ValueError(
+                                f"Invalid explicit online_grid point "
+                                f"(batch_size={batch_size}, total_tokens={total_tokens}, "
+                                f"kv_cache_size={kv_cache_size}): {exc}"
+                            ) from exc
+                if kv_has_valid_shape:
+                    valid_point_kv_sizes.add(kv_cache_size)
+
+            if point_inputs:
+                input_combinations.extend(point_inputs)
+                valid_batch_sizes.add(batch_size)
+                valid_total_tokens.add(total_tokens)
+                valid_kv_sizes.update(valid_point_kv_sizes)
+
+    missing_explicit_batches = sorted(explicit_batch_sizes - valid_batch_sizes)
+    if missing_explicit_batches:
+        raise ValueError(
+            "batch_size_list values have no physically legal pairing: "
+            f"{missing_explicit_batches}."
+        )
+    missing_explicit_totals = sorted(explicit_total_tokens - valid_total_tokens)
+    if missing_explicit_totals:
+        raise ValueError(
+            "total_tokens_list values have no physically legal pairing: "
+            f"{missing_explicit_totals}."
+        )
+    missing_explicit_kv = sorted(explicit_kv_sizes - valid_kv_sizes)
+    if missing_explicit_kv:
+        raise ValueError(
+            "kv_cache_sizes values have no physically legal pairing: "
+            f"{missing_explicit_kv}."
+        )
 
     if not input_combinations:
         raise ValueError("online_grid mixed prefill produced no valid input combinations.")
@@ -975,31 +1084,27 @@ def get_online_grid_mixed_prefill_input_combinations(
 def get_true_mixed_attention_input_combinations(
     max_seq_len: int,
     prefill_batch_sizes: List[int],
-    prefill_chunk_sizes: List[int],
-    decode_batch_sizes: List[int],
-    decode_kv_cache_sizes: List[int],
+    prefill_chunk_sizes: Optional[List[int]] = None,
+    decode_batch_sizes: Optional[List[int]] = None,
+    decode_kv_cache_sizes: Optional[List[int]] = None,
     prefill_kv_cache_size: int = 0,
+    max_model_len: Optional[int] = None,
 ):
     """Generate true mixed prefill+decode attention input combinations."""
     from frontier.profiling.attention.true_mixed_batch_input import TrueMixedBatchInput
 
-    if max_seq_len <= 0:
-        raise ValueError("max_seq_len must be positive")
+    max_model_len = _resolve_profile_max_model_len(max_seq_len, max_model_len)
     if prefill_kv_cache_size < 0:
         raise ValueError("prefill_kv_cache_size must be non-negative")
-    if prefill_kv_cache_size >= max_seq_len:
+    if prefill_kv_cache_size >= max_model_len:
         raise ValueError(
-            "prefill_kv_cache_size must be <= max_seq_len - 1, "
-            f"got {prefill_kv_cache_size}."
+            "prefill_kv_cache_size must leave room for at least one prefill token "
+            f"under max_model_len={max_model_len}, got {prefill_kv_cache_size}."
         )
     if not prefill_batch_sizes:
         raise ValueError("prefill_batch_sizes cannot be empty")
-    if not prefill_chunk_sizes:
-        raise ValueError("prefill_chunk_sizes cannot be empty")
     if not decode_batch_sizes:
         raise ValueError("decode_batch_sizes cannot be empty")
-    if not decode_kv_cache_sizes:
-        raise ValueError("decode_kv_cache_sizes cannot be empty")
 
     normalized_prefill_batch_sizes = []
     for prefill_bs in prefill_batch_sizes:
@@ -1013,21 +1118,91 @@ def get_true_mixed_attention_input_combinations(
         normalized_prefill_batch_sizes.append(int(prefill_bs))
     prefill_batch_sizes = sorted(set(normalized_prefill_batch_sizes))
 
-    normalized_prefill_chunk_sizes = []
-    for prefill_chunk_size in prefill_chunk_sizes:
-        if prefill_chunk_size <= 0:
-            raise ValueError(f"Invalid prefill chunk size: {prefill_chunk_size}")
-        if prefill_chunk_size + prefill_kv_cache_size > max_seq_len:
-            raise ValueError(
-                "prefill_chunk_sizes values plus prefill_kv_cache_size must be "
-                f"<= max_seq_len, got {prefill_chunk_size} + "
-                f"{prefill_kv_cache_size} > {max_seq_len}."
-            )
-        normalized_prefill_chunk_sizes.append(int(prefill_chunk_size))
-    endpoint_prefill_chunk_size = max_seq_len - prefill_kv_cache_size
-    if endpoint_prefill_chunk_size > 0:
-        normalized_prefill_chunk_sizes.append(endpoint_prefill_chunk_size)
-    prefill_chunk_sizes = sorted(set(normalized_prefill_chunk_sizes))
+    def _normalize_explicit_axis(name: str, values: List[int], minimum: int):
+        normalized = _normalize_positive_int_list(name, values, minimum)
+        if normalized is None:
+            raise RuntimeError(f"{name} normalization unexpectedly returned None")
+        return normalized
+
+    explicit_prefill_chunks = prefill_chunk_sizes is not None
+    explicit_prefill_values = (
+        _normalize_explicit_axis("prefill_chunk_sizes", prefill_chunk_sizes, 1)
+        if explicit_prefill_chunks
+        else []
+    )
+    explicit_prefill_value_set = set(explicit_prefill_values)
+    profile_endpoint = max_seq_len - prefill_kv_cache_size
+    automatic_prefill_values = _derive_axis_with_headroom(
+        anchors=_TRUE_MIXED_PREFILL_CHUNK_ANCHORS,
+        config_max=profile_endpoint,
+        physical_max=max_model_len - prefill_kv_cache_size,
+        minimum=1,
+    )
+    normalized_prefill_chunk_sizes = sorted(
+        set(automatic_prefill_values + explicit_prefill_values)
+    )
+
+    explicit_decode_kv = decode_kv_cache_sizes is not None
+    explicit_decode_values = (
+        _normalize_explicit_axis("decode_kv_cache_sizes", decode_kv_cache_sizes, 0)
+        if explicit_decode_kv
+        else []
+    )
+    explicit_decode_value_set = set(explicit_decode_values)
+    profile_endpoint = max_seq_len - 1
+    automatic_decode_values = _derive_axis_with_headroom(
+        anchors=_TRUE_MIXED_DECODE_KV_ANCHORS,
+        config_max=profile_endpoint,
+        physical_max=max_model_len - 1,
+        minimum=0,
+    )
+    normalized_decode_kv_cache_sizes = sorted(
+        set(automatic_decode_values + explicit_decode_values)
+    )
+
+    def _physical_prefill_chunks(values):
+        valid = []
+        for value in values:
+            if value + prefill_kv_cache_size > max_model_len:
+                if value in explicit_prefill_value_set:
+                    raise ValueError(
+                        "prefill_chunk_sizes values plus prefill_kv_cache_size must "
+                        f"be <= max_model_len, got {value} + "
+                        f"{prefill_kv_cache_size} > {max_model_len}."
+                    )
+                continue
+            valid.append(value)
+        return valid
+
+    def _physical_decode_kv(values):
+        valid = []
+        for value in values:
+            if value + 1 > max_model_len:
+                if value in explicit_decode_value_set:
+                    raise ValueError(
+                        "decode_kv_cache_sizes values must be <= max_model_len - 1, "
+                        f"got {value} > {max_model_len - 1}."
+                    )
+                continue
+            valid.append(value)
+        return valid
+
+    normalized_prefill_chunk_sizes = _physical_prefill_chunks(
+        normalized_prefill_chunk_sizes
+    )
+    normalized_decode_kv_cache_sizes = _physical_decode_kv(
+        normalized_decode_kv_cache_sizes
+    )
+    if not normalized_prefill_chunk_sizes:
+        raise ValueError(
+            "True-mixed attention profiling produced no physically valid prefill "
+            "chunk sizes."
+        )
+    if not normalized_decode_kv_cache_sizes:
+        raise ValueError(
+            "True-mixed attention profiling produced no physically valid decode "
+            "KV cache sizes."
+        )
 
     normalized_decode_batch_sizes = []
     for decode_bs in decode_batch_sizes:
@@ -1053,33 +1228,18 @@ def get_true_mixed_attention_input_combinations(
             f"{oversized_total_batch_sizes}."
         )
 
-    normalized_decode_kv_cache_sizes = []
-    for decode_kv_cache_size in decode_kv_cache_sizes:
-        if decode_kv_cache_size < 0:
-            raise ValueError(
-                f"Invalid decode kv cache size: {decode_kv_cache_size}"
-            )
-        if decode_kv_cache_size >= max_seq_len:
-            raise ValueError(
-                "decode_kv_cache_sizes values must be <= max_seq_len - 1, "
-                f"got {decode_kv_cache_size}."
-            )
-        normalized_decode_kv_cache_sizes.append(int(decode_kv_cache_size))
-    normalized_decode_kv_cache_sizes.append(max_seq_len - 1)
-    decode_kv_cache_sizes = sorted(set(normalized_decode_kv_cache_sizes))
-
     combinations = []
     for prefill_bs in prefill_batch_sizes:
-        for prefill_chunk_size in prefill_chunk_sizes:
+        for prefill_chunk_size in normalized_prefill_chunk_sizes:
             for decode_bs in decode_batch_sizes:
-                for decode_kv_cache_size in decode_kv_cache_sizes:
+                for decode_kv_cache_size in normalized_decode_kv_cache_sizes:
                     candidate = TrueMixedBatchInput(
                         prefill_seq_lens=[prefill_chunk_size] * prefill_bs,
                         prefill_kv_cache_sizes=[prefill_kv_cache_size] * prefill_bs,
                         decode_kv_cache_sizes=[decode_kv_cache_size] * decode_bs,
                     )
                     if not candidate.is_valid(
-                        max_seq_len=max_seq_len,
+                        max_seq_len=max_model_len,
                         max_batch_size=_MAX_MIXED_ATTENTION_BATCH_SIZE,
                     ):
                         raise RuntimeError(

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -545,7 +545,9 @@ def get_mixed_prefill_input_combinations(
         - "both": Generate both even and random combinations.
     """
     from frontier.profiling.attention.mixed_attention_input import MixedAttentionInput
-    
+
+    if max_seq_len <= 0:
+        raise ValueError("max_seq_len must be positive.")
     if min_batch_size < 2:
         raise ValueError("min_batch_size must be >= 2 for mixed prefill profiling.")
     if max_batch_size < min_batch_size:
@@ -559,8 +561,25 @@ def get_mixed_prefill_input_combinations(
         raise ValueError("kv_cache_sizes cannot be empty.")
     if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
         raise ValueError("All kv_cache_sizes must be non-negative.")
+    kv_cache_sizes = sorted({int(kv_cache_size) for kv_cache_size in kv_cache_sizes})
 
     input_combinations = []
+    seen_inputs = set()
+
+    def _append_unique(seq_lens, kv_cache_size, input_mode):
+        input_key = (tuple(seq_lens), kv_cache_size, input_mode)
+        if input_key in seen_inputs:
+            return
+        candidate = MixedAttentionInput(
+            seq_lens=list(seq_lens),
+            kv_cache_size=kv_cache_size,
+            mode=input_mode,
+        )
+        if not candidate.is_valid(max_seq_len=max_seq_len, max_batch_size=128):
+            return
+        seen_inputs.add(input_key)
+        input_combinations.append(candidate)
+
     modes_to_generate = []
     
     if mode == "both":
@@ -575,7 +594,13 @@ def get_mixed_prefill_input_combinations(
         + list(range(1024, 4 * 1024 + 1, 64))
         + list(range(4 * 1024, min(16 * 1024, max_seq_len) + 1, 256))
     )
-    
+    seq_length_candidates.append(max_seq_len)
+    for kv_cache_size in kv_cache_sizes:
+        endpoint_seq_len = max_seq_len - kv_cache_size
+        if endpoint_seq_len > 0:
+            seq_length_candidates.append(endpoint_seq_len)
+    seq_length_candidates = sorted(set(seq_length_candidates))
+
     # Filter to only include lengths <= max_seq_len
     seq_length_candidates = [s for s in seq_length_candidates if s <= max_seq_len]
     
@@ -591,13 +616,7 @@ def get_mixed_prefill_input_combinations(
                         if seq_len + kv_cache_size > max_seq_len:
                             continue
                         seq_lens = [seq_len] * batch_size
-                        input_combinations.append(
-                            MixedAttentionInput(
-                                seq_lens=seq_lens,
-                                kv_cache_size=kv_cache_size,
-                                mode="even"
-                            )
-                        )
+                        _append_unique(seq_lens, kv_cache_size, "even")
         
         elif current_mode == "random":
             # Random mode: sequences have varied lengths
@@ -656,13 +675,17 @@ def get_mixed_prefill_input_combinations(
                                 min(s, effective_max_len_with_cache) for s in seq_lens
                             ]
 
-                            input_combinations.append(
-                                MixedAttentionInput(
-                                    seq_lens=seq_lens,
-                                    kv_cache_size=kv_cache_size,
-                                    mode="random"
-                                )
-                            )
+                            _append_unique(seq_lens, kv_cache_size, "random")
+
+                # Keep one deterministic heterogeneous shape at the context
+                # boundary for every requested KV cache size.
+                for kv_cache_size in kv_cache_sizes:
+                    endpoint_seq_len = max_seq_len - kv_cache_size
+                    if endpoint_seq_len > 0:
+                        boundary_seq_lens = [endpoint_seq_len] + [
+                            max(1, endpoint_seq_len // 2)
+                        ] * (batch_size - 1)
+                        _append_unique(boundary_seq_lens, kv_cache_size, "random")
     
     return input_combinations
 
@@ -806,21 +829,25 @@ def get_online_grid_mixed_prefill_input_combinations(
     if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
         raise ValueError("All kv_cache_sizes must be non-negative.")
 
-    batch_sizes = _normalize_positive_int_list(
+    batch_size_extensions = _normalize_positive_int_list(
         "batch_size_list",
         batch_size_list,
         minimum=2,
     )
-    if batch_sizes is None:
-        batch_sizes = list(range(min_batch_size, max_batch_size + 1))
+    batch_sizes = set(range(min_batch_size, max_batch_size + 1))
+    if batch_size_extensions is not None:
+        batch_sizes.update(batch_size_extensions)
+    batch_sizes = sorted(batch_sizes)
 
-    total_tokens_values = _normalize_positive_int_list(
+    total_token_extensions = _normalize_positive_int_list(
         "total_tokens_list",
         total_tokens_list,
         minimum=1,
     )
-    if total_tokens_values is None:
-        total_tokens_values = list(range(min_total_tokens, max_total_tokens + 1))
+    total_tokens_values = set(range(min_total_tokens, max_total_tokens + 1))
+    if total_token_extensions is not None:
+        total_tokens_values.update(total_token_extensions)
+    total_tokens_values = sorted(total_tokens_values)
 
     input_combinations = []
     for batch_size in batch_sizes:
@@ -916,23 +943,45 @@ def get_true_mixed_attention_input_combinations(
     if not decode_kv_cache_sizes:
         raise ValueError("decode_kv_cache_sizes cannot be empty")
 
-    combinations = []
+    normalized_prefill_batch_sizes = []
     for prefill_bs in prefill_batch_sizes:
         if prefill_bs <= 0:
             raise ValueError(f"Invalid prefill batch size: {prefill_bs}")
+        normalized_prefill_batch_sizes.append(int(prefill_bs))
+    prefill_batch_sizes = sorted(set(normalized_prefill_batch_sizes))
+
+    normalized_prefill_chunk_sizes = []
+    for prefill_chunk_size in prefill_chunk_sizes:
+        if prefill_chunk_size <= 0:
+            raise ValueError(f"Invalid prefill chunk size: {prefill_chunk_size}")
+        normalized_prefill_chunk_sizes.append(int(prefill_chunk_size))
+    endpoint_prefill_chunk_size = max_seq_len - prefill_kv_cache_size
+    if endpoint_prefill_chunk_size > 0:
+        normalized_prefill_chunk_sizes.append(endpoint_prefill_chunk_size)
+    prefill_chunk_sizes = sorted(set(normalized_prefill_chunk_sizes))
+
+    normalized_decode_batch_sizes = []
+    for decode_bs in decode_batch_sizes:
+        if decode_bs <= 0:
+            raise ValueError(f"Invalid decode batch size: {decode_bs}")
+        normalized_decode_batch_sizes.append(int(decode_bs))
+    decode_batch_sizes = sorted(set(normalized_decode_batch_sizes))
+
+    normalized_decode_kv_cache_sizes = []
+    for decode_kv_cache_size in decode_kv_cache_sizes:
+        if decode_kv_cache_size < 0:
+            raise ValueError(
+                f"Invalid decode kv cache size: {decode_kv_cache_size}"
+            )
+        normalized_decode_kv_cache_sizes.append(int(decode_kv_cache_size))
+    normalized_decode_kv_cache_sizes.append(max_seq_len - 1)
+    decode_kv_cache_sizes = sorted(set(normalized_decode_kv_cache_sizes))
+
+    combinations = []
+    for prefill_bs in prefill_batch_sizes:
         for prefill_chunk_size in prefill_chunk_sizes:
-            if prefill_chunk_size <= 0:
-                raise ValueError(
-                    f"Invalid prefill chunk size: {prefill_chunk_size}"
-                )
             for decode_bs in decode_batch_sizes:
-                if decode_bs <= 0:
-                    raise ValueError(f"Invalid decode batch size: {decode_bs}")
                 for decode_kv_cache_size in decode_kv_cache_sizes:
-                    if decode_kv_cache_size < 0:
-                        raise ValueError(
-                            f"Invalid decode kv cache size: {decode_kv_cache_size}"
-                        )
                     candidate = TrueMixedBatchInput(
                         prefill_seq_lens=[prefill_chunk_size] * prefill_bs,
                         prefill_kv_cache_sizes=[prefill_kv_cache_size] * prefill_bs,

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -367,6 +367,7 @@ def get_attention_input_combinations(
     prefill_lengths_to_profile = get_seq_lengths_to_profile(max_seq_len)
     input_combinations.extend(product(prefill_lengths_to_profile, [0], [1], [True]))
     # Decodes
+    max_decode_kv_cache_size = max_seq_len - 1
     if decode_kv_cache_size_list is not None:
         kv_cache_sizes_to_profile = _normalize_positive_int_list(
             "decode_kv_cache_size_list",
@@ -376,15 +377,17 @@ def get_attention_input_combinations(
         oversized_kv_cache_sizes = [
             kv_cache_size
             for kv_cache_size in kv_cache_sizes_to_profile
-            if kv_cache_size > max_seq_len
+            if kv_cache_size > max_decode_kv_cache_size
         ]
         if oversized_kv_cache_sizes:
             raise ValueError(
-                "decode_kv_cache_size_list values must be <= max_seq_len, "
-                f"got {oversized_kv_cache_sizes} > {max_seq_len}"
+                "decode_kv_cache_size_list values must be <= max_seq_len - 1, "
+                f"got {oversized_kv_cache_sizes} > {max_decode_kv_cache_size}"
             )
     else:
-        kv_cache_sizes_to_profile = get_seq_lengths_to_profile(max_seq_len)
+        kv_cache_sizes_to_profile = get_seq_lengths_to_profile(
+            max_decode_kv_cache_size
+        )
     batch_sizes_to_profile = get_attention_batch_sizes_to_profile(
         min_batch_size, max_batch_size, batch_size_list
     )

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -528,6 +528,7 @@ def get_mixed_prefill_input_combinations(
     mode: str = "even",
     num_samples_per_config: int = 3,
     kv_cache_sizes: Optional[List[int]] = None,
+    max_model_len: Optional[int] = None,
 ):
     """
     Generate mixed-length prefill input combinations for profiling.
@@ -536,7 +537,9 @@ def get_mixed_prefill_input_combinations(
     with multiple sequences of potentially different lengths in a single batch.
     
     Args:
-        max_seq_len: Maximum sequence length to profile.
+        max_seq_len: Maximum sequence length in the profiling envelope.
+        max_model_len: Runtime context limit for each sequence, defaulting to
+                       ``max_seq_len``.
         min_batch_size: Minimum batch size (default 2, since 1 is single-seq).
         max_batch_size: Maximum batch size (default 8).
         mode: Generation mode - "even", "random", or "both".
@@ -553,8 +556,7 @@ def get_mixed_prefill_input_combinations(
     """
     from frontier.profiling.attention.mixed_attention_input import MixedAttentionInput
 
-    if max_seq_len <= 0:
-        raise ValueError("max_seq_len must be positive.")
+    max_model_len = _resolve_profile_max_model_len(max_seq_len, max_model_len)
     if min_batch_size < 2:
         raise ValueError("min_batch_size must be >= 2 for mixed prefill profiling.")
     if max_batch_size < min_batch_size:
@@ -571,23 +573,16 @@ def get_mixed_prefill_input_combinations(
             f"mode must be one of even, random, or both, got {mode!r}."
         )
 
-    if kv_cache_sizes is None:
-        kv_cache_sizes = [0]
-    if not kv_cache_sizes:
-        raise ValueError("kv_cache_sizes cannot be empty.")
-    if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
-        raise ValueError("All kv_cache_sizes must be non-negative.")
-    kv_cache_sizes = sorted({int(kv_cache_size) for kv_cache_size in kv_cache_sizes})
-    oversized_kv_cache_sizes = [
-        kv_cache_size
-        for kv_cache_size in kv_cache_sizes
-        if kv_cache_size >= max_seq_len
-    ]
-    if oversized_kv_cache_sizes:
-        raise ValueError(
-            "kv_cache_sizes values must be <= max_seq_len - 1, "
-            f"got {oversized_kv_cache_sizes}."
-        )
+    explicit_kv_cache_sizes = kv_cache_sizes is not None
+    normalized_kv_cache_sizes = _normalize_positive_int_list(
+        "kv_cache_sizes",
+        [0] if kv_cache_sizes is None else kv_cache_sizes,
+        minimum=0,
+    )
+    if normalized_kv_cache_sizes is None:
+        raise RuntimeError("kv_cache_sizes normalization unexpectedly returned None")
+    kv_cache_sizes = normalized_kv_cache_sizes
+    explicit_kv_size_set = set(kv_cache_sizes if explicit_kv_cache_sizes else ())
     input_combinations = []
     seen_inputs = set()
 
@@ -601,7 +596,7 @@ def get_mixed_prefill_input_combinations(
             mode=input_mode,
         )
         if not candidate.is_valid(
-            max_seq_len=max_seq_len,
+            max_seq_len=max_model_len,
             max_batch_size=_MAX_MIXED_ATTENTION_BATCH_SIZE,
         ):
             raise RuntimeError(f"Generated invalid mixed prefill input: {candidate}")
@@ -624,7 +619,7 @@ def get_mixed_prefill_input_combinations(
     )
     seq_length_candidates.append(max_seq_len)
     for kv_cache_size in kv_cache_sizes:
-        endpoint_seq_len = max_seq_len - kv_cache_size
+        endpoint_seq_len = min(max_seq_len, max_model_len - kv_cache_size)
         if endpoint_seq_len > 0:
             seq_length_candidates.append(endpoint_seq_len)
     seq_length_candidates = sorted(set(seq_length_candidates))
@@ -641,7 +636,7 @@ def get_mixed_prefill_input_combinations(
             for batch_size in batch_sizes:
                 for kv_cache_size in kv_cache_sizes:
                     for seq_len in seq_length_candidates:
-                        if seq_len + kv_cache_size > max_seq_len:
+                        if seq_len + kv_cache_size > max_model_len:
                             continue
                         seq_lens = [seq_len] * batch_size
                         _append_unique(seq_lens, kv_cache_size, "even")
@@ -662,7 +657,7 @@ def get_mixed_prefill_input_combinations(
                 ]
                 
                 for min_len, max_len in length_ranges:
-                    # Skip if range is beyond max_seq_len
+                    # Skip if the range is beyond the profiling envelope.
                     if min_len > max_seq_len:
                         continue
                     
@@ -674,11 +669,11 @@ def get_mixed_prefill_input_combinations(
                     
                     # Generate multiple random samples for each range
                     for kv_cache_size in kv_cache_sizes:
-                        if min_len + kv_cache_size > max_seq_len:
+                        if min_len + kv_cache_size > max_model_len:
                             continue
                         effective_max_len_with_cache = min(
                             effective_max_len,
-                            max_seq_len - kv_cache_size,
+                            max_model_len - kv_cache_size,
                         )
                         if effective_max_len_with_cache <= min_len:
                             continue
@@ -708,12 +703,23 @@ def get_mixed_prefill_input_combinations(
                 # Keep one deterministic heterogeneous shape at the context
                 # boundary for every requested KV cache size.
                 for kv_cache_size in kv_cache_sizes:
-                    endpoint_seq_len = max_seq_len - kv_cache_size
+                    endpoint_seq_len = min(max_seq_len, max_model_len - kv_cache_size)
                     if endpoint_seq_len > 0:
                         boundary_seq_lens = [endpoint_seq_len] + [
                             max(1, endpoint_seq_len // 2)
                         ] * (batch_size - 1)
                         _append_unique(boundary_seq_lens, kv_cache_size, "random")
+
+    valid_kv_sizes = {
+        item.kv_cache_size
+        for item in input_combinations
+    }
+    missing_explicit_kv = sorted(explicit_kv_size_set - valid_kv_sizes)
+    if missing_explicit_kv:
+        raise ValueError(
+            "kv_cache_sizes values have no runtime-legal pairing under "
+            f"max_model_len={max_model_len}: {missing_explicit_kv}."
+        )
 
     if not input_combinations:
         raise ValueError("Mixed prefill profiling produced no valid input combinations.")

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -40,6 +40,8 @@ EXPORTABLE_PROFILE_METHOD_CHOICES = [
     ProfileMethod.RECORD_FUNCTION.value,
 ]
 
+_MAX_MIXED_ATTENTION_BATCH_SIZE = 128
+
 
 def normalize_profile_method(profile_method: str) -> str:
     normalized = str(profile_method).strip().lower()
@@ -555,8 +557,17 @@ def get_mixed_prefill_input_combinations(
         raise ValueError("min_batch_size must be >= 2 for mixed prefill profiling.")
     if max_batch_size < min_batch_size:
         raise ValueError("max_batch_size must be >= min_batch_size.")
+    if max_batch_size > _MAX_MIXED_ATTENTION_BATCH_SIZE:
+        raise ValueError(
+            "max_batch_size must be <= "
+            f"{_MAX_MIXED_ATTENTION_BATCH_SIZE} for mixed prefill profiling."
+        )
     if num_samples_per_config <= 0:
         raise ValueError("num_samples_per_config must be > 0.")
+    if mode not in {"even", "random", "both"}:
+        raise ValueError(
+            f"mode must be one of even, random, or both, got {mode!r}."
+        )
 
     if kv_cache_sizes is None:
         kv_cache_sizes = [0]
@@ -565,6 +576,16 @@ def get_mixed_prefill_input_combinations(
     if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
         raise ValueError("All kv_cache_sizes must be non-negative.")
     kv_cache_sizes = sorted({int(kv_cache_size) for kv_cache_size in kv_cache_sizes})
+    oversized_kv_cache_sizes = [
+        kv_cache_size
+        for kv_cache_size in kv_cache_sizes
+        if kv_cache_size >= max_seq_len
+    ]
+    if oversized_kv_cache_sizes:
+        raise ValueError(
+            "kv_cache_sizes values must be <= max_seq_len - 1, "
+            f"got {oversized_kv_cache_sizes}."
+        )
 
     input_combinations = []
     seen_inputs = set()
@@ -578,8 +599,11 @@ def get_mixed_prefill_input_combinations(
             kv_cache_size=kv_cache_size,
             mode=input_mode,
         )
-        if not candidate.is_valid(max_seq_len=max_seq_len, max_batch_size=128):
-            return
+        if not candidate.is_valid(
+            max_seq_len=max_seq_len,
+            max_batch_size=_MAX_MIXED_ATTENTION_BATCH_SIZE,
+        ):
+            raise RuntimeError(f"Generated invalid mixed prefill input: {candidate}")
         seen_inputs.add(input_key)
         input_combinations.append(candidate)
 
@@ -689,7 +713,10 @@ def get_mixed_prefill_input_combinations(
                             max(1, endpoint_seq_len // 2)
                         ] * (batch_size - 1)
                         _append_unique(boundary_seq_lens, kv_cache_size, "random")
-    
+
+    if not input_combinations:
+        raise ValueError("Mixed prefill profiling produced no valid input combinations.")
+
     return input_combinations
 
 
@@ -819,6 +846,11 @@ def get_online_grid_mixed_prefill_input_combinations(
         raise ValueError("min_batch_size must be >= 2.")
     if max_batch_size < min_batch_size:
         raise ValueError("max_batch_size must be >= min_batch_size.")
+    if max_batch_size > _MAX_MIXED_ATTENTION_BATCH_SIZE:
+        raise ValueError(
+            "max_batch_size must be <= "
+            f"{_MAX_MIXED_ATTENTION_BATCH_SIZE} for mixed prefill profiling."
+        )
     if min_total_tokens <= 0:
         raise ValueError("min_total_tokens must be positive.")
     if max_total_tokens < min_total_tokens:
@@ -831,6 +863,16 @@ def get_online_grid_mixed_prefill_input_combinations(
         raise ValueError("kv_cache_sizes cannot be empty.")
     if any(kv_cache_size < 0 for kv_cache_size in kv_cache_sizes):
         raise ValueError("All kv_cache_sizes must be non-negative.")
+    oversized_kv_cache_sizes = [
+        kv_cache_size
+        for kv_cache_size in kv_cache_sizes
+        if kv_cache_size >= max_seq_len
+    ]
+    if oversized_kv_cache_sizes:
+        raise ValueError(
+            "kv_cache_sizes values must be <= max_seq_len - 1, "
+            f"got {oversized_kv_cache_sizes}."
+        )
 
     batch_size_extensions = _normalize_positive_int_list(
         "batch_size_list",
@@ -839,6 +881,16 @@ def get_online_grid_mixed_prefill_input_combinations(
     )
     batch_sizes = set(range(min_batch_size, max_batch_size + 1))
     if batch_size_extensions is not None:
+        oversized_batch_sizes = [
+            batch_size
+            for batch_size in batch_size_extensions
+            if batch_size > _MAX_MIXED_ATTENTION_BATCH_SIZE
+        ]
+        if oversized_batch_sizes:
+            raise ValueError(
+                "batch_size_list values must be <= "
+                f"{_MAX_MIXED_ATTENTION_BATCH_SIZE}, got {oversized_batch_sizes}."
+            )
         batch_sizes.update(batch_size_extensions)
     batch_sizes = sorted(batch_sizes)
 
@@ -856,8 +908,6 @@ def get_online_grid_mixed_prefill_input_combinations(
     for batch_size in batch_sizes:
         for total_tokens in total_tokens_values:
             if total_tokens < batch_size:
-                if batch_size_list is not None or total_tokens_list is not None:
-                    continue
                 raise ValueError(
                     f"Invalid grid point: total_tokens={total_tokens} < batch_size={batch_size}."
                 )
@@ -937,6 +987,11 @@ def get_true_mixed_attention_input_combinations(
         raise ValueError("max_seq_len must be positive")
     if prefill_kv_cache_size < 0:
         raise ValueError("prefill_kv_cache_size must be non-negative")
+    if prefill_kv_cache_size >= max_seq_len:
+        raise ValueError(
+            "prefill_kv_cache_size must be <= max_seq_len - 1, "
+            f"got {prefill_kv_cache_size}."
+        )
     if not prefill_batch_sizes:
         raise ValueError("prefill_batch_sizes cannot be empty")
     if not prefill_chunk_sizes:
@@ -950,6 +1005,11 @@ def get_true_mixed_attention_input_combinations(
     for prefill_bs in prefill_batch_sizes:
         if prefill_bs <= 0:
             raise ValueError(f"Invalid prefill batch size: {prefill_bs}")
+        if prefill_bs > _MAX_MIXED_ATTENTION_BATCH_SIZE:
+            raise ValueError(
+                "prefill_batch_sizes values must be <= "
+                f"{_MAX_MIXED_ATTENTION_BATCH_SIZE}, got {prefill_bs}."
+            )
         normalized_prefill_batch_sizes.append(int(prefill_bs))
     prefill_batch_sizes = sorted(set(normalized_prefill_batch_sizes))
 
@@ -957,6 +1017,12 @@ def get_true_mixed_attention_input_combinations(
     for prefill_chunk_size in prefill_chunk_sizes:
         if prefill_chunk_size <= 0:
             raise ValueError(f"Invalid prefill chunk size: {prefill_chunk_size}")
+        if prefill_chunk_size + prefill_kv_cache_size > max_seq_len:
+            raise ValueError(
+                "prefill_chunk_sizes values plus prefill_kv_cache_size must be "
+                f"<= max_seq_len, got {prefill_chunk_size} + "
+                f"{prefill_kv_cache_size} > {max_seq_len}."
+            )
         normalized_prefill_chunk_sizes.append(int(prefill_chunk_size))
     endpoint_prefill_chunk_size = max_seq_len - prefill_kv_cache_size
     if endpoint_prefill_chunk_size > 0:
@@ -967,14 +1033,36 @@ def get_true_mixed_attention_input_combinations(
     for decode_bs in decode_batch_sizes:
         if decode_bs <= 0:
             raise ValueError(f"Invalid decode batch size: {decode_bs}")
+        if decode_bs > _MAX_MIXED_ATTENTION_BATCH_SIZE:
+            raise ValueError(
+                "decode_batch_sizes values must be <= "
+                f"{_MAX_MIXED_ATTENTION_BATCH_SIZE}, got {decode_bs}."
+            )
         normalized_decode_batch_sizes.append(int(decode_bs))
     decode_batch_sizes = sorted(set(normalized_decode_batch_sizes))
+    oversized_total_batch_sizes = [
+        (prefill_bs, decode_bs)
+        for prefill_bs in prefill_batch_sizes
+        for decode_bs in decode_batch_sizes
+        if prefill_bs + decode_bs > _MAX_MIXED_ATTENTION_BATCH_SIZE
+    ]
+    if oversized_total_batch_sizes:
+        raise ValueError(
+            "true-mixed total batch size must be <= "
+            f"{_MAX_MIXED_ATTENTION_BATCH_SIZE}, got "
+            f"{oversized_total_batch_sizes}."
+        )
 
     normalized_decode_kv_cache_sizes = []
     for decode_kv_cache_size in decode_kv_cache_sizes:
         if decode_kv_cache_size < 0:
             raise ValueError(
                 f"Invalid decode kv cache size: {decode_kv_cache_size}"
+            )
+        if decode_kv_cache_size >= max_seq_len:
+            raise ValueError(
+                "decode_kv_cache_sizes values must be <= max_seq_len - 1, "
+                f"got {decode_kv_cache_size}."
             )
         normalized_decode_kv_cache_sizes.append(int(decode_kv_cache_size))
     normalized_decode_kv_cache_sizes.append(max_seq_len - 1)
@@ -990,8 +1078,18 @@ def get_true_mixed_attention_input_combinations(
                         prefill_kv_cache_sizes=[prefill_kv_cache_size] * prefill_bs,
                         decode_kv_cache_sizes=[decode_kv_cache_size] * decode_bs,
                     )
-                    if candidate.is_valid(max_seq_len=max_seq_len, max_batch_size=128):
-                        combinations.append(candidate)
+                    if not candidate.is_valid(
+                        max_seq_len=max_seq_len,
+                        max_batch_size=_MAX_MIXED_ATTENTION_BATCH_SIZE,
+                    ):
+                        raise RuntimeError(
+                            f"Generated invalid true-mixed attention input: {candidate}"
+                        )
+                    combinations.append(candidate)
+    if not combinations:
+        raise ValueError(
+            "True-mixed attention profiling produced no valid input combinations."
+        )
     return combinations
 
 

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -336,7 +336,9 @@ def get_attention_input_combinations(
     decode_kv_cache_size_list: List[int] = None,
     enable_chunked_prefill_grid_search: bool = True,
     fixed_chunked_prefill_size: int = -1,
+    max_model_len: Optional[int] = None,
 ):
+    max_model_len = _resolve_profile_max_model_len(max_seq_len, max_model_len)
     input_combinations = []
 
     if fixed_chunked_prefill_size == 0:
@@ -372,6 +374,7 @@ def get_attention_input_combinations(
     input_combinations.extend(product(prefill_lengths_to_profile, [0], [1], [True]))
     # Decodes
     max_decode_kv_cache_size = max_seq_len - 1
+    max_runtime_decode_kv_cache_size = max_model_len - 1
     if decode_kv_cache_size_list is not None:
         kv_cache_sizes_to_profile = _normalize_positive_int_list(
             "decode_kv_cache_size_list",
@@ -381,12 +384,12 @@ def get_attention_input_combinations(
         oversized_kv_cache_sizes = [
             kv_cache_size
             for kv_cache_size in kv_cache_sizes_to_profile
-            if kv_cache_size > max_decode_kv_cache_size
+            if kv_cache_size > max_runtime_decode_kv_cache_size
         ]
         if oversized_kv_cache_sizes:
             raise ValueError(
-                "decode_kv_cache_size_list values must be <= max_seq_len - 1, "
-                f"got {oversized_kv_cache_sizes} > {max_decode_kv_cache_size}"
+                "decode_kv_cache_size_list values must be <= max_model_len - 1, "
+                f"got {oversized_kv_cache_sizes} > {max_runtime_decode_kv_cache_size}"
             )
     else:
         kv_cache_sizes_to_profile = get_seq_lengths_to_profile(
@@ -416,7 +419,10 @@ def get_attention_input_combinations(
             is_prefill,
         )
 
-        if attention_input.is_valid(max_seq_len):
+        if attention_input.is_valid(
+            max_seq_len=max_seq_len,
+            max_model_len=max_model_len,
+        ):
             valid_input_combinations.append(attention_input)
     return valid_input_combinations
 

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -200,6 +200,8 @@ def get_num_tokens_to_profile(
             num_tokens_to_profile.append(num_tokens)
         else:
             break
+    if max_num_tokens > 0:
+        num_tokens_to_profile.append(max_num_tokens)
 
     if extra_num_tokens:
         for num_tokens in extra_num_tokens:
@@ -208,8 +210,9 @@ def get_num_tokens_to_profile(
                 raise ValueError(
                     f"extra_num_tokens must be positive integers, got {token_value}"
                 )
-            if token_value <= max_num_tokens:
-                num_tokens_to_profile.append(token_value)
+            # Explicit extensions belong to the requested profiling domain.
+            # The profiler owns the physical-capacity check for each workload.
+            num_tokens_to_profile.append(token_value)
 
     # Deduplicate while preserving deterministic sort order.
     num_tokens_to_profile = sorted(set(num_tokens_to_profile), reverse=True)
@@ -263,11 +266,15 @@ def get_attention_batch_sizes_to_profile(
         return sorted(normalized)
 
     BATCH_SIZE_SPACE = list(range(1, 128 + 1, 1)) + list(range(128, 1024 + 1, 8))
-    return list(
+    batch_sizes_to_profile = list(
         filter(
             lambda x: (x >= min_batch_size and x <= max_batch_size), BATCH_SIZE_SPACE
         )
     )
+    for boundary in (min_batch_size, max_batch_size):
+        if boundary > 0 and min_batch_size <= boundary <= max_batch_size:
+            batch_sizes_to_profile.append(boundary)
+    return sorted(set(batch_sizes_to_profile))
 
 
 def get_attention_prefill_chunk_sizes_to_profile(max_seq_len: int):
@@ -286,7 +293,9 @@ def get_attention_prefill_chunk_sizes_to_profile(max_seq_len: int):
             prefill_chunk_sizes_to_profile.append(prefill_chunk_size)
         else:
             break
-    return prefill_chunk_sizes_to_profile
+    if max_seq_len > 0:
+        prefill_chunk_sizes_to_profile.append(max_seq_len)
+    return sorted(set(prefill_chunk_sizes_to_profile))
 
 
 def get_seq_lengths_to_profile(max_seq_len: int):
@@ -306,8 +315,9 @@ def get_seq_lengths_to_profile(max_seq_len: int):
                     f"FRONTIER_EXTRA_SEQ_LENGTHS contains negative value: {value}"
                 )
             SEQ_LENGTH_SIZE_SPACE.append(value)
+    SEQ_LENGTH_SIZE_SPACE.append(max_seq_len)
     seq_lengths_to_profile = [
-        seq_length for seq_length in SEQ_LENGTH_SIZE_SPACE if seq_length < max_seq_len
+        seq_length for seq_length in SEQ_LENGTH_SIZE_SPACE if seq_length <= max_seq_len
     ]
     return sorted(set(seq_lengths_to_profile))
 

--- a/tests/unit/test_attention_memory_filter_contract.py
+++ b/tests/unit/test_attention_memory_filter_contract.py
@@ -1,0 +1,81 @@
+import pytest
+
+from frontier.profiling.attention.main import (
+    _filter_standard_attention_inputs_by_memory,
+    _validate_explicit_decode_kv_coverage,
+)
+from frontier.profiling.utils import get_attention_input_combinations
+
+
+def _explicit_decode_inputs(kv_cache_size: int):
+    return get_attention_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=1,
+        max_batch_size=1,
+        profile_only_prefill=False,
+        profile_only_decode=True,
+        decode_kv_cache_size_list=[kv_cache_size],
+    )
+
+
+def test_memory_filter_warns_when_explicit_kv_is_dropped_for_target():
+    inputs = _explicit_decode_inputs(511)
+
+    with pytest.warns(RuntimeWarning, match="explicit decode KV values.*511"):
+        filtered, retained_explicit_kv = _filter_standard_attention_inputs_by_memory(
+            inputs,
+            max_num_tokens=256,
+            model="test-model",
+            tensor_parallel_size=1,
+            explicit_decode_kv_cache_sizes=[511],
+        )
+
+    assert filtered == []
+    assert retained_explicit_kv == set()
+
+
+def test_explicit_kv_coverage_allows_target_specific_subsets():
+    inputs = _explicit_decode_inputs(511)
+
+    with pytest.warns(RuntimeWarning):
+        filtered_small, retained_small = _filter_standard_attention_inputs_by_memory(
+            inputs,
+            max_num_tokens=256,
+            model="small-model",
+            tensor_parallel_size=1,
+            explicit_decode_kv_cache_sizes=[511],
+        )
+    filtered_large, retained_large = _filter_standard_attention_inputs_by_memory(
+        inputs,
+        max_num_tokens=512,
+        model="large-model",
+        tensor_parallel_size=1,
+        explicit_decode_kv_cache_sizes=[511],
+    )
+
+    assert filtered_small == []
+    assert retained_small == set()
+    assert len(filtered_large) == 1
+    assert retained_large == {511}
+
+    _validate_explicit_decode_kv_coverage(
+        explicit_decode_kv_cache_sizes=[511],
+        retained_explicit_kv={511},
+        target_capacities={
+            ("small-model", 1): 256,
+            ("large-model", 1): 512,
+        },
+    )
+
+
+def test_explicit_kv_coverage_fails_when_all_targets_drop_value():
+    with pytest.raises(ValueError, match="no physically legal pairing.*511"):
+        _validate_explicit_decode_kv_coverage(
+            explicit_decode_kv_cache_sizes=[511],
+            retained_explicit_kv=set(),
+            target_capacities={
+                ("small-model", 1): 256,
+                ("medium-model", 1): 384,
+            },
+        )

--- a/tests/unit/test_examples_profiling_contracts.py
+++ b/tests/unit/test_examples_profiling_contracts.py
@@ -59,6 +59,14 @@ def test_attention_recipe_explicitly_profiles_chunked_prefill_state() -> None:
     assert "chunked prefill" in text.lower()
 
 
+def test_attention_recipe_propagates_profile_and_runtime_context_lengths() -> None:
+    text = _read(PROFILING_DIR / "profile_attention_chunked_prefill.sh")
+
+    assert 'MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"' in text
+    assert "--max_model_len" in text
+    assert "--max_seq_len" in text
+
+
 def test_profiling_scripts_route_outputs_to_compute_taxonomy() -> None:
     for script in EXPECTED_SCRIPTS:
         text = _read(script)

--- a/tests/unit/test_moe_ep_sampling_domain.py
+++ b/tests/unit/test_moe_ep_sampling_domain.py
@@ -1,0 +1,74 @@
+"""Tests for the runtime-legal MoE expert-parallel sampling envelope."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from frontier.profiling.moe.main import parse_args
+from frontier.profiling.moe.moe_input import (
+    get_default_moe_profiling_config,
+    get_runtime_legal_expert_parallel_sizes,
+    resolve_moe_expert_parallel_sizes,
+)
+
+
+def test_runtime_legal_ep_sizes_include_every_positive_divisor() -> None:
+    assert get_runtime_legal_expert_parallel_sizes(60) == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        10,
+        12,
+        15,
+        20,
+        30,
+        60,
+    ]
+
+
+def test_default_moe_profile_maps_all_ep_sizes_to_local_widths() -> None:
+    config = get_default_moe_profiling_config(num_experts=60)
+
+    assert config.num_experts_per_device_list == [
+        60,
+        30,
+        20,
+        15,
+        12,
+        10,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+    ]
+
+
+def test_explicit_ep_sizes_are_deduplicated_and_validated() -> None:
+    assert resolve_moe_expert_parallel_sizes(60, [20, 2, 20, 1]) == [20, 2, 1]
+
+    with pytest.raises(ValueError, match="divisor"):
+        resolve_moe_expert_parallel_sizes(60, [7])
+
+    with pytest.raises(ValueError, match="at least one"):
+        resolve_moe_expert_parallel_sizes(60, [])
+
+
+@pytest.mark.parametrize("num_experts", [0, -1])
+def test_ep_domain_rejects_non_positive_expert_count(num_experts: int) -> None:
+    with pytest.raises(ValueError, match="num_experts"):
+        get_runtime_legal_expert_parallel_sizes(num_experts)
+
+
+def test_moe_cli_uses_model_derived_ep_domain_when_unspecified(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["frontier.profiling.moe.main", "--device", "a100"])
+
+    args, _ = parse_args()
+
+    assert args.expert_parallel_sizes is None

--- a/tests/unit/test_moe_ep_sampling_domain.py
+++ b/tests/unit/test_moe_ep_sampling_domain.py
@@ -6,12 +6,15 @@ import sys
 
 import pytest
 
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.moe import main as moe_main
 from frontier.profiling.moe.main import parse_args
 from frontier.profiling.moe.moe_input import (
     get_default_moe_profiling_config,
     get_runtime_legal_expert_parallel_sizes,
     resolve_moe_expert_parallel_sizes,
 )
+from frontier.profiling.utils import get_num_tokens_to_profile
 
 
 def test_runtime_legal_ep_sizes_include_every_positive_divisor() -> None:
@@ -72,3 +75,56 @@ def test_moe_cli_uses_model_derived_ep_domain_when_unspecified(monkeypatch) -> N
     args, _ = parse_args()
 
     assert args.expert_parallel_sizes is None
+
+
+def test_moe_confirmation_reports_all_model_domains_and_aggregate_total(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["frontier.profiling.moe.main", "--device", "a100"])
+    args, _ = parse_args()
+    num_tokens_to_profile = get_num_tokens_to_profile(args.max_tokens)
+    model_configs = {
+        model: ModelConfig.from_model_name(model) for model in args.models
+    }
+    resolved_ep_sizes_by_model = {
+        model: resolve_moe_expert_parallel_sizes(
+            model_config.num_experts,
+            args.expert_parallel_sizes,
+        )
+        for model, model_config in model_configs.items()
+    }
+
+    sections = moe_main._build_moe_confirmation_sections(
+        args=args,
+        model_configs=model_configs,
+        resolved_ep_sizes_by_model=resolved_ep_sizes_by_model,
+        num_tokens_count=len(num_tokens_to_profile),
+        use_vllm_kernel=True,
+    )
+
+    section_map = {section_name: dict(rows) for section_name, rows in sections}
+    model_domains = section_map["Resolved Model Profiling Domains"]
+    assert "[1, 2, 4, 8]" in model_domains["mixtral_8x7b_moe"]
+    assert "12,432 configurations" in model_domains["mixtral_8x7b_moe"]
+    assert "[1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60]" in model_domains[
+        "qwen2_moe_example"
+    ]
+    assert "37,296 configurations" in model_domains["qwen2_moe_example"]
+    assert "49,728" in section_map["Profiling Matrix"]["Total Configurations"]
+
+
+def test_moe_configuration_count_includes_load_distribution_samples() -> None:
+    cases_per_parallel_point = 3 * 2
+
+    assert moe_main._count_moe_configurations(
+        num_tokens_count=3,
+        tensor_parallel_count=3,
+        expert_parallel_count=4,
+        cases_per_parallel_point=cases_per_parallel_point,
+    ) == 216
+    assert moe_main._count_moe_configurations(
+        num_tokens_count=3,
+        tensor_parallel_count=1,
+        expert_parallel_count=4,
+        cases_per_parallel_point=cases_per_parallel_point,
+    ) == 72

--- a/tests/unit/test_moe_load_distribution_contract.py
+++ b/tests/unit/test_moe_load_distribution_contract.py
@@ -1,0 +1,55 @@
+import pytest
+
+from frontier.profiling.moe.load_distribution import generate_expert_routing
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"num_tokens": 0}, "num_tokens"),
+        ({"num_tokens": -1}, "num_tokens"),
+        ({"num_experts": 0, "top_k": 0}, "num_experts"),
+        ({"num_experts": -1, "top_k": 0}, "num_experts"),
+        ({"top_k": 0}, "top_k"),
+        ({"top_k": -1}, "top_k"),
+    ],
+)
+def test_generate_expert_routing_rejects_non_positive_dimensions(
+    kwargs,
+    message,
+):
+    base_kwargs = {
+        "num_tokens": 4,
+        "num_experts": 8,
+        "top_k": 2,
+        "load_distribution": "uniform",
+        "seed": 42,
+    }
+    base_kwargs.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        generate_expert_routing(**base_kwargs)
+
+
+def test_generate_expert_routing_accepts_full_width_topk():
+    weights, expert_ids = generate_expert_routing(
+        num_tokens=4,
+        num_experts=8,
+        top_k=8,
+        load_distribution="uniform",
+        seed=42,
+    )
+
+    assert tuple(weights.shape) == (4, 8)
+    assert tuple(expert_ids.shape) == (4, 8)
+
+
+def test_generate_expert_routing_rejects_topk_above_expert_count():
+    with pytest.raises(ValueError, match="top_k.*cannot exceed num_experts"):
+        generate_expert_routing(
+            num_tokens=4,
+            num_experts=8,
+            top_k=9,
+            load_distribution="uniform",
+            seed=42,
+        )

--- a/tests/unit/test_moe_routing_input_contract.py
+++ b/tests/unit/test_moe_routing_input_contract.py
@@ -1,0 +1,89 @@
+import pytest
+import torch
+
+from frontier.profiling.moe.moe_wrapper import MoEWrapper
+from frontier.profiling.moe.load_distribution import generate_expert_routing
+
+
+def _cpu_wrapper(*, expert_parallel_size: int = 1) -> MoEWrapper:
+    wrapper = MoEWrapper.__new__(MoEWrapper)
+    wrapper.expert_parallel_size = expert_parallel_size
+    wrapper.num_experts = 8
+    wrapper.num_experts_per_device = 8 // expert_parallel_size
+    wrapper.router_topk = 2
+    return wrapper
+
+
+def test_prepare_routing_inputs_rejects_counts_inconsistent_with_generated_route() -> None:
+    wrapper = _cpu_wrapper(expert_parallel_size=2)
+
+    with pytest.raises(ValueError, match="expert_token_counts.*match"):
+        wrapper._prepare_routing_inputs(
+            num_tokens=17,
+            load_distribution="skewed",
+            seed=3,
+            expert_token_counts=[34, 0, 0, 0],
+        )
+
+
+def test_prepare_routing_inputs_accepts_matching_local_counts() -> None:
+    wrapper = _cpu_wrapper(expert_parallel_size=2)
+    generated = wrapper._prepare_routing_inputs(
+        num_tokens=17,
+        load_distribution="skewed",
+        seed=3,
+    )
+
+    reused = wrapper._prepare_routing_inputs(
+        num_tokens=17,
+        load_distribution="skewed",
+        seed=3,
+        expert_token_counts=generated["expert_token_counts"],
+    )
+
+    assert reused["expert_token_counts"] == generated["expert_token_counts"]
+
+
+def test_prepare_routing_inputs_rejects_integral_float_counts() -> None:
+    wrapper = _cpu_wrapper(expert_parallel_size=1)
+    generated = wrapper._prepare_routing_inputs(
+        num_tokens=17,
+        load_distribution="uniform",
+        seed=3,
+    )
+    supplied = list(generated["expert_token_counts"])
+    supplied[0] = float(supplied[0])
+
+    with pytest.raises(ValueError, match="non-negative integers"):
+        wrapper._prepare_routing_inputs(
+            num_tokens=17,
+            load_distribution="uniform",
+            seed=3,
+            expert_token_counts=supplied,
+        )
+
+
+def test_extremely_skewed_preserves_a_hot_subset_when_topk_is_wide() -> None:
+    _, topk_ids = generate_expert_routing(
+        num_tokens=512,
+        num_experts=16,
+        top_k=8,
+        load_distribution="extremely_skewed",
+        seed=42,
+    )
+
+    hot_rows = (topk_ids < 8).all(dim=1)
+
+    assert int(hot_rows.sum()) >= 350
+
+
+def test_skewed_distribution_keeps_expert_zero_reachable() -> None:
+    _, topk_ids = generate_expert_routing(
+        num_tokens=512,
+        num_experts=8,
+        top_k=2,
+        load_distribution="skewed",
+        seed=42,
+    )
+
+    assert bool((topk_ids == 0).any())

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -101,6 +101,13 @@ def test_decode_attention_input_reserves_the_current_token():
     assert not AttentionInput(0, 1000, 1, False).is_valid(1000)
 
 
+def test_decode_memory_limit_reserves_the_current_token():
+    decode_input = AttentionInput(0, 32, 1, False)
+
+    assert not decode_input.is_under_memory_limit(32)
+    assert decode_input.is_under_memory_limit(33)
+
+
 def test_explicit_decode_cache_endpoint_remains_bounded():
     inputs = get_attention_input_combinations(
         max_seq_len=1000,

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -1,0 +1,115 @@
+import pytest
+
+from frontier.profiling.utils import (
+    get_attention_batch_sizes_to_profile,
+    get_attention_input_combinations,
+    get_attention_prefill_chunk_sizes_to_profile,
+    get_num_tokens_to_profile,
+    get_seq_lengths_to_profile,
+)
+from frontier.profiling.moe.moe_input import get_default_moe_profiling_config
+
+
+def _attention_input_tuples(inputs):
+    return [
+        (
+            item.prefill_chunk_size,
+            item.kv_cache_size,
+            item.batch_size,
+            item.is_prefill,
+        )
+        for item in inputs
+    ]
+
+
+def test_extra_num_tokens_are_unioned_even_when_above_default_grid_limit():
+    values = get_num_tokens_to_profile(10, extra_num_tokens=[11, 11, 7])
+
+    assert values == sorted(set(values), reverse=True)
+    assert 11 in values
+    assert 7 in values
+
+
+def test_default_token_grid_reaches_requested_endpoint():
+    values = get_num_tokens_to_profile(10)
+
+    assert max(values) == 10
+    assert all(value <= 10 for value in values)
+
+
+@pytest.mark.parametrize("extra_value", [0, -1])
+def test_extra_num_tokens_reject_non_positive_values(extra_value):
+    with pytest.raises(ValueError, match="extra_num_tokens"):
+        get_num_tokens_to_profile(10, extra_num_tokens=[extra_value])
+
+
+def test_sequence_length_grid_reaches_requested_endpoint():
+    values = get_seq_lengths_to_profile(1000)
+
+    assert values == sorted(set(values))
+    assert values
+    assert max(values) == 1000
+    assert all(value <= 1000 for value in values)
+
+
+def test_prefill_chunk_grid_reaches_requested_endpoint():
+    values = get_attention_prefill_chunk_sizes_to_profile(1000)
+
+    assert values == sorted(set(values))
+    assert values
+    assert max(values) == 1000
+    assert all(value <= 1000 for value in values)
+
+
+def test_attention_batch_grid_reaches_requested_endpoints():
+    values = get_attention_batch_sizes_to_profile(129, 130)
+
+    assert values == [129, 130]
+
+
+def test_default_moe_token_grid_reaches_requested_endpoint():
+    config = get_default_moe_profiling_config(max_tokens=5000)
+
+    assert max(config.num_tokens_list) == 5000
+    assert config.num_tokens_list == sorted(set(config.num_tokens_list))
+
+
+def test_attention_combinations_cover_prefill_and_decode_endpoints_deterministically():
+    kwargs = dict(
+        max_seq_len=1000,
+        min_batch_size=1,
+        max_batch_size=2,
+        profile_only_prefill=False,
+        profile_only_decode=False,
+    )
+    first = get_attention_input_combinations(**kwargs)
+    second = get_attention_input_combinations(**kwargs)
+    first_tuples = _attention_input_tuples(first)
+
+    assert first_tuples == _attention_input_tuples(second)
+    assert (1000, 0, 1, True) in first_tuples
+    assert (0, 1000, 1, False) in first_tuples
+    assert all(item.is_valid(1000) for item in first)
+
+
+def test_explicit_decode_cache_endpoint_remains_bounded():
+    inputs = get_attention_input_combinations(
+        max_seq_len=1000,
+        min_batch_size=1,
+        max_batch_size=1,
+        profile_only_prefill=False,
+        profile_only_decode=True,
+        decode_kv_cache_size_list=[1000],
+    )
+
+    assert _attention_input_tuples(inputs) == [(0, 1000, 1, False)]
+
+    with pytest.raises(ValueError, match="decode_kv_cache_size_list"):
+        get_attention_input_combinations(
+            max_seq_len=1000,
+            min_batch_size=1,
+            max_batch_size=1,
+            profile_only_prefill=False,
+            profile_only_decode=True,
+            decode_kv_cache_size_list=[1001],
+        )

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -131,6 +131,47 @@ def test_explicit_decode_cache_endpoint_remains_bounded():
         )
 
 
+def test_standard_decode_kv_can_extend_beyond_profile_context():
+    inputs = get_attention_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=1,
+        max_batch_size=1,
+        profile_only_prefill=False,
+        profile_only_decode=True,
+        decode_kv_cache_size_list=[300],
+    )
+
+    assert _attention_input_tuples(inputs) == [(0, 300, 1, False)]
+    assert inputs[0].is_valid(max_seq_len=256, max_model_len=512)
+
+
+def test_standard_decode_kv_still_fails_at_runtime_capacity():
+    with pytest.raises(ValueError, match="max_model_len - 1"):
+        get_attention_input_combinations(
+            max_seq_len=256,
+            max_model_len=512,
+            min_batch_size=1,
+            max_batch_size=1,
+            profile_only_prefill=False,
+            profile_only_decode=True,
+            decode_kv_cache_size_list=[512],
+        )
+
+
+def test_standard_auto_decode_axis_stays_within_profile_context():
+    inputs = get_attention_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=1,
+        max_batch_size=1,
+        profile_only_prefill=False,
+        profile_only_decode=True,
+    )
+
+    assert max(item.kv_cache_size for item in inputs) == 255
+
+
 def test_legacy_mixed_prefill_retains_high_kv_endpoint_with_legal_sequence():
     inputs = get_mixed_prefill_input_combinations(
         max_seq_len=1000,

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -146,6 +146,34 @@ def test_legacy_mixed_prefill_retains_high_kv_endpoint_with_legal_sequence():
     assert all(item.is_valid(1000, max_batch_size=128) for item in high_kv_inputs)
 
 
+def test_legacy_mixed_prefill_explicit_kv_can_extend_beyond_profile_context():
+    inputs = get_mixed_prefill_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=2,
+        max_batch_size=2,
+        mode="even",
+        kv_cache_sizes=[300],
+    )
+
+    assert inputs
+    assert all(item.max_seq_len <= 256 for item in inputs)
+    assert all(item.max_seq_len + item.kv_cache_size <= 512 for item in inputs)
+    assert {item.kv_cache_size for item in inputs} == {300}
+
+
+def test_legacy_mixed_prefill_explicit_kv_without_legal_pair_fails_fast():
+    with pytest.raises(ValueError, match="kv_cache_sizes"):
+        get_mixed_prefill_input_combinations(
+            max_seq_len=256,
+            max_model_len=512,
+            min_batch_size=2,
+            max_batch_size=2,
+            mode="even",
+            kv_cache_sizes=[512],
+        )
+
+
 def test_legacy_mixed_prefill_emits_unique_structural_workloads():
     inputs = get_mixed_prefill_input_combinations(
         max_seq_len=1000,

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -1,5 +1,6 @@
 import pytest
 
+from frontier.profiling.attention.attention_input import AttentionInput
 from frontier.profiling.utils import (
     get_attention_batch_sizes_to_profile,
     get_attention_input_combinations,
@@ -91,8 +92,13 @@ def test_attention_combinations_cover_prefill_and_decode_endpoints_deterministic
 
     assert first_tuples == _attention_input_tuples(second)
     assert (1000, 0, 1, True) in first_tuples
-    assert (0, 1000, 1, False) in first_tuples
+    assert (0, 999, 1, False) in first_tuples
     assert all(item.is_valid(1000) for item in first)
+
+
+def test_decode_attention_input_reserves_the_current_token():
+    assert AttentionInput(0, 999, 1, False).is_valid(1000)
+    assert not AttentionInput(0, 1000, 1, False).is_valid(1000)
 
 
 def test_explicit_decode_cache_endpoint_remains_bounded():
@@ -102,10 +108,10 @@ def test_explicit_decode_cache_endpoint_remains_bounded():
         max_batch_size=1,
         profile_only_prefill=False,
         profile_only_decode=True,
-        decode_kv_cache_size_list=[1000],
+        decode_kv_cache_size_list=[999],
     )
 
-    assert _attention_input_tuples(inputs) == [(0, 1000, 1, False)]
+    assert _attention_input_tuples(inputs) == [(0, 999, 1, False)]
 
     with pytest.raises(ValueError, match="decode_kv_cache_size_list"):
         get_attention_input_combinations(
@@ -114,7 +120,7 @@ def test_explicit_decode_cache_endpoint_remains_bounded():
             max_batch_size=1,
             profile_only_prefill=False,
             profile_only_decode=True,
-            decode_kv_cache_size_list=[1001],
+            decode_kv_cache_size_list=[1000],
         )
 
 

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -5,7 +5,10 @@ from frontier.profiling.utils import (
     get_attention_input_combinations,
     get_attention_prefill_chunk_sizes_to_profile,
     get_num_tokens_to_profile,
+    get_mixed_prefill_input_combinations,
+    get_online_grid_mixed_prefill_input_combinations,
     get_seq_lengths_to_profile,
+    get_true_mixed_attention_input_combinations,
 )
 from frontier.profiling.moe.moe_input import get_default_moe_profiling_config
 
@@ -113,3 +116,64 @@ def test_explicit_decode_cache_endpoint_remains_bounded():
             profile_only_decode=True,
             decode_kv_cache_size_list=[1001],
         )
+
+
+def test_legacy_mixed_prefill_retains_high_kv_endpoint_with_legal_sequence():
+    inputs = get_mixed_prefill_input_combinations(
+        max_seq_len=1000,
+        min_batch_size=2,
+        max_batch_size=2,
+        mode="even",
+        kv_cache_sizes=[0, 992],
+    )
+
+    high_kv_inputs = [item for item in inputs if item.kv_cache_size == 992]
+    assert high_kv_inputs
+    assert max(item.max_seq_len + item.kv_cache_size for item in high_kv_inputs) == 1000
+    assert all(item.is_valid(1000, max_batch_size=128) for item in high_kv_inputs)
+
+
+def test_legacy_mixed_prefill_emits_unique_structural_workloads():
+    inputs = get_mixed_prefill_input_combinations(
+        max_seq_len=1000,
+        min_batch_size=2,
+        max_batch_size=8,
+        mode="both",
+        kv_cache_sizes=[0],
+    )
+
+    identities = {
+        (tuple(item.seq_lens), item.kv_cache_size, item.mode) for item in inputs
+    }
+    assert len(inputs) == len(identities)
+
+
+def test_online_grid_explicit_lists_extend_default_envelope():
+    inputs = get_online_grid_mixed_prefill_input_combinations(
+        max_seq_len=1000,
+        min_batch_size=2,
+        max_batch_size=3,
+        min_total_tokens=10,
+        max_total_tokens=11,
+        shapes_per_point=1,
+        batch_size_list=[4],
+        total_tokens_list=[12],
+    )
+
+    points = {(item.batch_size, item.total_tokens) for item in inputs}
+    assert {(2, 10), (3, 11), (4, 12)} <= points
+
+
+def test_true_mixed_grid_reaches_prefill_and_decode_endpoints():
+    inputs = get_true_mixed_attention_input_combinations(
+        max_seq_len=1000,
+        prefill_batch_sizes=[1],
+        prefill_chunk_sizes=[64],
+        decode_batch_sizes=[1],
+        decode_kv_cache_sizes=[128],
+        prefill_kv_cache_size=0,
+    )
+
+    assert max(item.prefill_seq_lens[0] for item in inputs) == 1000
+    assert max(item.decode_kv_cache_sizes[0] for item in inputs) == 999
+    assert all(item.is_valid(max_seq_len=1000, max_batch_size=128) for item in inputs)

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -154,6 +154,28 @@ def test_legacy_mixed_prefill_emits_unique_structural_workloads():
     assert len(inputs) == len(identities)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"min_batch_size": 129, "max_batch_size": 129}, "batch_size"),
+        ({"kv_cache_sizes": [1000]}, "kv_cache_sizes"),
+        ({"mode": "unsupported"}, "mode"),
+    ],
+)
+def test_legacy_mixed_prefill_rejects_runtime_invalid_axes(kwargs, message):
+    base_kwargs = {
+        "max_seq_len": 1000,
+        "min_batch_size": 2,
+        "max_batch_size": 2,
+        "mode": "even",
+        "kv_cache_sizes": [0],
+    }
+    base_kwargs.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        get_mixed_prefill_input_combinations(**base_kwargs)
+
+
 def test_online_grid_explicit_lists_extend_default_envelope():
     inputs = get_online_grid_mixed_prefill_input_combinations(
         max_seq_len=1000,
@@ -170,6 +192,34 @@ def test_online_grid_explicit_lists_extend_default_envelope():
     assert {(2, 10), (3, 11), (4, 12)} <= points
 
 
+def test_online_grid_rejects_runtime_invalid_explicit_batch_size():
+    with pytest.raises(ValueError, match="batch_size_list"):
+        get_online_grid_mixed_prefill_input_combinations(
+            max_seq_len=1000,
+            min_batch_size=2,
+            max_batch_size=2,
+            min_total_tokens=10,
+            max_total_tokens=10,
+            shapes_per_point=1,
+            batch_size_list=[129],
+            total_tokens_list=[129],
+        )
+
+
+def test_online_grid_rejects_invalid_explicit_axis_cross_product():
+    with pytest.raises(ValueError, match="total_tokens"):
+        get_online_grid_mixed_prefill_input_combinations(
+            max_seq_len=1000,
+            min_batch_size=2,
+            max_batch_size=2,
+            min_total_tokens=10,
+            max_total_tokens=10,
+            shapes_per_point=1,
+            batch_size_list=[4],
+            total_tokens_list=[3],
+        )
+
+
 def test_true_mixed_grid_reaches_prefill_and_decode_endpoints():
     inputs = get_true_mixed_attention_input_combinations(
         max_seq_len=1000,
@@ -183,3 +233,33 @@ def test_true_mixed_grid_reaches_prefill_and_decode_endpoints():
     assert max(item.prefill_seq_lens[0] for item in inputs) == 1000
     assert max(item.decode_kv_cache_sizes[0] for item in inputs) == 999
     assert all(item.is_valid(max_seq_len=1000, max_batch_size=128) for item in inputs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"prefill_chunk_sizes": [1001]}, "prefill_chunk_sizes"),
+        ({"decode_kv_cache_sizes": [1000]}, "decode_kv_cache_sizes"),
+        (
+            {
+                "prefill_batch_sizes": [100],
+                "decode_batch_sizes": [29],
+            },
+            "total batch size",
+        ),
+        ({"prefill_kv_cache_size": 1000}, "prefill_kv_cache_size"),
+    ],
+)
+def test_true_mixed_rejects_runtime_invalid_explicit_axes(kwargs, message):
+    base_kwargs = {
+        "max_seq_len": 1000,
+        "prefill_batch_sizes": [1],
+        "prefill_chunk_sizes": [64],
+        "decode_batch_sizes": [1],
+        "decode_kv_cache_sizes": [128],
+        "prefill_kv_cache_size": 0,
+    }
+    base_kwargs.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        get_true_mixed_attention_input_combinations(**base_kwargs)

--- a/tests/unit/test_profiling_sampling_domain.py
+++ b/tests/unit/test_profiling_sampling_domain.py
@@ -227,6 +227,108 @@ def test_online_grid_rejects_invalid_explicit_axis_cross_product():
         )
 
 
+def test_online_grid_skips_invalid_automatic_points_but_keeps_explicit_points():
+    inputs = get_online_grid_mixed_prefill_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=2,
+        max_batch_size=2,
+        min_total_tokens=1025,
+        max_total_tokens=1055,
+        shapes_per_point=1,
+        batch_size_list=[2],
+        total_tokens_list=[64, 128],
+    )
+
+    points = {(item.batch_size, item.total_tokens) for item in inputs}
+    assert points == {(2, 64), (2, 128)}
+
+
+def test_online_grid_rejects_explicit_point_without_a_legal_pair():
+    with pytest.raises(ValueError, match="total_tokens"):
+        get_online_grid_mixed_prefill_input_combinations(
+            max_seq_len=256,
+            max_model_len=512,
+            min_batch_size=2,
+            max_batch_size=2,
+            min_total_tokens=1025,
+            max_total_tokens=1055,
+            shapes_per_point=1,
+            batch_size_list=[2],
+            total_tokens_list=[1025],
+        )
+
+
+def test_online_grid_explicit_kv_can_extend_beyond_profile_context():
+    inputs = get_online_grid_mixed_prefill_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=2,
+        max_batch_size=2,
+        min_total_tokens=64,
+        max_total_tokens=64,
+        shapes_per_point=1,
+        kv_cache_sizes=[256],
+    )
+
+    assert len(inputs) == 1
+    assert inputs[0].kv_cache_size == 256
+
+
+def test_online_grid_rejects_model_capacity_below_profile_context():
+    with pytest.raises(ValueError, match="max_model_len must be >= max_seq_len"):
+        get_online_grid_mixed_prefill_input_combinations(
+            max_seq_len=256,
+            max_model_len=128,
+            min_batch_size=2,
+            max_batch_size=2,
+            min_total_tokens=64,
+            max_total_tokens=64,
+            shapes_per_point=1,
+        )
+
+
+def test_online_grid_keeps_legal_kv_siblings_when_an_automatic_pair_is_invalid():
+    inputs = get_online_grid_mixed_prefill_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=2,
+        max_batch_size=32,
+        min_total_tokens=64,
+        max_total_tokens=64,
+        shapes_per_point=1,
+        kv_cache_sizes=[0, 500],
+    )
+
+    point_kv = {
+        (item.batch_size, item.total_tokens, item.kv_cache_size)
+        for item in inputs
+    }
+    assert (2, 64, 0) in point_kv
+    assert (2, 64, 500) not in point_kv
+    assert (32, 64, 500) in point_kv
+
+
+def test_online_grid_keeps_a_valid_shape_when_its_sibling_shape_is_invalid():
+    inputs = get_online_grid_mixed_prefill_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        min_batch_size=2,
+        max_batch_size=32,
+        min_total_tokens=64,
+        max_total_tokens=64,
+        shapes_per_point=2,
+        kv_cache_sizes=[0, 480],
+    )
+
+    point_modes = {
+        (item.batch_size, item.total_tokens, item.kv_cache_size, item.mode)
+        for item in inputs
+    }
+    assert (2, 64, 480, "online_grid_balanced") in point_modes
+    assert (2, 64, 480, "online_grid_skewed") not in point_modes
+
+
 def test_true_mixed_grid_reaches_prefill_and_decode_endpoints():
     inputs = get_true_mixed_attention_input_combinations(
         max_seq_len=1000,
@@ -240,6 +342,101 @@ def test_true_mixed_grid_reaches_prefill_and_decode_endpoints():
     assert max(item.prefill_seq_lens[0] for item in inputs) == 1000
     assert max(item.decode_kv_cache_sizes[0] for item in inputs) == 999
     assert all(item.is_valid(max_seq_len=1000, max_batch_size=128) for item in inputs)
+
+
+@pytest.mark.parametrize(
+    ("max_seq_len", "expected_prefill_chunks", "expected_decode_kv"),
+    [
+        (128, {64, 128, 256}, {127, 128}),
+        (256, {64, 128, 256, 512}, {128, 255, 256}),
+        (
+            1024,
+            {64, 128, 256, 512, 1024, 2048},
+            {128, 256, 512, 1023, 1024},
+        ),
+    ],
+)
+def test_true_mixed_auto_axes_follow_profile_context(
+    max_seq_len, expected_prefill_chunks, expected_decode_kv
+):
+    inputs = get_true_mixed_attention_input_combinations(
+        max_seq_len=max_seq_len,
+        max_model_len=max_seq_len * 2,
+        prefill_batch_sizes=[1, 2, 4],
+        prefill_chunk_sizes=None,
+        decode_batch_sizes=[1, 2, 4, 8],
+        decode_kv_cache_sizes=None,
+        prefill_kv_cache_size=0,
+    )
+
+    prefill_chunks = {item.prefill_seq_lens[0] for item in inputs}
+    decode_kv = {item.decode_kv_cache_sizes[0] for item in inputs}
+    assert prefill_chunks == expected_prefill_chunks
+    assert decode_kv == expected_decode_kv
+
+
+def test_true_mixed_auto_axes_use_physical_boundary_when_next_anchor_does_not_fit():
+    inputs = get_true_mixed_attention_input_combinations(
+        max_seq_len=1000,
+        max_model_len=1010,
+        prefill_batch_sizes=[1],
+        prefill_chunk_sizes=None,
+        decode_batch_sizes=[1],
+        decode_kv_cache_sizes=None,
+        prefill_kv_cache_size=0,
+    )
+
+    prefill_chunks = {item.prefill_seq_lens[0] for item in inputs}
+    decode_kv = {item.decode_kv_cache_sizes[0] for item in inputs}
+    assert prefill_chunks == {64, 128, 256, 512, 1000, 1010}
+    assert decode_kv == {128, 256, 512, 999, 1009}
+
+
+def test_true_mixed_explicit_axes_can_extend_beyond_profile_context():
+    inputs = get_true_mixed_attention_input_combinations(
+        max_seq_len=256,
+        max_model_len=512,
+        prefill_batch_sizes=[1],
+        prefill_chunk_sizes=[512],
+        decode_batch_sizes=[1],
+        decode_kv_cache_sizes=[256],
+        prefill_kv_cache_size=0,
+    )
+
+    extended = [
+        item
+        for item in inputs
+        if item.prefill_seq_lens == [512]
+        and item.decode_kv_cache_sizes == [256]
+    ]
+    assert len(extended) == 1
+    assert len(inputs) > len(extended)
+
+
+def test_true_mixed_explicit_axes_beyond_profile_capacity_fail_fast():
+    with pytest.raises(ValueError):
+        get_true_mixed_attention_input_combinations(
+            max_seq_len=256,
+            max_model_len=512,
+            prefill_batch_sizes=[1],
+            prefill_chunk_sizes=[513],
+            decode_batch_sizes=[1],
+            decode_kv_cache_sizes=[256],
+            prefill_kv_cache_size=0,
+        )
+
+
+def test_true_mixed_rejects_model_capacity_below_profile_context():
+    with pytest.raises(ValueError, match="max_model_len must be >= max_seq_len"):
+        get_true_mixed_attention_input_combinations(
+            max_seq_len=256,
+            max_model_len=128,
+            prefill_batch_sizes=[1],
+            prefill_chunk_sizes=None,
+            decode_batch_sizes=[1],
+            decode_kv_cache_sizes=None,
+            prefill_kv_cache_size=0,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Scope

This PR is the profiling-envelope and runtime-legal MoE EP slice stacked on approved PR #20 (`18d1a23e`).

It:
- separates the profiling envelope (`max_seq_len`) from the runtime context limit (`max_model_len`);
- bounds automatic standard decode at `max_seq_len - 1` while allowing explicit runtime-legal values through `max_model_len - 1`;
- filters each standard-attention target by physical KV capacity and reserves the current decode token;
- validates legacy, online-grid, true-mixed, and MoE routing axes before worker dispatch;
- resolves every runtime-legal positive EP divisor and reports per-model plus aggregate workloads correctly.

## Option-B explicit KV contract

Explicit standard-attention decode KV values are filtered independently for each `(model, TP)` target. A target-local physical drop emits a `RuntimeWarning` naming the dropped KV values, combination count, model, TP, physical capacity, and retained values. The parent process prints requested/retained coverage and target capacities. A requested value raises `ValueError` only when every selected target drops it. Explicit values that violate `kv_cache_size + 1 <= max_model_len` still fail fast.

## Boundary

This PR changes code-side sampling, validation, physical filtering, and user-visible discard feedback only. It does not regenerate canonical profiling CSVs, modify `README.md`, add an independent profiling-facing adapter, repair pre-existing producer metadata persistence, or redesign the MTP unified-family/interface. Those follow-ups remain separately recorded.

## Validation

- Option-B warning contract: `3 passed`.
- Combined sampling/EP/routing matrix: `59 passed`.
- Synthetic PR #20 + PR #21 stack: `322 passed, 2 deselected`; no merge conflict.
- Targeted PR #21 sampling/EP matrix: `33 passed`; MoE routing/load matrix: `13 passed`.
- Warning probe: requested `[255, 300, 511]`; capacity `256` retained `[255]` and warned for `2` dropped combinations `[300, 511]`; capacity `512` retained all three; retained union `[255, 300, 511]`.
- All-target drop probe: explicit `511` raised `ValueError` with the selected target-capacity map.
- Numeric checks: decode endpoint `999/1000`; decode capacity `32 -> False`, `33 -> True`; MoE aggregate `12,432 + 37,296 = 49,728`; extreme-skew hot rows `423/512`.
- Production compile and `git diff --check` passed.
- Independent local review: architecture `CLEAR`; code/spec `APPROVE`; concurrent Claude run exhausted the requested `1800s` without a final verdict and is not counted as approval.

Latest verified head: `8cc267ea`.

PR #20 and PR #21 remain open and unmerged; auto-merge is unset.
