### PR TITLE
Make developer-specific test-harness paths configurable via environment variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 | Date       | Summary of Changes |
 | ---------- | ------------------ |
-| 2026-09-06 | Added the `FRONTIER_TMP_ROOT` override for the heavyweight test-harness scratch root. |
+| 2026-09-06 | Added the `FRONTIER_TMP_ROOT` and `FRONTIER_PDAF_REFERENCE_REPO_ROOT` overrides for developer-specific test-harness paths. |
 | 2026-09-05 | Added the authoritative vLLM parallel-semantics and Frontier lane-mapping contract. |
 | 2026-09-05 | Clarified Replica-local collective backend materialization. |
 
@@ -775,6 +775,10 @@ export FRONTIER_TMP_ROOT=/path/to/large/scratch
 ```
 
 `FRONTIER_WALLTIME_TMPDIR` (sweep-specific child temp directory) must still resolve to a descendant of that root.
+
+### Pinned Reference checkout for PD-AF parity
+
+The PD-AF parity harness (`tests/e2e/pd_af_parity/`) and `tests/integration/test_pdaf_reference_lifecycle_observer.py` compare the current branch against a pinned, read-only Reference checkout whose git HEAD and source hashes are asserted at runtime. Its location is resolved by `tests/e2e/pd_af_parity/reference_repo_root.py`, with the historical default `/data/ycfeng/stepfun-performance-optimization/Frontier/worktrees/ref-afd-readonly`. If your checkout lives elsewhere, point `FRONTIER_PDAF_REFERENCE_REPO_ROOT` at it (absolute path). Only the location is configurable; the pinned identity checks are unchanged, so the tests still require a checkout at the pinned commit.
 
 ## Contributing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 | Date       | Summary of Changes |
 | ---------- | ------------------ |
+| 2026-09-06 | Added the `FRONTIER_TMP_ROOT` override for the heavyweight test-harness scratch root. |
 | 2026-09-05 | Added the authoritative vLLM parallel-semantics and Frontier lane-mapping contract. |
 | 2026-09-05 | Clarified Replica-local collective backend materialization. |
 
@@ -764,6 +765,16 @@ Start with:
 - `pytest tests/unit/test_pdd_public_surface_docs.py tests/unit/test_examples_pdd_scripts.py -q`
 - `bash tests/debug/e2e-level/monolith_mode/scripts/test_dense_tp2_pp2_dummy.sh`
 - `bash tests/debug/e2e-level/monolith_mode/scripts/test_moe_tp2_ep2_pp2_dummy.sh`
+
+### Scratch root for heavyweight harnesses
+
+The wall-time scaling sweep (`tests/performance/sim_walltime_scaling/sweep.py`), the MoE-EP baseline replay (`tests/e2e/moe_ep_baseline_replay.py`), and the MoE-EP non-dummy matrix (`tests/e2e/moe_ep_non_dummy_matrix.py`) write large intermediate outputs under one shared scratch root, resolved by `tests/scratch_root.py`. The historical default is `/data/ycfeng/tmp`. On any other machine, set `FRONTIER_TMP_ROOT` to an absolute, writable directory before running those harnesses or their unit tests:
+
+```bash
+export FRONTIER_TMP_ROOT=/path/to/large/scratch
+```
+
+`FRONTIER_WALLTIME_TMPDIR` (sweep-specific child temp directory) must still resolve to a descendant of that root.
 
 ## Contributing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -774,11 +774,11 @@ The wall-time scaling sweep (`tests/performance/sim_walltime_scaling/sweep.py`),
 export FRONTIER_TMP_ROOT=/path/to/large/scratch
 ```
 
-`FRONTIER_WALLTIME_TMPDIR` (sweep-specific child temp directory) must still resolve to a descendant of that root.
+`FRONTIER_WALLTIME_TMPDIR` (sweep-specific child temp directory) must still resolve to a descendant of that root. The shell wrapper `tests/e2e/run_moe_ep_non_dummy_matrix.sh` forwards `--output-root` only when `MATRIX_OUTPUT_ROOT` is set, so `FRONTIER_TMP_ROOT` alone controls its default output location.
 
 ### Pinned Reference checkout for PD-AF parity
 
-The PD-AF parity harness (`tests/e2e/pd_af_parity/`) and `tests/integration/test_pdaf_reference_lifecycle_observer.py` compare the current branch against a pinned, read-only Reference checkout whose git HEAD and source hashes are asserted at runtime. Its location is resolved by `tests/e2e/pd_af_parity/reference_repo_root.py`, with the historical default `/data/ycfeng/stepfun-performance-optimization/Frontier/worktrees/ref-afd-readonly`. If your checkout lives elsewhere, point `FRONTIER_PDAF_REFERENCE_REPO_ROOT` at it (absolute path). Only the location is configurable; the pinned identity checks are unchanged, so the tests still require a checkout at the pinned commit.
+The PD-AF parity harness (`tests/e2e/pd_af_parity/`) and `tests/integration/test_pdaf_reference_lifecycle_observer.py` compare the current branch against a pinned, read-only Reference checkout whose git HEAD and source hashes are asserted at runtime. Its location is resolved by `tests/e2e/pd_af_parity/reference_repo_root.py`, with the historical default `/data/ycfeng/stepfun-performance-optimization/Frontier/worktrees/ref-afd-readonly`. If your checkout lives elsewhere, point `FRONTIER_PDAF_REFERENCE_REPO_ROOT` at it (absolute path). The value is canonicalized (symlinks and `..` resolved) so the sidecar, the integration driver, and the harness compare the same string. Only the location is configurable; the pinned identity checks are unchanged, so the tests still require a checkout at the pinned commit. `reference_observer_bootstrap.py` carries its own copy of the resolver because it runs under a Reference-only `PYTHONPATH`.
 
 ## Contributing
 

--- a/tests/e2e/moe_ep_baseline_replay.py
+++ b/tests/e2e/moe_ep_baseline_replay.py
@@ -29,10 +29,10 @@ from tests.e2e.moe_ep_non_dummy_matrix import (
     _write_jsonl,
     validate_profile_inputs,
 )
+from tests.scratch_root import SCRATCH_ROOT_ENV, resolve_scratch_root
 
 
 EXPECTED_BASELINE_COMMIT = "5cb8dda2ed6aafeaa02a480685d34014ae43e4f9"
-TMP_ROOT = Path("/data/ycfeng/tmp")
 EXPECTED_ARCHITECTURE_COUNTS = Counter(
     {
         "co-location": 50,
@@ -56,10 +56,20 @@ def translate_routing_selector(distribution: str) -> tuple[str, str]:
     return mode, normalized
 
 
+def tmp_root() -> Path:
+    """Return the scratch root that bounds every replay write path."""
+
+    return resolve_scratch_root()
+
+
 def _require_tmp_path(path: Path, *, label: str) -> Path:
     resolved = path.resolve()
-    if not resolved.is_relative_to(TMP_ROOT.resolve()):
-        raise ValueError(f"{label} must be under {TMP_ROOT}: {resolved}")
+    scratch_root = tmp_root()
+    if not resolved.is_relative_to(scratch_root.resolve()):
+        raise ValueError(
+            f"{label} must be under {scratch_root}: {resolved} "
+            f"(set {SCRATCH_ROOT_ENV} to relocate the scratch root)"
+        )
     return resolved
 
 
@@ -190,14 +200,15 @@ def build_baseline_shell_command(
         case.routing_distribution
     )
 
+    scratch_root = tmp_root()
     env = dict(os.environ)
     env.update(
         {
             "PYTHONPATH": str(baseline_repo_root),
             "PYTHONDONTWRITEBYTECODE": "1",
-            "TMPDIR": str(TMP_ROOT),
-            "TEMP": str(TMP_ROOT),
-            "TMP": str(TMP_ROOT),
+            "TMPDIR": str(scratch_root),
+            "TEMP": str(scratch_root),
+            "TMP": str(scratch_root),
             "PYTHON_BIN": str(python_executable),
             "WANDB_DISABLED": "true",
             "VIDUR_DISABLE_WANDB": "1",
@@ -772,12 +783,12 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--data-cwd",
         type=Path,
-        default=TMP_ROOT / "frontier_baseline_replay_data",
+        default=tmp_root() / "frontier_baseline_replay_data",
     )
     parser.add_argument(
         "--output-root",
         type=Path,
-        default=TMP_ROOT / "frontier_baseline_replay_observable_v1",
+        default=tmp_root() / "frontier_baseline_replay_observable_v1",
     )
     parser.add_argument(
         "--results-path",

--- a/tests/e2e/moe_ep_non_dummy_matrix.py
+++ b/tests/e2e/moe_ep_non_dummy_matrix.py
@@ -48,6 +48,7 @@ from frontier.operators.families import (
     resolve_moe_operator_tp_key,
 )
 from frontier.types import ClusterType
+from tests.scratch_root import resolve_scratch_root
 
 
 ARCHITECTURE_CASE_COUNTS = {
@@ -7894,14 +7895,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.matrix_kind == "optimization":
         manifest_name = "moe_ep_non_dummy_optimization_matrix_manifest.jsonl"
         results_name = "moe_ep_non_dummy_optimization_matrix_results.jsonl"
-        default_output_root = Path(
-            "/data/ycfeng/tmp/frontier_non_dummy_optimization_matrix"
+        default_output_root = (
+            resolve_scratch_root() / "frontier_non_dummy_optimization_matrix"
         )
         cases = build_optimization_matrix(repo_root)
     else:
         manifest_name = "moe_ep_non_dummy_matrix_manifest.jsonl"
         results_name = "moe_ep_non_dummy_matrix_results.jsonl"
-        default_output_root = Path("/data/ycfeng/tmp/frontier_non_dummy_matrix")
+        default_output_root = resolve_scratch_root() / "frontier_non_dummy_matrix"
         cases = build_matrix(repo_root)
     manifest_path = task_dir / manifest_name
     pair_manifest_path = (

--- a/tests/e2e/pd_af_parity/harness.py
+++ b/tests/e2e/pd_af_parity/harness.py
@@ -15,6 +15,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
+from tests.e2e.pd_af_parity.reference_repo_root import resolve_reference_repo_root
+
 
 class ParityInputError(ValueError):
     """Raised when a parity input artifact is missing, ambiguous, or malformed."""
@@ -187,10 +189,8 @@ REFERENCE_FIRST_REAL_DECODE_LIFECYCLE_FILENAME = (
 REFERENCE_FIRST_REAL_DECODE_SCHEMA_VERSION = (
     "frontier.pdaf.reference-first-real-decode/v1"
 )
-REFERENCE_REPO_ROOT = Path(
-    "/data/ycfeng/stepfun-performance-optimization/Frontier/"
-    "worktrees/ref-afd-readonly"
-)
+# Resolved once at import so callers and tests can treat it as a stable pin.
+REFERENCE_REPO_ROOT = resolve_reference_repo_root()
 REFERENCE_GIT_HEAD = "dcb1cc8ee160a9c3c5412293d93b64042960aa4d"
 REFERENCE_REQUEST_SOURCE_SHA256 = (
     "4cff6da775a1b04ba4c252ccc679a3f2919ed5bfc98f1c039dff1519b9bc42b0"

--- a/tests/e2e/pd_af_parity/reference_observer_bootstrap.py
+++ b/tests/e2e/pd_af_parity/reference_observer_bootstrap.py
@@ -15,11 +15,14 @@ from pathlib import Path
 from types import ModuleType
 from typing import Sequence
 
-
-REFERENCE_REPO_ROOT = Path(
-    "/data/ycfeng/stepfun-performance-optimization/Frontier/"
-    "worktrees/ref-afd-readonly"
+from tests.e2e.pd_af_parity.reference_repo_root import (
+    REFERENCE_REPO_ROOT_ENV,
+    resolve_reference_repo_root,
 )
+
+
+# Resolved once at import so callers and tests can treat it as a stable pin.
+REFERENCE_REPO_ROOT = resolve_reference_repo_root()
 REFERENCE_GIT_HEAD = "dcb1cc8ee160a9c3c5412293d93b64042960aa4d"
 REFERENCE_SOURCE_IDENTITIES = {
     "request_source_sha256": (
@@ -95,7 +98,8 @@ def _require_reference_root(value: str | Path) -> Path:
     if root != expected:
         raise ReferenceObserverBootstrapError(
             "reference_repo_root must equal the pinned Reference repo root: "
-            f"expected={expected}, actual={root}"
+            f"expected={expected}, actual={root} "
+            f"(set {REFERENCE_REPO_ROOT_ENV} to relocate the pinned checkout)"
         )
     return root
 

--- a/tests/e2e/pd_af_parity/reference_observer_bootstrap.py
+++ b/tests/e2e/pd_af_parity/reference_observer_bootstrap.py
@@ -15,14 +15,35 @@ from pathlib import Path
 from types import ModuleType
 from typing import Sequence
 
-from tests.e2e.pd_af_parity.reference_repo_root import (
-    REFERENCE_REPO_ROOT_ENV,
-    resolve_reference_repo_root,
+
+# This bootstrap runs as a script under a Reference-only PYTHONPATH, so it must
+# stay stdlib-only and must not import the current repository's ``tests``
+# package. The two definitions below intentionally mirror
+# ``tests.e2e.pd_af_parity.reference_repo_root``; a unit test keeps them in sync.
+REFERENCE_REPO_ROOT_ENV = "FRONTIER_PDAF_REFERENCE_REPO_ROOT"
+FALLBACK_REFERENCE_REPO_ROOT = Path(
+    "/data/ycfeng/stepfun-performance-optimization/Frontier/"
+    "worktrees/ref-afd-readonly"
 )
 
 
+def _resolve_pinned_reference_repo_root() -> Path:
+    """Return the canonical pinned Reference root from the environment."""
+
+    configured_value = os.environ.get(REFERENCE_REPO_ROOT_ENV)
+    if configured_value is None:
+        return FALLBACK_REFERENCE_REPO_ROOT.resolve(strict=False)
+    reference_repo_root = Path(configured_value)
+    if not configured_value or not reference_repo_root.is_absolute():
+        raise ValueError(
+            f"{REFERENCE_REPO_ROOT_ENV} must be an absolute path, "
+            f"got {configured_value!r}"
+        )
+    return reference_repo_root.resolve(strict=False)
+
+
 # Resolved once at import so callers and tests can treat it as a stable pin.
-REFERENCE_REPO_ROOT = resolve_reference_repo_root()
+REFERENCE_REPO_ROOT = _resolve_pinned_reference_repo_root()
 REFERENCE_GIT_HEAD = "dcb1cc8ee160a9c3c5412293d93b64042960aa4d"
 REFERENCE_SOURCE_IDENTITIES = {
     "request_source_sha256": (

--- a/tests/e2e/pd_af_parity/reference_repo_root.py
+++ b/tests/e2e/pd_af_parity/reference_repo_root.py
@@ -1,0 +1,36 @@
+"""Resolve the pinned Reference repo root used by the PD-AF parity harness.
+
+The parity harness compares the current branch against a pinned, read-only
+Reference checkout whose git HEAD and source hashes are asserted at runtime.
+Historically the checkout location was hard-coded to a developer-specific
+path. Set ``FRONTIER_PDAF_REFERENCE_REPO_ROOT`` to an absolute path to relocate
+it; the historical path remains the fallback so existing deployments keep
+working. Only the location is configurable: the pinned identity checks are
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+REFERENCE_REPO_ROOT_ENV = "FRONTIER_PDAF_REFERENCE_REPO_ROOT"
+FALLBACK_REFERENCE_REPO_ROOT = Path(
+    "/data/ycfeng/stepfun-performance-optimization/Frontier/"
+    "worktrees/ref-afd-readonly"
+)
+
+
+def resolve_reference_repo_root() -> Path:
+    """Return the configured Reference repo root without touching the filesystem."""
+
+    configured_value = os.environ.get(REFERENCE_REPO_ROOT_ENV)
+    if configured_value is None:
+        return FALLBACK_REFERENCE_REPO_ROOT
+    reference_repo_root = Path(configured_value)
+    if not configured_value or not reference_repo_root.is_absolute():
+        raise ValueError(
+            f"{REFERENCE_REPO_ROOT_ENV} must be an absolute path, "
+            f"got {configured_value!r}"
+        )
+    return reference_repo_root

--- a/tests/e2e/pd_af_parity/reference_repo_root.py
+++ b/tests/e2e/pd_af_parity/reference_repo_root.py
@@ -7,6 +7,14 @@ path. Set ``FRONTIER_PDAF_REFERENCE_REPO_ROOT`` to an absolute path to relocate
 it; the historical path remains the fallback so existing deployments keep
 working. Only the location is configurable: the pinned identity checks are
 unchanged.
+
+The returned path is canonical (symlinks and ``..`` resolved) so that the
+sidecar written by the bootstrap, the integration driver, and the harness
+validator all compare the same string.
+
+``reference_observer_bootstrap.py`` deliberately carries its own copy of this
+logic because it runs under a Reference-only ``PYTHONPATH`` and cannot import
+this module; ``tests/unit/test_pdaf_reference_repo_root.py`` keeps them in sync.
 """
 
 from __future__ import annotations
@@ -22,15 +30,19 @@ FALLBACK_REFERENCE_REPO_ROOT = Path(
 
 
 def resolve_reference_repo_root() -> Path:
-    """Return the configured Reference repo root without touching the filesystem."""
+    """Return the canonical configured Reference repo root.
+
+    Uses ``resolve(strict=False)`` so a missing fallback path does not raise; the
+    callers that need existence still call ``resolve(strict=True)`` themselves.
+    """
 
     configured_value = os.environ.get(REFERENCE_REPO_ROOT_ENV)
     if configured_value is None:
-        return FALLBACK_REFERENCE_REPO_ROOT
+        return FALLBACK_REFERENCE_REPO_ROOT.resolve(strict=False)
     reference_repo_root = Path(configured_value)
     if not configured_value or not reference_repo_root.is_absolute():
         raise ValueError(
             f"{REFERENCE_REPO_ROOT_ENV} must be an absolute path, "
             f"got {configured_value!r}"
         )
-    return reference_repo_root
+    return reference_repo_root.resolve(strict=False)

--- a/tests/e2e/run_moe_ep_non_dummy_matrix.sh
+++ b/tests/e2e/run_moe_ep_non_dummy_matrix.sh
@@ -12,9 +12,15 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   exit 2
 fi
 
-exec "$PYTHON_BIN" "$REPO_ROOT/tests/e2e/moe_ep_non_dummy_matrix.py" \
-  --repo-root "$REPO_ROOT" \
-  --task-dir "$REPO_ROOT/task_memory/task_2026-08-12_moe_ep_rank_stragger_analysis" \
-  --output-root "${MATRIX_OUTPUT_ROOT:-/data/ycfeng/tmp/frontier_non_dummy_matrix}" \
-  --mode "${MATRIX_MODE:-run}" \
-  "$@"
+ARGS=(
+  --repo-root "$REPO_ROOT"
+  --task-dir "$REPO_ROOT/task_memory/task_2026-08-12_moe_ep_rank_stragger_analysis"
+)
+# Only forward --output-root when the caller set MATRIX_OUTPUT_ROOT explicitly.
+# Otherwise the Python entry point derives its default from FRONTIER_TMP_ROOT.
+if [ -n "${MATRIX_OUTPUT_ROOT:-}" ]; then
+  ARGS+=(--output-root "$MATRIX_OUTPUT_ROOT")
+fi
+ARGS+=(--mode "${MATRIX_MODE:-run}")
+
+exec "$PYTHON_BIN" "$REPO_ROOT/tests/e2e/moe_ep_non_dummy_matrix.py" "${ARGS[@]}" "$@"

--- a/tests/integration/test_pdaf_reference_lifecycle_observer.py
+++ b/tests/integration/test_pdaf_reference_lifecycle_observer.py
@@ -14,12 +14,10 @@ from typing import Mapping
 import pytest
 
 from tests.e2e.pd_af_parity import harness
+from tests.e2e.pd_af_parity.reference_repo_root import resolve_reference_repo_root
 
 
-REFERENCE_REPO_ROOT = Path(
-    "/data/ycfeng/stepfun-performance-optimization/Frontier/"
-    "worktrees/ref-afd-readonly"
-)
+REFERENCE_REPO_ROOT = resolve_reference_repo_root()
 REFERENCE_GIT_HEAD = "dcb1cc8ee160a9c3c5412293d93b64042960aa4d"
 PARITY_DIR = Path(__file__).parents[1] / "e2e" / "pd_af_parity"
 OBSERVER_SOURCE = PARITY_DIR / "reference_lifecycle_observer.py"

--- a/tests/performance/sim_walltime_scaling/sweep.py
+++ b/tests/performance/sim_walltime_scaling/sweep.py
@@ -32,13 +32,13 @@ from tests.performance.sim_walltime_scaling.run_case import (
     _runner_sha256,
     write_json_atomic,
 )
+from tests.scratch_root import SCRATCH_ROOT_ENV, resolve_scratch_root
 
 
 DEFAULT_SCALES = (32, 64, 128, 256, 512, 1024, 4096)
 DEFAULT_TIMEOUT_S = 14_400.0
 OUTPUT_TAIL_BYTES = 20_000
 TERMINATION_GRACE_S = 5.0
-DEFAULT_TEMP_ROOT = Path("/data/ycfeng/tmp")
 TEMP_ROOT_ENV = "FRONTIER_WALLTIME_TMPDIR"
 RUN_CASE_PATH = Path(__file__).with_name("run_case.py").resolve()
 DENSE_MASTER_WRAPPER = (
@@ -310,25 +310,33 @@ def _process_group_exists(process_group_id: int) -> bool:
     return True
 
 
+def _default_temp_root() -> Path:
+    """Return the scratch root that bounds every wall-time temp directory."""
+
+    return resolve_scratch_root()
+
+
 def _resolve_temp_root() -> Path:
+    default_temp_root = _default_temp_root()
     configured_value = os.environ.get(TEMP_ROOT_ENV)
     temp_root = (
         Path(configured_value)
         if configured_value is not None
-        else DEFAULT_TEMP_ROOT
+        else default_temp_root
     )
     if not temp_root.is_absolute():
         raise ValueError(
             f"{TEMP_ROOT_ENV} must be an absolute path, got {configured_value!r}"
         )
-    resolved_default_root = DEFAULT_TEMP_ROOT.resolve(strict=False)
+    resolved_default_root = default_temp_root.resolve(strict=False)
     resolved_temp_root = temp_root.resolve(strict=False)
     try:
         resolved_temp_root.relative_to(resolved_default_root)
     except ValueError as exc:
         raise ValueError(
             f"{TEMP_ROOT_ENV} must resolve to {resolved_default_root} or one of "
-            f"its descendants, got {resolved_temp_root}"
+            f"its descendants, got {resolved_temp_root} "
+            f"(set {SCRATCH_ROOT_ENV} to relocate the scratch root)"
         ) from exc
     temp_root = resolved_temp_root
     try:

--- a/tests/scratch_root.py
+++ b/tests/scratch_root.py
@@ -1,0 +1,36 @@
+"""Resolve the writable scratch root shared by Frontier's heavyweight test harnesses.
+
+The wall-time scaling sweep, the MoE-EP baseline replay, and the MoE-EP
+non-dummy matrix all write large intermediate outputs under one scratch root.
+Historically that root was hard-coded to a developer-specific path. Set
+``FRONTIER_TMP_ROOT`` to an absolute, writable directory to relocate it; the
+historical path remains the fallback so existing deployments keep working.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+SCRATCH_ROOT_ENV = "FRONTIER_TMP_ROOT"
+FALLBACK_SCRATCH_ROOT = Path("/data/ycfeng/tmp")
+
+
+def resolve_scratch_root() -> Path:
+    """Return the configured scratch root without touching the filesystem.
+
+    Reads ``FRONTIER_TMP_ROOT`` on every call so tests and callers that set the
+    variable after import are honored. Callers remain responsible for
+    resolving symlinks and creating the directory, matching their existing
+    behavior for the fallback path.
+    """
+
+    configured_value = os.environ.get(SCRATCH_ROOT_ENV)
+    if configured_value is None:
+        return FALLBACK_SCRATCH_ROOT
+    scratch_root = Path(configured_value)
+    if not configured_value or not scratch_root.is_absolute():
+        raise ValueError(
+            f"{SCRATCH_ROOT_ENV} must be an absolute path, got {configured_value!r}"
+        )
+    return scratch_root

--- a/tests/unit/test_moe_ep_baseline_replay.py
+++ b/tests/unit/test_moe_ep_baseline_replay.py
@@ -19,6 +19,15 @@ from tests.e2e.moe_ep_non_dummy_matrix import build_matrix, write_manifest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+@pytest.fixture(autouse=True)
+def _scratch_root_under_tmp_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Point the replay scratch root at pytest's tmp_path for every test."""
+
+    monkeypatch.setenv(baseline.SCRATCH_ROOT_ENV, str(tmp_path))
+
+
 def test_baseline_replay_harness_exists_under_e2e_tests() -> None:
     assert (REPO_ROOT / "tests/e2e/moe_ep_baseline_replay.py").is_file()
 
@@ -80,9 +89,9 @@ def test_baseline_command_uses_old_selector_and_baseline_only_pythonpath(
 
     assert env["PYTHONPATH"] == str(baseline_root.resolve())
     assert env["PYTHONDONTWRITEBYTECODE"] == "1"
-    assert env["TMPDIR"] == str(baseline.TMP_ROOT)
-    assert env["TEMP"] == str(baseline.TMP_ROOT)
-    assert env["TMP"] == str(baseline.TMP_ROOT)
+    assert env["TMPDIR"] == str(tmp_path)
+    assert env["TEMP"] == str(tmp_path)
+    assert env["TMP"] == str(tmp_path)
     assert env["ENABLE_DUMMY_MODE"] == "false"
     assert env["MOE_ROUTING_MODE"] == "uniform_random"
     assert env["MOE_ROUTING_DISTRIBUTION_TYPE"] == "random"

--- a/tests/unit/test_moe_ep_non_dummy_matrix.py
+++ b/tests/unit/test_moe_ep_non_dummy_matrix.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 import tests.e2e.moe_ep_non_dummy_matrix as matrix_module
+from tests.scratch_root import resolve_scratch_root
 import frontier.scheduler.cluster_scheduler.base_cluster_scheduler as cluster_scheduler_module
 from frontier.scheduler.cluster_scheduler.base_cluster_scheduler import BaseClusterScheduler
 from frontier.types import ClusterType
@@ -2981,8 +2982,8 @@ def test_preflight_cli_writes_independent_ledger_and_fails_closed(
     ):
         assert list(selected_cases) == cases
         assert repo_root == REPO_ROOT
-        assert output_root == Path(
-            "/data/ycfeng/tmp/frontier_non_dummy_optimization_matrix"
+        assert output_root == (
+            resolve_scratch_root() / "frontier_non_dummy_optimization_matrix"
         )
         assert matrix_kind == "optimization"
         return expected_rows

--- a/tests/unit/test_moe_ep_non_dummy_matrix.py
+++ b/tests/unit/test_moe_ep_non_dummy_matrix.py
@@ -5712,3 +5712,51 @@ def test_find_metrics_dir_rejects_stale_metrics(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError, match="fresh"):
         _find_metrics_dir(tmp_path, case, started_at_ns=metrics_path.stat().st_mtime_ns + 1)
+
+
+def test_python_entry_point_defaults_output_root_from_frontier_tmp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting --output-root, as run_moe_ep_non_dummy_matrix.sh now does, lands under FRONTIER_TMP_ROOT."""
+
+    scratch = tmp_path / "scratch"
+    monkeypatch.setenv("FRONTIER_TMP_ROOT", str(scratch))
+    cases = matrix_module.build_matrix(REPO_ROOT)[:1]
+    observed: dict[str, Path] = {}
+
+    def fake_preflight_cases(selected_cases, repo_root, output_root, *, matrix_kind):
+        observed["output_root"] = output_root
+        assert matrix_kind == "regression"
+        return [
+            {
+                "case_id": case.case_id,
+                "status": "READY",
+                "blockers": [],
+                "preflight_only": True,
+            }
+            for case in selected_cases
+        ]
+
+    def fail_if_run(*_args, **_kwargs):
+        raise AssertionError("preflight must not launch simulator cases")
+
+    monkeypatch.setattr(matrix_module, "build_matrix", lambda _repo_root: cases)
+    monkeypatch.setattr(matrix_module, "preflight_cases", fake_preflight_cases)
+    monkeypatch.setattr(matrix_module, "run_cases", fail_if_run)
+
+    exit_code = matrix_module.main(
+        [
+            "--mode",
+            "preflight",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--task-dir",
+            str(tmp_path / "task"),
+            "--preflight-path",
+            str(tmp_path / "preflight.jsonl"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert observed["output_root"] == scratch / "frontier_non_dummy_matrix"

--- a/tests/unit/test_pdaf_parity_harness_wave1.py
+++ b/tests/unit/test_pdaf_parity_harness_wave1.py
@@ -80,10 +80,7 @@ def _write_reference_lifecycle(
         "schema_version": "frontier.pdaf.reference-first-real-decode/v1",
         "producer": {
             "branch_kind": "reference",
-            "reference_repo_root": (
-                "/data/ycfeng/stepfun-performance-optimization/Frontier/"
-                "worktrees/ref-afd-readonly"
-            ),
+            "reference_repo_root": str(harness.REFERENCE_REPO_ROOT),
             "reference_git_head": (
                 "dcb1cc8ee160a9c3c5412293d93b64042960aa4d"
             ),

--- a/tests/unit/test_pdaf_reference_repo_root.py
+++ b/tests/unit/test_pdaf_reference_repo_root.py
@@ -1,0 +1,58 @@
+"""Contract tests for the FRONTIER_PDAF_REFERENCE_REPO_ROOT override."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.pd_af_parity.reference_repo_root import (
+    FALLBACK_REFERENCE_REPO_ROOT,
+    REFERENCE_REPO_ROOT_ENV,
+    resolve_reference_repo_root,
+)
+
+
+def test_env_name_and_fallback_are_stable() -> None:
+    assert REFERENCE_REPO_ROOT_ENV == "FRONTIER_PDAF_REFERENCE_REPO_ROOT"
+    assert FALLBACK_REFERENCE_REPO_ROOT == Path(
+        "/data/ycfeng/stepfun-performance-optimization/Frontier/"
+        "worktrees/ref-afd-readonly"
+    )
+
+
+def test_unset_variable_returns_historical_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(REFERENCE_REPO_ROOT_ENV, raising=False)
+
+    assert resolve_reference_repo_root() == FALLBACK_REFERENCE_REPO_ROOT
+
+
+def test_absolute_override_is_returned_without_filesystem_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured = tmp_path / "ref-afd-readonly"
+    monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, str(configured))
+
+    assert resolve_reference_repo_root() == configured
+    assert not configured.exists()
+
+
+@pytest.mark.parametrize("configured_value", ["relative/path", "", "."])
+def test_non_absolute_override_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_value: str,
+) -> None:
+    monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, configured_value)
+
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_reference_repo_root()
+
+
+def test_harness_and_bootstrap_share_the_resolved_root() -> None:
+    from tests.e2e.pd_af_parity import harness, reference_observer_bootstrap
+
+    assert harness.REFERENCE_REPO_ROOT == reference_observer_bootstrap.REFERENCE_REPO_ROOT
+    assert harness.REFERENCE_REPO_ROOT.is_absolute()

--- a/tests/unit/test_pdaf_reference_repo_root.py
+++ b/tests/unit/test_pdaf_reference_repo_root.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import ast
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from tests.e2e.pd_af_parity import harness, reference_observer_bootstrap
 from tests.e2e.pd_af_parity.reference_repo_root import (
     FALLBACK_REFERENCE_REPO_ROOT,
     REFERENCE_REPO_ROOT_ENV,
     resolve_reference_repo_root,
 )
+
+
+BOOTSTRAP_SOURCE = Path(reference_observer_bootstrap.__file__).resolve(strict=True)
 
 
 def test_env_name_and_fallback_are_stable() -> None:
@@ -21,22 +29,24 @@ def test_env_name_and_fallback_are_stable() -> None:
     )
 
 
-def test_unset_variable_returns_historical_fallback(
+def test_unset_variable_returns_canonical_historical_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(REFERENCE_REPO_ROOT_ENV, raising=False)
 
-    assert resolve_reference_repo_root() == FALLBACK_REFERENCE_REPO_ROOT
+    assert resolve_reference_repo_root() == FALLBACK_REFERENCE_REPO_ROOT.resolve(
+        strict=False
+    )
 
 
-def test_absolute_override_is_returned_without_filesystem_access(
+def test_absolute_override_to_missing_path_does_not_require_existence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     configured = tmp_path / "ref-afd-readonly"
     monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, str(configured))
 
-    assert resolve_reference_repo_root() == configured
+    assert resolve_reference_repo_root() == configured.resolve(strict=False)
     assert not configured.exists()
 
 
@@ -51,8 +61,190 @@ def test_non_absolute_override_is_rejected(
         resolve_reference_repo_root()
 
 
-def test_harness_and_bootstrap_share_the_resolved_root() -> None:
-    from tests.e2e.pd_af_parity import harness, reference_observer_bootstrap
+def test_override_containing_parent_segments_is_canonicalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_root = tmp_path / "worktrees" / "ref-afd-readonly"
+    real_root.mkdir(parents=True)
+    dotted = tmp_path / "worktrees" / "other" / ".." / "ref-afd-readonly"
+    monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, str(dotted))
 
+    resolved = resolve_reference_repo_root()
+
+    assert resolved == real_root.resolve(strict=True)
+    assert ".." not in resolved.parts
+
+
+def test_override_through_symlink_is_canonicalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_root = tmp_path / "real" / "ref-afd-readonly"
+    real_root.mkdir(parents=True)
+    link = tmp_path / "link"
+    link.symlink_to(real_root, target_is_directory=True)
+    monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, str(link))
+
+    assert resolve_reference_repo_root() == real_root.resolve(strict=True)
+
+
+def test_sidecar_root_equals_harness_validation_root_under_symlink_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bootstrap writes ``str(_require_reference_root(...))`` into the sidecar
+    and the harness compares it against ``str(REFERENCE_REPO_ROOT)``. Both must
+    agree even when the configured path goes through a symlink and ``..``."""
+
+    real_root = tmp_path / "real" / "ref-afd-readonly"
+    (real_root / "sub").mkdir(parents=True)
+    link = tmp_path / "link"
+    link.symlink_to(real_root, target_is_directory=True)
+    configured = link / "sub" / ".."
+    monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, str(configured))
+
+    harness_root = resolve_reference_repo_root()
+    monkeypatch.setattr(
+        reference_observer_bootstrap, "REFERENCE_REPO_ROOT", harness_root
+    )
+
+    sidecar_root = reference_observer_bootstrap._require_reference_root(str(link))
+
+    assert str(sidecar_root) == str(harness_root)
+    assert str(sidecar_root) == str(real_root.resolve(strict=True))
+
+
+def test_harness_and_bootstrap_share_the_resolved_root() -> None:
     assert harness.REFERENCE_REPO_ROOT == reference_observer_bootstrap.REFERENCE_REPO_ROOT
     assert harness.REFERENCE_REPO_ROOT.is_absolute()
+
+
+def test_bootstrap_resolver_mirrors_shared_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bootstrap carries its own copy of the resolver; keep them in lockstep."""
+
+    assert (
+        reference_observer_bootstrap.REFERENCE_REPO_ROOT_ENV
+        == REFERENCE_REPO_ROOT_ENV
+    )
+    assert (
+        reference_observer_bootstrap.FALLBACK_REFERENCE_REPO_ROOT
+        == FALLBACK_REFERENCE_REPO_ROOT
+    )
+
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real_root, target_is_directory=True)
+
+    for configured in (None, str(link), str(tmp_path / "x" / ".." / "real")):
+        if configured is None:
+            monkeypatch.delenv(REFERENCE_REPO_ROOT_ENV, raising=False)
+        else:
+            monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, configured)
+        assert (
+            reference_observer_bootstrap._resolve_pinned_reference_repo_root()
+            == resolve_reference_repo_root()
+        ), configured
+
+    for bad in ("relative", ""):
+        monkeypatch.setenv(REFERENCE_REPO_ROOT_ENV, bad)
+        with pytest.raises(ValueError, match="absolute"):
+            reference_observer_bootstrap._resolve_pinned_reference_repo_root()
+
+
+def test_bootstrap_imports_only_the_standard_library() -> None:
+    """The bootstrap runs under a Reference-only PYTHONPATH; importing the
+    current repository's ``tests`` package would fail before argument parsing."""
+
+    tree = ast.parse(BOOTSTRAP_SOURCE.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+
+    stdlib = set(sys.stdlib_module_names)
+    non_stdlib = sorted(name for name in imported if name not in stdlib)
+    assert non_stdlib == [], non_stdlib
+
+
+def test_bootstrap_reaches_argument_parsing_under_reference_only_pythonpath(
+    tmp_path: Path,
+) -> None:
+    """Mirror the integration test launch: script by absolute path, cwd and
+    PYTHONPATH pointing at a tree that does not contain this repository."""
+
+    fake_reference = tmp_path / "ref-afd-readonly"
+    fake_reference.mkdir()
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(fake_reference)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment.pop(REFERENCE_REPO_ROOT_ENV, None)
+
+    completed = subprocess.run(
+        [sys.executable, "-B", str(BOOTSTRAP_SOURCE)],
+        cwd=fake_reference,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    # No arguments: the bootstrap's own argument parser must be the thing that
+    # rejects the invocation, which proves module import succeeded.
+    assert completed.returncode == 2, completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr
+    assert "Traceback" not in completed.stderr
+    assert "--reference-repo-root" in completed.stderr
+    assert "exactly one -- delimiter is required" in completed.stderr
+
+
+def test_bootstrap_honors_override_under_reference_only_pythonpath(
+    tmp_path: Path,
+) -> None:
+    """With the override set, a mismatching --reference-repo-root must be
+    rejected by the bootstrap's own check, proving the env read happened."""
+
+    pinned = tmp_path / "pinned"
+    pinned.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(pinned)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment[REFERENCE_REPO_ROOT_ENV] = str(pinned)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            str(BOOTSTRAP_SOURCE),
+            "--reference-repo-root",
+            str(other),
+            "--sidecar-path",
+            str(tmp_path / "sidecar.json"),
+            "--expected-request-count",
+            "1",
+            "--",
+            "--simulation_mode",
+            "offline",
+        ],
+        cwd=pinned,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "ModuleNotFoundError" not in completed.stderr
+    assert "must equal the pinned Reference repo root" in completed.stderr
+    assert str(pinned.resolve()) in completed.stderr
+    assert REFERENCE_REPO_ROOT_ENV in completed.stderr

--- a/tests/unit/test_run_moe_ep_non_dummy_matrix_wrapper.py
+++ b/tests/unit/test_run_moe_ep_non_dummy_matrix_wrapper.py
@@ -1,0 +1,64 @@
+"""Contract tests for the MoE-EP non-dummy matrix shell wrapper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "tests" / "e2e" / "run_moe_ep_non_dummy_matrix.sh"
+
+
+def _run_wrapper(tmp_path: Path, extra_env: dict[str, str]) -> list[str]:
+    """Run the wrapper with a stub interpreter that echoes its arguments."""
+
+    stub = tmp_path / "stub-python"
+    stub.write_text('#!/bin/bash\nprintf "%s\\n" "$@"\n', encoding="utf-8")
+    stub.chmod(0o755)
+
+    environment = os.environ.copy()
+    for key in ("MATRIX_OUTPUT_ROOT", "MATRIX_MODE", "FRONTIER_TMP_ROOT"):
+        environment.pop(key, None)
+    environment["PYTHON_BIN"] = str(stub)
+    environment.update(extra_env)
+
+    completed = subprocess.run(
+        ["bash", str(WRAPPER), "--continue-on-failure"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return completed.stdout.splitlines()
+
+
+def test_wrapper_passes_bash_syntax_check() -> None:
+    subprocess.run(["bash", "-n", str(WRAPPER)], check=True, timeout=30)
+
+
+def test_wrapper_defers_output_root_to_python_when_matrix_output_root_unset(
+    tmp_path: Path,
+) -> None:
+    argv = _run_wrapper(tmp_path, {"FRONTIER_TMP_ROOT": str(tmp_path / "scratch")})
+
+    assert argv[0] == str(REPO_ROOT / "tests" / "e2e" / "moe_ep_non_dummy_matrix.py")
+    assert "--output-root" not in argv
+    assert "/data/ycfeng" not in " ".join(argv)
+    assert argv[argv.index("--repo-root") + 1] == str(REPO_ROOT)
+    assert argv[argv.index("--mode") + 1] == "run"
+    assert argv[-1] == "--continue-on-failure"
+
+
+def test_wrapper_preserves_explicit_matrix_output_root(tmp_path: Path) -> None:
+    explicit = tmp_path / "explicit-output"
+
+    argv = _run_wrapper(
+        tmp_path,
+        {"MATRIX_OUTPUT_ROOT": str(explicit), "MATRIX_MODE": "preflight"},
+    )
+
+    assert argv[argv.index("--output-root") + 1] == str(explicit)
+    assert argv[argv.index("--mode") + 1] == "preflight"
+    assert argv[-1] == "--continue-on-failure"

--- a/tests/unit/test_run_moe_ep_non_dummy_matrix_wrapper.py
+++ b/tests/unit/test_run_moe_ep_non_dummy_matrix_wrapper.py
@@ -45,7 +45,7 @@ def test_wrapper_defers_output_root_to_python_when_matrix_output_root_unset(
 
     assert argv[0] == str(REPO_ROOT / "tests" / "e2e" / "moe_ep_non_dummy_matrix.py")
     assert "--output-root" not in argv
-    assert "/data/ycfeng" not in " ".join(argv)
+    assert "/data/ycfeng/tmp/frontier_non_dummy_matrix" not in " ".join(argv)
     assert argv[argv.index("--repo-root") + 1] == str(REPO_ROOT)
     assert argv[argv.index("--mode") + 1] == "run"
     assert argv[-1] == "--continue-on-failure"

--- a/tests/unit/test_scratch_root.py
+++ b/tests/unit/test_scratch_root.py
@@ -1,0 +1,59 @@
+"""Contract tests for the shared FRONTIER_TMP_ROOT scratch-root override."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.scratch_root import (
+    FALLBACK_SCRATCH_ROOT,
+    SCRATCH_ROOT_ENV,
+    resolve_scratch_root,
+)
+
+
+def test_env_name_and_fallback_are_stable() -> None:
+    assert SCRATCH_ROOT_ENV == "FRONTIER_TMP_ROOT"
+    assert FALLBACK_SCRATCH_ROOT == Path("/data/ycfeng/tmp")
+
+
+def test_unset_variable_returns_historical_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(SCRATCH_ROOT_ENV, raising=False)
+
+    assert resolve_scratch_root() == FALLBACK_SCRATCH_ROOT
+
+
+def test_absolute_override_is_returned_without_filesystem_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured = tmp_path / "does-not-exist-yet"
+    monkeypatch.setenv(SCRATCH_ROOT_ENV, str(configured))
+
+    assert resolve_scratch_root() == configured
+    assert not configured.exists()
+
+
+def test_override_is_reread_on_every_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SCRATCH_ROOT_ENV, str(tmp_path / "first"))
+    assert resolve_scratch_root() == tmp_path / "first"
+
+    monkeypatch.setenv(SCRATCH_ROOT_ENV, str(tmp_path / "second"))
+    assert resolve_scratch_root() == tmp_path / "second"
+
+
+@pytest.mark.parametrize("configured_value", ["relative/path", "", "."])
+def test_non_absolute_override_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_value: str,
+) -> None:
+    monkeypatch.setenv(SCRATCH_ROOT_ENV, configured_value)
+
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_scratch_root()

--- a/tests/unit/test_sim_walltime_scaling_sweep.py
+++ b/tests/unit/test_sim_walltime_scaling_sweep.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -21,6 +22,15 @@ from tests.performance.sim_walltime_scaling.run_case import (
 
 
 SWEEP_MODULE = "tests.performance.sim_walltime_scaling.sweep"
+
+
+@pytest.fixture(autouse=True)
+def scratch_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Relocate the scratch root so child temp files never touch a developer path."""
+
+    root = tmp_path / "scratch-root"
+    monkeypatch.setenv("FRONTIER_TMP_ROOT", str(root))
+    return root
 
 
 def _load_sweep() -> Any:
@@ -593,6 +603,7 @@ def test_execute_child_records_only_bounded_output_tails() -> None:
 def test_execute_child_uses_explicit_default_temp_root_and_ignores_tmpdir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    scratch_root: Path,
 ) -> None:
     sweep = _load_sweep()
     real_temporary_file = sweep.tempfile.TemporaryFile
@@ -612,15 +623,26 @@ def test_execute_child_uses_explicit_default_temp_root_and_ignores_tmpdir(
     outcome = sweep._execute_child([sys.executable, "-c", "pass"], 5.0)
 
     assert outcome.returncode == 0
-    assert observed_dirs == [Path("/data/ycfeng/tmp")] * 2
+    assert scratch_root.is_dir()
+    assert observed_dirs == [scratch_root.resolve()] * 2
 
 
-def test_execute_child_creates_and_uses_task_specific_temp_root_override(
-    tmp_path: Path,
+def test_execute_child_falls_back_to_historical_scratch_root_when_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sweep = _load_sweep()
-    configured_root = tmp_path / "explicit" / "walltime-temp"
+    monkeypatch.delenv("FRONTIER_TMP_ROOT", raising=False)
+    monkeypatch.delenv("FRONTIER_WALLTIME_TMPDIR", raising=False)
+
+    assert sweep._default_temp_root() == Path("/data/ycfeng/tmp")
+
+
+def test_execute_child_creates_and_uses_task_specific_temp_root_override(
+    monkeypatch: pytest.MonkeyPatch,
+    scratch_root: Path,
+) -> None:
+    sweep = _load_sweep()
+    configured_root = scratch_root / "explicit" / "walltime-temp"
     real_temporary_file = sweep.tempfile.TemporaryFile
     observed_dirs: list[Path | None] = []
 
@@ -654,11 +676,12 @@ def test_execute_child_rejects_non_absolute_temp_root(
 
 
 def test_execute_child_rejects_temp_root_that_is_not_a_directory(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    scratch_root: Path,
 ) -> None:
     sweep = _load_sweep()
-    configured_file = tmp_path / "not-a-directory"
+    scratch_root.mkdir(parents=True)
+    configured_file = scratch_root / "not-a-directory"
     configured_file.write_text("occupied")
     monkeypatch.setenv("FRONTIER_WALLTIME_TMPDIR", str(configured_file))
 
@@ -668,24 +691,26 @@ def test_execute_child_rejects_temp_root_that_is_not_a_directory(
 
 def test_temp_root_override_rejects_absolute_path_outside_default_root(
     monkeypatch: pytest.MonkeyPatch,
+    scratch_root: Path,
 ) -> None:
     sweep = _load_sweep()
     monkeypatch.setenv("FRONTIER_WALLTIME_TMPDIR", "/tmp")
 
-    with pytest.raises(ValueError, match="/data/ycfeng/tmp"):
+    with pytest.raises(ValueError, match=re.escape(str(scratch_root.resolve()))):
         sweep._resolve_temp_root()
 
 
 def test_temp_root_override_rejects_symlink_escape_from_default_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    scratch_root: Path,
 ) -> None:
     sweep = _load_sweep()
     escape_link = tmp_path / "escape-to-system-tmp"
     escape_link.symlink_to("/tmp", target_is_directory=True)
     monkeypatch.setenv("FRONTIER_WALLTIME_TMPDIR", str(escape_link))
 
-    with pytest.raises(ValueError, match="/data/ycfeng/tmp"):
+    with pytest.raises(ValueError, match=re.escape(str(scratch_root.resolve()))):
         sweep._resolve_temp_root()
 
 


### PR DESCRIPTION
## Problem

Several test harnesses hard-code paths that only exist on the original author's machine, so on a fresh clone they cannot run and their unit tests fail before exercising any logic.

**Scratch root** `/data/ycfeng/tmp`, used for large intermediate outputs by:

- `tests/performance/sim_walltime_scaling/sweep.py` (`DEFAULT_TEMP_ROOT`, which also bounds `FRONTIER_WALLTIME_TMPDIR`)
- `tests/e2e/moe_ep_baseline_replay.py` (`TMP_ROOT`, used for path validation, child `TMPDIR`, and CLI defaults)
- `tests/e2e/moe_ep_non_dummy_matrix.py` (default `--output-root` for both matrix kinds)

**Pinned Reference checkout** `/data/ycfeng/stepfun-performance-optimization/Frontier/worktrees/ref-afd-readonly`, used by the PD-AF parity harness (`tests/e2e/pd_af_parity/harness.py`, `reference_observer_bootstrap.py`) and `tests/integration/test_pdaf_reference_lifecycle_observer.py`.

## Change

Two commits, one per path family. Both keep the historical path as the fallback when the variable is unset, so existing deployments are unchanged.

**`FRONTIER_TMP_ROOT`** (commit 1)

- Add `tests/scratch_root.py` with `resolve_scratch_root()`. The value must be absolute and is re-read on every call.
- The three harness modules resolve their root through it. `FRONTIER_WALLTIME_TMPDIR` keeps its semantics and must still resolve to a descendant of the (now relocatable) root. Rejection messages point at `FRONTIER_TMP_ROOT` as the remedy.
- Unit tests for the two affected harnesses point the root at pytest's `tmp_path` via an autouse fixture. New `tests/unit/test_scratch_root.py` covers the helper.

**`FRONTIER_PDAF_REFERENCE_REPO_ROOT`** (commit 2)

- Add `tests/e2e/pd_af_parity/reference_repo_root.py` with `resolve_reference_repo_root()`.
- `harness.py`, `reference_observer_bootstrap.py`, and the integration test resolve `REFERENCE_REPO_ROOT` through it once at import, so the many call sites that treat it as a stable pin keep working. Only the location is configurable; the pinned git HEAD and source SHA-256 checks are unchanged. The bootstrap's mismatch error names the variable.
- `test_pdaf_parity_harness_wave1.py` builds its producer payload from the resolved root instead of a literal. New `tests/unit/test_pdaf_reference_repo_root.py` covers the helper.

`AGENTS.md` documents both variables under **Tests** and gets a Modification History row.

## Verification

Fresh clone on a machine without `/data/ycfeng` (`environment.yml` + `pip install -e ".[test]"`, plus torch/matplotlib), running `tests/unit tests/integration`:

| Scope | Before | After |
|---|---|---|
| `test_sim_walltime_scaling_sweep.py` + `test_moe_ep_baseline_replay.py` | 13 failed, 96 passed | 0 failed, 110 passed |
| Overall | 87 failed, 6 errors | 74 failed, 6 errors |

With `FRONTIER_PDAF_REFERENCE_REPO_ROOT` pointed at an existing plain directory, 17 of the 51 bootstrap unit tests additionally pass; the remaining 34 (and the 5 integration errors) need a real checkout at the pinned commit `dcb1cc8e`, which is not in this repository's public history, so they cannot pass anywhere without that private worktree. That is inherent to the identity checks and unchanged by this PR.

Other remaining failures pre-exist on `main` and are unrelated: docs-contract tests referencing a missing `tests/debug` fixture directory, and a few tests needing the profiling env.

Also verified manually: with `FRONTIER_TMP_ROOT` set, `sweep._resolve_temp_root()` returns the override and rejects `FRONTIER_WALLTIME_TMPDIR=/tmp`; with both variables unset, both helpers return their historical paths.

## Out of scope

The `/local/ycfeng/...` interpreter defaults in the GPU profiling shell scripts under `tests/analysis`, `tests/e2e/operator_parity`, and `tests/performance` are not touched here.
