### PR TITLE
Add MI355X hybrid GDN profiling and SGLang correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ conda activate frontier-profiling
 
 Do not blindly install profiling dependencies into an existing environment unless you have confirmed version compatibility.
 
+AMD Instinct MI355X (`gfx950`) profiling is supported through the pinned ROCm
+workflow in [docs/profiling/ROCM_MI355X.md](docs/profiling/ROCM_MI355X.md).
+
 Production Docker users can start from the public image:
 
 ```bash

--- a/data/config/device/mi355x.json
+++ b/data/config/device/mi355x.json
@@ -1,0 +1,10 @@
+{
+  "device": "mi355x",
+  "fp16_tflops": 2516,
+  "total_memory_gb": 288,
+  "source_urls": [
+    "https://www.amd.com/en/products/accelerators/instinct/mi350/mi355x.html",
+    "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/product-briefs/amd-instinct-mi355x-gpu-brochure.pdf"
+  ],
+  "notes": "Dense FP16/BF16 matrix throughput and HBM3E capacity for one AMD Instinct MI355X OAM accelerator (gfx950)."
+}

--- a/data/config/models/Qwen3.8-2.4T-A95B-Quark-MXFP4.json
+++ b/data/config/models/Qwen3.8-2.4T-A95B-Quark-MXFP4.json
@@ -1,0 +1,56 @@
+{
+  "architectures": [
+    "Qwen3_5MoeForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "attn_output_gate": true,
+  "dtype": "bfloat16",
+  "full_attention_interval": 4,
+  "head_dim": 256,
+  "hidden_act": "silu",
+  "hidden_size": 8192,
+  "linear_conv_kernel_dim": 4,
+  "linear_key_head_dim": 128,
+  "linear_num_key_heads": 16,
+  "linear_num_value_heads": 128,
+  "linear_value_head_dim": 128,
+  "max_position_embeddings": 262144,
+  "model_type": "qwen3_5_moe_text",
+  "moe_intermediate_size": 2048,
+  "mtp_num_hidden_layers": 1,
+  "num_attention_heads": 64,
+  "num_experts": 512,
+  "num_experts_per_tok": 10,
+  "num_hidden_layers": 92,
+  "num_key_value_heads": 4,
+  "partial_rotary_factor": 0.25,
+  "quantization_config": {
+    "frontier_quantized_operations": [
+      "moe_grouped_gemm"
+    ],
+    "global_quant_config": {
+      "input_tensors": {
+        "dtype": "fp4",
+        "group_size": 32,
+        "is_dynamic": true,
+        "scale_format": "e8m0"
+      },
+      "weight": {
+        "dtype": "fp4",
+        "group_size": 32,
+        "is_dynamic": false,
+        "scale_format": "e8m0"
+      }
+    },
+    "quant_method": "quark"
+  },
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 10000000,
+  "shared_expert_intermediate_size": 2048,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "use_qk_norm": true,
+  "vocab_size": 248320
+}

--- a/docs/profiling/MI355X_CORRELATION.md
+++ b/docs/profiling/MI355X_CORRELATION.md
@@ -1,0 +1,770 @@
+# MI355X capture and Frontier correlation
+
+The initial validation target is one SGLang replica using TP=8, EP=1, PP=1
+across an eight-GPU MI355X node. `frontier.validation` captures actual batch
+metadata and replays it through the existing Frontier predictor without asking
+a scheduler to reconstruct the runtime's decisions. The existing `sglang`
+scheduler remains available for subsequent serving-level experiments.
+
+## Capture
+
+Run inside the pinned SGLang environment with this Frontier checkout on
+`PYTHONPATH`. The adapter uses `sglang.benchmark.one_batch`'s checkpoint loader,
+allocation, extend and decode helpers; it requires the CPU length metadata and
+`ModelRunnerOutput.can_run_graph` contract present in the tested runtime.
+
+Choose an experiment directory outside the source checkout. Every invocation
+requires a new output directory. Workers write separate rank ledgers; the
+parent validates and merges them only after every worker succeeds.
+
+```bash
+export SGLANG_USE_AITER=1
+python -m frontier.validation.sglang_capture \
+  --model-path /models/amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --tp-size 8 --attention-backend aiter --page-size 1 \
+  --random-seed 1234 \
+  --chunked-prefill-size 16384 --mem-fraction-static 0.9 \
+  --disable-radix-cache \
+  --cuda-graph-backend-decode full --cuda-graph-backend-prefill disabled \
+  --cuda-graph-bs-decode 1 2 4 8 12 16 24 32 \
+  --batch-size 16 24 32 --input-len 1024 --output-len 32 \
+  --capture-warmups 2 --repetitions 10 --trace --trace-steps 3 \
+  --output-dir /experiments/mi355x/capture-001
+```
+
+The static runner executes each complete prefill in one call. The server's
+chunk budget is recorded but does **not** split these offline batches; for
+example batch 32 x 1024 is a 32768-token prefill. This is intentional for the
+initial operator/batch calibration. Serving/chunked-prefill correlation needs
+actual scheduler batches and is not established by this benchmark.
+
+Normal repetitions are timed without Kineto. `--trace` adds a separate pass
+with synchronized `frontier.batch:<id>` markers and exports rank 0 by default.
+Use `--trace-ranks 0 1 2 3 4 5 6 7` when all-rank kernel diagnostics are needed.
+The profiler pass is excluded from timing statistics.
+
+The manifest records model path, runtime versions, source digest, topology,
+launch settings and timing semantics. Per-rank files record graph capture
+sizes, GPU memory, token capacity and request-pool capacity. Seeded inputs and
+finite-logit checks are shared across ranks. Output hashes must agree across
+TP ranks. Differences between repeated greedy outputs are recorded explicitly:
+they can change expert routing and must be considered when interpreting timing
+variation. No prompt or output text is stored in the batch ledger.
+
+Pin SGLang's `--random-seed` whenever separate captures will share runtime
+profiles. Its generated default changes between launches and is part of the
+runtime identity. A matching seed still does not guarantee that free-running
+decode produces the same token trajectory or expert routes; compare the frozen
+trajectory digest and routing records rather than assuming reproducibility.
+
+Inspect the resolved server settings in the manifest: the pinned SGLang AITER
+path multiplies the requested memory fraction by 0.85 for model context limits
+above 8192. A requested 0.9 therefore resolves to 0.765. Static pool capacity
+with prefix caching disabled is not the same as the earlier serving request
+limit; the runtime pool and memory records are authoritative for this capture.
+
+`forward_gpu_ms` uses GPU events around model forward and excludes sampling.
+`step_wall_ms` includes input preparation, forward and sampling through device
+synchronization. TP aggregation takes the maximum elapsed duration across
+ranks; it does not sum rank times or assume synchronized host clock origins.
+These metrics are distinct from serving TTFT and TPOT.
+
+```bash
+python -m frontier.validation.report \
+  --capture-dir /experiments/mi355x/capture-001 \
+  --output /experiments/mi355x/capture-001/timing-summary.json
+```
+
+The report excludes the first four decode steps, takes a median within each
+repetition and reports the median and coefficient of variation across repeats.
+It also compares every profiled batch against unprofiled repetitions of the
+**same step and exact shape**, taking the maximum rank duration in both cases.
+The default diagnostic threshold is 5% absolute change, including unexpectedly
+faster samples. Do not calibrate full-model latency from materially perturbed
+profiles or subtract a global correction factor from operator times. Passing
+this check alone does not establish unbiased individual kernel measurements.
+
+## Complete decoder trace decomposition
+
+The explicit `sglang_qwen35_rocm_separate_shared_v1` contract supports one-node
+TP=8/EP=1 with separate shared experts, unfused AITER TP reductions and one GPU
+stream. It partitions every decoder kernel exactly once against the model-owned
+hybrid layer schedule. Unknown operators, missing boundaries, extra layers or
+multi-stream traces fail admission. Small timestamp overlaps on the identified
+stream remain visible as overlap time; kernel sums are not replaced by spans.
+
+```bash
+python -m frontier.validation.operator_trace \
+  --capture-dir /experiments/mi355x/capture-001 \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --rank 0 \
+  --output /experiments/mi355x/decoder-components.json
+```
+
+The output retains batch/rank/layer identity, kernel index ranges, component
+sums, decoder span/busy time, source hashes and the profile-perturbation check.
+Fusions stay intact: QKV projection includes QK norm; attention output projection
+includes its gate; MXFP4 expert computation includes activation quantization and
+combine; shared gate/sigmoid/multiply/add is a separate fused component.
+Sorting is distinct from expert GEMMs. These runtime components are not all
+one-to-one matches for Frontier's existing operator families.
+
+This is a **kernel-only diagnostic dataset**, not a native CSV export. Eager
+traces must not be relabeled as CUDA-event profiles. Reduction samples include
+rank-arrival skew and are not isolated bandwidth measurements. Work outside the
+decoder includes preparation, embedding, final norm, logits and sampling; it
+is not a measured full-forward residual. Expert-routing vectors are not yet
+captured, so these samples do not establish EP or multi-node scaling.
+
+## Separate eager operator events
+
+Add `--operator-event-layers 0 3 --operator-event-repetitions 5` to the capture
+command to measure representative GDN and full-attention layers on the real
+loaded checkpoint. After the normal baseline and optional trace pass for each
+shape, the adapter temporarily wraps selected model call boundaries and runs
+separate eager-prefill-only passes **without Kineto**. Existing decode graphs
+and model tensors are unchanged, and callables are restored afterwards.
+
+`operator-batches.jsonl` contains the separate timed TP cohorts;
+`operator-events-rankN.jsonl` contains nested scope IDs, parent IDs and inclusive
+GPU-event milliseconds. Parent and child durations must not be added together.
+Scopes include decoder layers, GDN/attention, normalization, shared experts,
+router/top-k, routed experts and attention/MoE boundaries containing reductions.
+The files are diagnostic inputs pending mapping/coverage checks, not automatic
+native profile replacements. Compare these passes against matching baseline
+prefills with `summarize_profile_perturbation` before calibration.
+
+The eager observer deliberately does not time operators inside existing decode
+graphs. The tested ROCm PyTorch runtime rejects its `external=True` timing events
+during HIP capture. GPU-only Kineto also removes the CPU batch markers and does
+not eliminate graph-tracing perturbation. The separate HIP-node path below
+avoids these two mechanisms; neither observer silently falls back to eager decode.
+Shared/cached module objects are attributed through their active decoder scope,
+and every selected scope must execute exactly once in each measured prefill.
+These selected-layer samples do not establish coverage of all expert routing
+distributions or first-layer versus later-layer initialization costs.
+
+## Separate full-decode HIP graph events
+
+Add `--graph-event-layers 0 3 --graph-event-repetitions 5` to recapture the loaded
+model's full decode graphs after all baseline, trace and eager-event passes.
+The adapter uses public HIP event-record nodes and capture dependencies,
+without Kineto or PyTorch external events. Python wrappers run only during
+capture and are restored before measurement. Event handles remain alive for
+the worker's graph lifetime; no persistent SGLang source or model weights change.
+
+The default scopes are input normalization, the GDN/full-attention mixer,
+attention reduction plus MLP normalization, and MLP including TP reduction.
+These scopes are disjoint. Nested timers are rejected because interior event
+nodes would add overhead inside the parent span. Custom disjoint leaf scopes
+can be selected with `--graph-event-components`; they do not automatically
+cover work between those call boundaries.
+
+`graph-batches.jsonl` contains separate profiled TP cohorts, while
+`graph-events-rankN.jsonl` retains batch/rank/layer/component identity, physical
+graph size, capture ID and `HIP_GRAPH_EVENT` milliseconds. These are event spans,
+**not** `KERNEL_ONLY` profiles. A logical batch of 20 using a captured graph of
+24 must resolve to physical size 24; missing graphs and multiple capture variants
+for the same physical size fail admission.
+
+Use `--freeze-decode-inputs` to make subsequent baseline and diagnostic passes
+consume the first baseline repetition's token trajectory for each workload.
+This is an explicit teacher-forced timing experiment, not free-running serving.
+Tensors are prepared outside measured steps; only trajectory hashes are written.
+The final generated tokens are not part of the trajectory because no decode
+consumes them. The timing quality check requires identical trajectory hashes
+as well as matching step and shape. Fixed inputs remove feedback from changed
+greedy outputs, but do not guarantee identical activations or expert routing.
+
+```bash
+python -m frontier.validation.graph_event_report \
+  --capture-dir /experiments/mi355x/capture-graph-001 \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --output /experiments/mi355x/capture-graph-001/graph-scope-summary.json
+```
+
+The report requires complete selected-scope coverage on every decode batch and
+TP rank, matching measurement families and physical sizes, and a baseline
+perturbation check. It preserves rejected samples and keeps ranks/layers
+separate. Summing per-component rank maxima is not a measured critical path.
+Even when whole-forward latency passes the check, endpoint overhead can bias
+small scopes. This report therefore does not admit native CSV export or claim
+full-model correlation. In particular, the coarse MLP/reduction scopes must
+not be split into invented compute and communication costs or extrapolated to EP.
+
+For a direct diagnostic of the same decoder boundary used by
+`SGLangCostContract`, add `--graph-decoder-event`. This inserts only one HIP
+event pair: the start is immediately before layer 0 and the end immediately
+after the final decoder layer. Embedding and the final residual/norm, logits,
+sampling and host work remain outside the span. Layer-level graph scopes are
+optional and should normally be omitted from this run so their additional
+event nodes do not enter the whole-decoder measurement.
+
+```bash
+# Capture with the ordinary static-batch arguments plus:
+--freeze-decode-inputs --graph-decoder-event --graph-event-repetitions 5
+
+python -m frontier.validation.graph_event_report \
+  --capture-dir /experiments/mi355x/capture-decoder-001 \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --decoder \
+  --output /experiments/mi355x/capture-decoder-001/decoder-event-summary.json
+```
+
+The report requires exactly one decoder span per decode batch and TP rank,
+checks the captured graph and physical padding identity, and preserves the
+per-rank durations rather than summing them. It also reports the same-rank
+forward-minus-decoder gap and requires the independent whole-forward
+perturbation audit. This remains an in-situ diagnostic: it is not exported as
+an isolated primitive profile and is never used to fit a correction factor.
+
+## Expert routing and native boundary admission
+
+Add `--routing-all-layers --routing-repetitions 3 --freeze-decode-inputs` to
+capture the expert selections from every decoder layer, or select a subset
+with `--routing-layers 0 3`. This is limited to the standard top-k output,
+separate shared experts, one stream and TP-only execution without expert
+placement remapping. An independent routed-expert capturer must be disabled.
+
+After the untouched baseline, the adapter recaptures graphs retaining references
+to the router's actual expert-ID and weight tensors. It adds no counter/copy
+kernels to graph capture. Necessary device-to-host snapshots occur after each
+measured step; CPU validation, hashes, histograms and compression wait until the
+whole repetition ends. Retaining tensors can affect graph-pool allocation and
+the snapshot work can still disturb subsequent steps, so this pass remains
+profiled and must pass the baseline perturbation check before calibration.
+
+`routing-batches.jsonl` is the routing-only timing ledger;
+`routing-routing-rankN.jsonl.gz` stores its per-layer expert counts and hashes.
+With `--graph-event-layers`, a subsequent pass captures routing and graph-event
+timings together, storing `graph-routing-rankN.jsonl.gz`. Both diagnostic passes
+use the same fixed input trajectory as the original baseline.
+
+Records retain separate logical and padding expert-count vectors, per-token
+assignment/set hashes, weight hashes and positive-weight slot counts. Valid
+IDs with zero weight remain counted as selections: weights alone do not prove
+that the backend prunes sorting or GEMM work. Padding sentinels are allowed
+only with zero weights; live tokens must select distinct valid experts.
+
+```bash
+python -m frontier.validation.routing_report \
+  --capture-dir /experiments/mi355x/capture-routing-001 \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --native-features-output /experiments/mi355x/routing-native-features.jsonl.gz \
+  --output /experiments/mi355x/routing-summary.json
+```
+
+The report requires complete selected-layer coverage for every decode batch and
+TP rank. It checks graph/model identity, reports TP routing disagreement and
+compares repetitions and matching routing-only/timed passes. Per-token hashes
+distinguish different assignments even when the aggregate histograms agree.
+Features reuse Frontier's existing `EPLaneWorkload` and `MoELoadImbalanceInput`
+for observed EP=1 loads. Logical and physical features are exported separately
+on rank 0; TP rank counts are never added together. This exports workload
+features, not GEMM timings or a fitted latency model, and does not establish EP
+scaling. Expert weights/IDs themselves and prompt/output text are not written.
+
+`frontier.validation.runtime_mapping` audits each SGLang boundary against native
+operator registries and the active architecture profile:
+
+```bash
+python -m frontier.validation.runtime_mapping \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --layer 0 --phase decode \
+  --measurement-type HIP_GRAPH_EVENT \
+  --components gdn mlp_including_tp_reduce \
+  --output /experiments/mi355x/runtime-map.json
+```
+
+The map keeps composite/partial scopes, missing gates, fused residuals and
+collectives explicit. Later input norms include the preceding layer's FFN
+residual add. The runtime reduces shared+routed MoE output once; that duration
+must not be assigned to both native reduction fields. The generic attention
+post projection lacks output gating, and fused shared gating/addition has no
+native operator. Unknown scopes and layer/phase mismatches fail admission.
+No simulator costs or default numerics change through this audit, and no
+`HIP_GRAPH_EVENT` CSV import is admitted by relabeling the measurement family.
+
+## GDN held-out validation
+
+The first available component predictor is GDN. The following imports batches
+16 and 32 into Frontier's existing kernel-only GDN schema and predicts batch
+24 using `ProfiledGDNPredictor`. Calibration and validation sets must be
+disjoint, including their physical graph shapes after padding.
+
+```bash
+python -m frontier.validation.gdn_correlation \
+  --capture-dir /experiments/mi355x/capture-001 \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --device mi355x \
+  --calibration-sizes 16 32 --validation-sizes 24 \
+  --output-dir /experiments/mi355x/gdn-validation-001
+```
+
+Every imported batch must contain exactly the model's number of GDN layers.
+The importer rejects incomplete profile boundaries and traces containing
+multiple GPU identities. Kernel sums, busy-time union, overlap, gaps and
+all-reduce totals remain distinct quantities. GDN error compares the predicted
+sum across GDN layers with the held-out measured GDN sum. This is rank-0
+component validation, not full-model or end-to-end serving validation.
+Both sides of this error calculation are profiled kernel sums. A small held-out
+error does not demonstrate agreement with unprofiled decode latency when the
+underlying trace fails the matching-step perturbation check.
+
+Projection regressors are fitted separately for prefill, decode and mixed
+phases. Matching batch-size sweeps use bounded linear interpolation between
+measured endpoints; other unseen shapes use the existing random-forest
+fallback. Exact measured rows retain their original lookup values. Sparse
+grids do not establish accuracy for extrapolated workloads.
+
+## Native full-model replay
+
+Use the standard `frontier.main` configuration flags after `--`. For the
+matching topology, set `replica_config_device=mi355x`,
+`replica_config_network_device=mi355x_ubb`, attention/MoE TP=8, EP=1, PP=1,
+one replica, block size 1 and `decode_cuda_graph_mode=full_decode_only`.
+Pass an explicitly calibrated communication backend. `--audit-only` checks
+which compute files are missing without training the predictors.
+
+```bash
+python -m frontier.validation.replay \
+  --ledger /experiments/mi355x/capture-001/batches.jsonl \
+  --manifest /experiments/mi355x/capture-001/manifest.json \
+  --output-dir /experiments/mi355x/replay-001 \
+  --audit-only -- \
+  --simulation_mode offline --sys_arch co-location \
+  --cluster_config_num_replicas 1 \
+  --replica_config_model_name Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --replica_config_device mi355x --replica_config_network_device mi355x_ubb \
+  --replica_config_attn_tensor_parallel_size 8 \
+  --replica_config_moe_tensor_parallel_size 8 \
+  --replica_config_moe_expert_parallel_size 1 \
+  --replica_config_num_pipeline_stages 1 \
+  --replica_scheduler_config_type sglang \
+  --sglang_scheduler_config_block_size 1 \
+  --decode_cuda_graph_mode full_decode_only \
+  --cc_backend_config_type analytical \
+  --random_forrest_execution_time_predictor_config_skip_cpu_overhead_modeling
+```
+
+The analytical communication default in this **audit-only** example is not a
+calibrated MI355X communication model. Select measured AITER/RCCL profiles or
+explicitly calibrated backend parameters before numerical full-model replay.
+Removing `--audit-only` requires all active predictor profile families. Eager
+prefill consumes CUDA-event profiles; full-graph decode consumes kernel-only
+profiles. Existing EP=8 MoE smoke data is not compatible with TP=8/EP=1.
+
+Replay rejects dummy mode and incomplete TP cohorts. Captured latency values
+are never passed to the predictor. Predictions use the exact hybrid layer
+schedule and are compared with maximum per-rank forward GPU time. Full decode
+GDN predictions use captured physical lanes, while logical request progress
+remains unchanged. The result is per-batch error, not a reconstructed request
+arrival/scheduling timeline.
+
+Native `model_time_ms` currently covers decoder blocks. The captured forward
+also includes embedding, final normalization and logits processing. Account
+for these boundary operations before treating the full-forward comparison
+as numerical parity; the replay summary explicitly labels this limitation.
+
+The opt-in runtime-cost workflow below can collect matching SGLang attention,
+GDN, linear/shared-expert, TP=8/EP=1 routed-expert and AITER collective evidence.
+These private exact-workload tables do not change the generic simulator. Live
+scheduling, mixed batches, CPU overhead, request arrivals and memory admission
+remain necessary before reporting serving throughput/latency correlation.
+
+Keep generated profiles, raw traces and experiment reports in the external
+experiment directory. Reviewable source changes consist of generic adapters,
+schemas, tests and runnable recipes.
+## Opt-in SGLang runtime cost adapter
+
+`frontier.runtime_cost.sglang.SGLangCostContract` now composes the supported
+Qwen hybrid runtime's physical boundaries into native `ExecutionTime` objects.
+It is explicitly constructed by the static validation workflow; registering
+the `sglang_runtime` operator family does **not** switch the existing model
+architecture, sklearn predictor, serving scheduler or profile CSV defaults.
+The first contract is full-graph, non-speculative decode on one node with
+TP > 1, EP=PP=DP=1 and separate shared experts. Prefill, partial-stage probes,
+overlapping streams, alternative fused communication and distributed EP are
+not admitted by this adapter.
+
+The physical `sglang_*` operator map is authoritative. Legacy scalar fields
+are compatibility aggregates: for example shared activation and the separate
+shared-output gate share the legacy activation carrier, while the combined
+shared+routed output reduction uses the MoE TP carrier once. The shared TP
+reduction carrier and standalone residual-add carriers remain zero. Later
+input norms own the previous layer's FFN residual, and post-attention norms
+own the current attention residual. The final FFN residual belongs to the
+excluded final norm. Aggregation evaluates every configured layer before
+forming native per-layer averages; it never multiplies one observed layer's
+costs by model depth.
+
+Each cost query carries a model fingerprint (checkpoint, dimensions, schedule,
+quantization), stack identity, layer identity, logical size and **every physical
+context length**. Routed sorting and quantization/GEMM/combine queries retain
+the canonical EP=1 physical expert-count vector including padding. Planning
+rejects zero-weight valid selections until a pruning-aware cost
+contract is available; counts alone do not prove the backend's executed work.
+Query construction has no observed forward-time or output-logit inputs. The capture
+bridge verifies all-rank routing agreement before using rank 0's counts.
+Padding sequence lengths include the scheduled query token and must be supplied
+explicitly from the active backend's graph contract, not guessed from requests.
+
+For a capture's selected decode batch, write a private coverage plan:
+
+```bash
+python -m frontier.validation.runtime_cost \
+  --capture-dir /path/to/capture \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --device mi355x \
+  --batch-id CAPTURED_BATCH_ID --pass-name routing \
+  --output /path/outside/repo/runtime-cost-plan.json
+```
+
+For padded batches also pass `--padding-context-lens` with one explicit value
+per padded lane. The command writes the exact queries, routing audit and missing
+profile coverage. No profile file means an empty coverage table, **not** dummy
+timing or a prediction. Add `--profile /path/to/costs.json --predict` only when
+a complete compatible table exists.
+
+`ExactRuntimeCostTable` exchanges schema-version-1 JSON with `identity` and
+`rows`; each row has the `dataclasses.asdict(CostQuery)` value as `query` and
+`dataclasses.asdict(CostEstimate)` as `estimate`. Estimates require the matching
+query hash, a strictly positive finite millisecond cost, source provenance,
+measurement family and evidence basis. Each coverage-plan entry contains a
+canonical `query` plus its `query_key`; the hash belongs to the cost estimate
+when building a table row. The strict table performs no fitting,
+interpolation, layer tying or extrapolation. Missing, duplicate, cross-stack,
+wrong-layer, altered-routing or differently padded rows fail. Exact-table
+replay is a composition/coverage check, not held-out generalization evidence.
+
+The cost-provider API allows a separately calibrated model to replace the
+exact table later. Full-graph compute requires compatible `KERNEL_ONLY` or
+explicitly labeled `HIP_GRAPH_REPLAY` isolated-compute evidence; collectives require independently calibrated
+collective evidence. Eager `CUDA_EVENT` values cannot price this graph path.
+In-situ kernel sums and `HIP_GRAPH_EVENT` scopes require an explicit
+`in_situ_diagnostic` basis and `--allow-diagnostic`; HIP graph events are never
+relabeled as kernel-only profiles. The adapter does not infer profile quality
+from a provenance string or erase profiling rejection flags upstream.
+
+Next collect matching fused compute and communication profiles, fit using
+calibration workloads only, and reserve whole physical graph sizes for
+validation (including their padded logical batches). Observed routing remains
+conditioning information, not proof that an unprofiled repetition chose the
+same experts. Native decoder cost still excludes embedding, final residual/norm,
+logits and host work; it does not establish full-forward or serving parity.
+
+Runnable contract and unchanged-default regression checks:
+
+```bash
+pytest tests/unit/test_sglang_runtime_cost.py tests/unit/test_execution_time_op_times.py -q
+pytest tests/integration/test_validation_simulator_matrix.py -q
+```
+
+### Isolated fused primitives and runtime custom reduction
+
+`frontier.profiling.runtime.sglang_primitives` runs under eight-rank `torchrun`
+in the pinned ROCm/SGLang environment without loading a checkpoint. It profiles
+plain Gemma norm, fused residual/Gemma norm, the shared-output gate/add,
+strided attention-output sigmoid gating plus local row-parallel projection,
+and the **actual SGLang TP custom all-reduce**. RCCL fallback is rejected; a
+generic `torch.distributed.all_reduce` profile is not substituted. The norm
+path is SGLang's Triton implementation selected with AITER enabled.
+
+Example split (use fresh, external output directories):
+
+```bash
+python -m torch.distributed.run --standalone --nproc_per_node=8 \
+  -m frontier.profiling.runtime.sglang_primitives \
+  --capture-manifest /path/to/capture/manifest.json \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --device mi355x \
+  --sizes 16 32 --invocations 32 128 --repetitions 20 \
+  --split calibration --trace --output-dir /path/outside/repo/primitive-train
+
+python -m torch.distributed.run --standalone --nproc_per_node=8 \
+  -m frontier.profiling.runtime.sglang_primitives \
+  --capture-manifest /path/to/capture/manifest.json \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --device mi355x \
+  --sizes 24 --invocations 32 128 --repetitions 20 \
+  --split validation --trace --output-dir /path/outside/repo/primitive-holdout
+
+python -m frontier.validation.primitive_calibration \
+  --calibration-dir /path/outside/repo/primitive-train \
+  --validation-dir /path/outside/repo/primitive-holdout \
+  --output /path/outside/repo/primitive-report.json
+```
+
+Each graph contains independent invocations and independent parameters. This
+creates a streaming working set, not repeated reuse of one cached weight.
+Mutable inputs are restored outside timing; first/last outputs are checked
+against FP32-math references before capture and after replay. Timings bracket
+the graph replay and are divided by the invocation count. They are labeled
+`HIP_GRAPH_REPLAY`, **not** pure kernel durations, in-situ graph-scope events,
+or eager CUDA-event costs. Rank-0 kernel traces run in a separate profiling
+pass after all uninstrumented measurements, using representative two-call
+graphs of the same callables. This avoids ROCTracer omissions on large graph
+batches, but does **not** prove complete timed-graph invocation coverage.
+Missing representative trace coverage rejects the run. Numerical checks use
+synthetic BF16 data, not checkpoint outputs.
+
+`PrimitiveCalibration` requires complete aligned rank cohorts, at least 20
+repetitions, two calibration physical sizes, and at least two graph lengths.
+It aggregates max-rank local duration per repetition and retains each rank's
+median; this is not a clock-synchronized multi-device makespan. The longest
+graph is selected in advance. Default quality limits are 10% for graph-length
+sensitivity and `(p90 - p10) / median` spread. Held-out sizes must not overlap
+training and use the same graph lengths, producer, hardware, environment and
+runtime identity. A 10% held-out error check does not modify the fitted model.
+
+The provider performs bounded linear interpolation in **physical size** only;
+all model dimensions (including explicit attention head width), quantization,
+TP topology and runtime settings are fixed by identity. Norm costs are tied
+across layers by fused-residual ownership, both TP reduction boundaries map
+to the same calibrated primitive, and a padded logical batch uses its physical
+graph size. Out-of-range queries, unstable primitives and unsupported scopes
+fail instead of receiving a zero or generic fallback. The provider's call-time
+gate checks calibration quality; the independent validation report is still
+required before making any held-out accuracy claim.
+
+This is a **partial** provider: the default primitive list excludes stateful
+GDN/attention scopes and route-sensitive MoE scopes. The explicit GDN,
+attention and MoE calibrations below can add those boundaries only for their
+pinned workload contracts. Primitive-level holdout accuracy does not establish
+whole-model cache/overlap behavior, full-forward latency, serving performance
+or multi-node scaling. The CLI writes a report, not a complete runtime-cost
+table, and does not ingest observed forward times.
+
+```bash
+pytest tests/unit/test_primitive_calibration.py tests/unit/test_sglang_runtime_cost.py -q
+```
+
+### BF16 shared-expert, router and GDN projection scopes
+
+The same producer also accepts six additional `--primitives` selections:
+`shared_expert_gate_up`, `shared_expert_activation`, `shared_expert_down`,
+`moe_router_linear`, `gdn_input_projections`, and `gdn_output_projection`.
+These use actual SGLang linear/activation implementations with independently
+initialized BF16 weights and FP32-math numerical references. They do not
+load a model checkpoint or change any generic profiling CSV defaults.
+
+The shared gate/up is a merged column-parallel projection; its SiLU/multiply
+activation and row-parallel down projection have separate cost boundaries.
+The router remains replicated across TP ranks. GDN input projection invokes
+SGLang's sequential ROCm helper with both QKVZ and B/A merged projections
+sharing one hidden input. The GDN output scope applies SGLang's gated RMS norm
+and then the local row-parallel linear; it does **not** include recurrent state
+work or an all-reduce. All reductions and shared-output gate/add costs remain
+separate.
+The producer rejects native activation fallback, unsupported alternate-stream
+GDN execution, and model configurations quantizing these dense projections.
+
+For the supported model at TP=8, per-rank weight shapes are:
+
+| Scope | Local BF16 weights (output, input) |
+|---|---|
+| Shared gate/up | (512, 8192) |
+| Shared down | (8192, 256) |
+| Replicated router | (512, 8192) |
+| GDN QKVZ and B/A | (4608, 8192) and (32, 8192) |
+| GDN output | (8192, 2048) |
+
+Shapes are derived from the model configuration, not these example values.
+The row-level `dense_spec` records input/output widths, merged partitions,
+per-rank weight shapes, dtype, the gated-norm input transform and
+excluded-reduction ownership. Consumers
+validate its structure and require agreement across ranks, calibration sizes,
+graph lengths and independent validation. A kernel-method label alone is not
+enough to erase a layout change.
+
+Use the earlier two-run recipe with an explicit primitive list to collect only
+these new scopes:
+
+```bash
+# Append to BOTH calibration and independent validation producer invocations:
+--primitives shared_expert_gate_up shared_expert_activation shared_expert_down \
+  moe_router_linear gdn_input_projections gdn_output_projection
+```
+
+Keep training sizes and held-out physical sizes disjoint; use the same producer
+snapshot for both sides of each experiment. No tuning or correction from the
+held-out measurements enters `PrimitiveCalibration`. Native cost composition
+still fails until **all** decoder scopes have compatible evidence. In
+particular, GDN/attention core, routing/top-k/sorting and routed MXFP4 experts
+are not supplied by this extension.
+
+```bash
+pytest tests/unit/test_sglang_dense_primitives.py tests/unit/test_primitive_calibration.py -q
+```
+
+### Stateful SGLang GDN decode core
+
+`gdn_core_decode` profiles the complete native Qwen GDN boundary between the
+two input projections and gated RMS norm. It includes QKV/B/A split and
+materialization, packed QKV concatenation, BF16 causal-convolution state update,
+the FP32-state packed recurrent kernel, and materialization of the strided Z
+gate view. The output gated norm remains in `gdn_output_projection`.
+
+Each captured invocation owns independent convolution and recurrent state.
+Correctness checks compare output, convolution state, sampled recurrent heads,
+and the materialized Z gate against independent FP32 math before capture and
+after replay. The `gdn_core_spec` records per-rank heads, projection widths,
+state shapes/dtypes, kernel width, padding sentinel and boundary ownership.
+
+GDN padding differs from dense padding: physical projection/transform work
+still executes, while padded recurrent lanes carry cache index `-1` and must
+not mutate a request state. Supply logical sizes alongside physical sizes:
+
+```bash
+# Example calibration endpoints with four padded graph lanes.
+--sizes 16 32 --logical-sizes 12 28 \
+--primitives gdn_core_decode gdn_output_projection
+
+# Independent interpolation holdout with the same padding ownership.
+--sizes 24 --logical-sizes 20 \
+--primitives gdn_core_decode gdn_output_projection
+```
+
+Calibration requires a constant `physical_size - logical_size`; queries and
+held-out rows with different padding ownership are rejected. This is a bounded
+decode calibration for one pinned identity, not a GDN prefill model, generic
+batch extrapolation, checkpoint/full-forward fit, or serving-speedup claim.
+
+```bash
+pytest tests/unit/test_sglang_gdn_primitives.py tests/unit/test_primitive_calibration.py -q
+```
+
+### Stateful SGLang attention decode boundaries
+
+Four opt-in primitives cover the native Qwen attention path before the existing
+`attention_post` gate/output-projection scope:
+
+- `attn_pre_proj_qknorm`: TP-local `QKVParallelLinear` plus fused Q/K Gemma RMS
+  normalization and extraction of the per-head output gate;
+- `attn_rope`: SGLang rotary embedding with the model's partial rotary factor;
+- `attn_kv_cache_write`: SGLang's page-size-one cache store; and
+- `attn_decode`: AITER ragged paged attention with its model-wide partition
+  specialization and NHD BF16 cache layout.
+
+The recorded `attention_decode_spec` pins local Q/KV head counts, head and
+rotary dimensions, QKV/gate projection shape, cache dtype/layout/page size,
+RoPE parameters, maximum position and boundary ownership. AITER's ragged
+`kv_indptr` is constructed explicitly as int32; integer promotion would violate
+the native ABI and is not accepted as equivalent metadata.
+
+Attention rows require both logical sizes and active context lengths. The
+physical context vector is a uniform logical prefix followed by one-token
+padding lanes. Calibration, validation and query-time use must agree on the
+active context, padding context and padding count:
+
+```bash
+# Example calibration endpoints with four graph-padding lanes.
+--sizes 16 32 --logical-sizes 12 28 \
+--active-context-lengths 1029 1029 \
+--primitives attn_pre_proj_qknorm attn_rope attn_kv_cache_write attn_decode
+
+# Independent physical-size holdout.
+--sizes 24 --logical-sizes 20 --active-context-lengths 1029 \
+--primitives attn_pre_proj_qknorm attn_rope attn_kv_cache_write attn_decode
+```
+
+Very small boundaries can need longer independent-invocation graphs so both
+graph lengths are in the same streaming working-set regime. Collect those
+primitives in separate cohorts when necessary, then combine only rows with
+identical producer source, hardware, environment and runtime identity.
+Graph-length choice remains subject to the same 10% sensitivity gate; it must
+not be chosen from held-out error. These synthetic BF16 profiles are bounded
+decoder costs, not checkpoint-output, full-forward, serving or multi-node
+validation.
+
+```bash
+pytest tests/unit/test_sglang_attention_primitives.py \
+  tests/unit/test_primitive_calibration.py -q
+```
+
+### Qwen MoE routing and exact-route MXFP4 experts
+
+The replicated router projection uses the dense primitive above. Select
+`moe_routing_topk` explicitly to profile the following AITER fused top-k
+boundary over the same physical-size calibration and holdout split. Its shape
+contract pins 512 experts, top-k 10, BF16 logits, FP32 output weights, int32
+expert IDs, unrenormalized softmax scoring and exclusion of the router linear.
+The eager correctness oracle checks the selected expert set and each gathered
+softmax probability; only the native fused call is captured and timed.
+
+```bash
+# Add to the calibration and independent validation commands, with disjoint sizes.
+--primitives moe_routing_topk
+```
+
+Sorting and expert execution cannot be inferred from physical batch size alone.
+Their queries include the complete 512-entry physical expert histogram for an
+audited captured layer, including graph-padding routes. Generate the private
+query plan with `frontier.validation.runtime_cost`, then profile each exact
+route on all eight ranks:
+
+```bash
+python -m torch.distributed.run --standalone --nproc_per_node=8 \
+  -m frontier.profiling.runtime.sglang_moe_routes \
+  --capture-manifest /path/to/capture/manifest.json \
+  --query-plan /path/outside/repo/runtime-cost-plan.json \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 --device mi355x \
+  --primitives moe_sorting moe_experts_quant_gemm_combine \
+  --invocations 32 128 --repetitions 20 --trace \
+  --output-dir /path/outside/repo/routed-profiles
+
+python -m frontier.validation.routed_primitive_calibration \
+  --profile-dir /path/outside/repo/routed-profiles \
+  --query-plan /path/outside/repo/runtime-cost-plan.json \
+  --primitives moe_sorting moe_experts_quant_gemm_combine \
+  --report /path/outside/repo/routed-report.json \
+  --table /path/outside/repo/routed-table.json
+```
+
+The producer deterministically reconstructs valid, distinct per-token top-k
+assignments from each exact histogram and verifies that Opus sorting reproduces
+the packed token/slot and expert-block ownership. Sorting is untimed when
+profiling `moe_experts_quant_gemm_combine`; that boundary contains both dynamic
+MXFP4 activation-quantization stages, both AITER MFMA expert GEMMs, activation
+and combine, but excludes sorting and TP reduction.
+
+Expert graphs allocate independent TP-local packed tensors per invocation.
+Zero-valued synthetic MXFP4 weights preserve the exact tensor extents, strides,
+shuffle marker and memory traffic while providing an exact-zero output oracle.
+They do not load checkpoint weights and are not a numerical checkpoint-output
+test. Representative traces must contain both expert GEMM stages. Because these
+graphs have a large streaming working set, profile and release one layer at a
+time and verify available HBM before choosing graph lengths.
+
+`ExactRoutedCalibration` requires complete aligned eight-rank cohorts, two or
+more graph lengths, at least 20 repetitions, matching kernel evidence and a
+10% graph-length-sensitivity/spread gate. It selects the longest graph length
+in advance and returns costs only for the identical query key, layer and route
+histogram. There is deliberately no cross-route interpolation, layer tying or
+held-forward correction. Merge admitted rows into a private exact table only
+after `ExactRuntimeCostTable.audit` reports complete coverage; generated plans,
+profiles, tables, traces and performance results stay outside the repository.
+
+For an exact post-prediction decoder check, the source capture must combine
+`--graph-decoder-event` with all-layer graph-pass routing. Build and profile the
+runtime-cost plan for one selected `graph-batches.jsonl` batch, then produce a
+complete prediction with `frontier.validation.runtime_cost --pass-name graph`.
+Correlate that prediction only with the decoder event and routes from the same
+batch:
+
+```bash
+python -m frontier.validation.runtime_cost_correlation \
+  --capture-dir /path/to/combined-decoder-and-routing-capture \
+  --prediction /path/outside/repo/exact-runtime-cost-prediction.json \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --output /path/outside/repo/exact-decoder-correlation.json
+```
+
+The command independently reconstructs the runtime identity and exact query
+keys, requires complete fixed-input TP graph coverage, audits all-layer routing
+agreement, validates one decoder event on every rank, and enforces both the
+selected-batch and capture-wide perturbation gates before calculating error.
+The observation remains post-prediction: it is never used to construct queries,
+admit profiles, fit or correct costs. The result does not claim full-forward or
+serving parity. Because fixed token inputs do not freeze expert routes, other
+graph repetitions are different conditioning points and must be planned,
+profiled and reported separately rather than pooled into an exact-route error.
+
+```bash
+pytest tests/unit/test_sglang_moe_primitives.py \
+  tests/unit/test_sglang_runtime_cost.py \
+  tests/unit/test_runtime_cost_correlation.py -q
+```

--- a/docs/profiling/README.md
+++ b/docs/profiling/README.md
@@ -1,5 +1,12 @@
 # Profiling User Guide
 
+## Modification History
+
+| Date | Summary of Changes |
+|------|--------------------|
+| 2026-08-31 | Added the AMD MI355X ROCm profiling workflow. |
+| 2026-08-14 | Updated MoE smoke documentation to use the canonical routing-distribution selector. |
+
 ## Scope
 
 This guide covers the user-facing profiling workflow for `pre-release-v0.3`.
@@ -30,6 +37,9 @@ export PYTHONPATH=$PWD
 ```
 
 If you already have `torch`, `vllm`, `flashinfer`, and CUDA tools installed in another environment, you can use that environment instead. Run commands from the repository root and set `PYTHONPATH=$PWD`.
+
+For AMD Instinct MI355X profiling with ROCm, use the pinned container and
+platform-specific commands in [ROCm MI355X Profiling](ROCM_MI355X.md).
 
 Dry-run commands do not launch GPU kernels. They check command construction, path routing, and argument parsing.
 

--- a/docs/profiling/ROCM_MI355X.md
+++ b/docs/profiling/ROCM_MI355X.md
@@ -1,0 +1,235 @@
+# ROCm MI355X Profiling
+
+This workflow profiles Frontier operators on an eight-GPU AMD Instinct MI355X
+UBB node (`gfx950`). It uses vLLM's ROCm attention implementation, AITER for
+MXFP4 MoE, and PyTorch distributed collectives backed by RCCL.
+
+## Validated stack
+
+The initial port was validated with this immutable image:
+
+```text
+vllm/vllm-openai-rocm@sha256:e0a3b2bd3fe7ec563916c3a5d949898d133458c18d6b2f460c906885cfb32032
+```
+
+The image contains PyTorch `2.12.0+git6bbd260`, HIP `7.2.53211`, vLLM
+`0.28.0`, Triton `3.7.1`, and AITER. Pin the digest when comparing results;
+changing the image also changes the kernel stack under test.
+
+## Start the profiling container
+
+Run this from a Frontier checkout. Replace `/path/to/models` only if a later
+workflow needs model weights; the Frontier operator profilers synthesize their
+inputs and weights from the checked-in model configuration.
+
+```bash
+IMAGE=vllm/vllm-openai-rocm@sha256:e0a3b2bd3fe7ec563916c3a5d949898d133458c18d6b2f460c906885cfb32032
+
+docker run --rm -it \
+  --name frontier-mi355x-dev \
+  --network host \
+  --ipc host \
+  --device /dev/kfd \
+  --device /dev/dri \
+  --group-add video \
+  --cap-add SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  -e PYTHONPATH=/workspace/Frontier \
+  -v "$PWD:/workspace/Frontier" \
+  -v /path/to/models:/models:ro \
+  -w /workspace/Frontier \
+  --entrypoint bash \
+  "$IMAGE"
+```
+
+Verify that PyTorch sees the expected platform and device count:
+
+```bash
+python - <<'PY'
+import torch
+
+print("torch:", torch.__version__)
+print("HIP:", torch.version.hip)
+print("devices:", torch.cuda.device_count())
+print("device 0:", torch.cuda.get_device_name(0))
+PY
+```
+
+PyTorch intentionally retains its `torch.cuda` API and the distributed backend
+name `nccl` on ROCm. The runtime routes those calls to HIP and RCCL.
+
+## Device visibility
+
+Use the native ROCm variable for subprocess profiling:
+
+```bash
+export ROCR_VISIBLE_DEVICES=0
+unset HIP_VISIBLE_DEVICES CUDA_VISIBLE_DEVICES
+```
+
+Do not set `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` to the same physical
+nonzero ID. Some runtime versions apply the second variable after the first and
+hide the selected device through a second index remapping.
+
+## Qwen3.8 operator smokes
+
+The checked-in `Qwen3.8-2.4T-A95B-Quark-MXFP4` configuration describes the
+92-layer, 512-expert checkpoint. Its base activations are BF16; only
+`moe_grouped_gemm` is marked MXFP4.
+
+Profile common and shared-expert linear operations:
+
+```bash
+python -m frontier.profiling.linear_op.main \
+  --disable_ray \
+  --num_gpus 1 \
+  --device mi355x \
+  --models Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --num_tensor_parallel_workers 1 \
+  --num_tokens_list 1 16 \
+  --is_moe \
+  --profile_method cuda_event \
+  --output_dir data/profiling \
+  --yes
+```
+
+Profile the model's full-attention operator:
+
+```bash
+python -m frontier.profiling.attention.main \
+  --disable_ray \
+  --num_gpus 1 \
+  --device mi355x \
+  --models Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --num_tensor_parallel_workers 1 \
+  --attention_backend VLLM_ROCM \
+  --max_model_len 16 \
+  --max_seq_len 16 \
+  --min_batch_size 1 \
+  --max_batch_size 1 \
+  --profile_only_prefill \
+  --profile_method cuda_event \
+  --output_dir data/profiling \
+  --yes
+```
+
+Profile an isolated Qwen3.8 gated-delta-network layer with the real vLLM
+Qwen3.5 module, synthetic BF16 weights, BF16 convolution state, and FP32
+recurrent state:
+
+```bash
+export VLLM_ROCM_USE_AITER=1
+
+python -m frontier.profiling.gdn.main \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --model-path /models/amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --device mi355x \
+  --prefill-seq-lens 16 128 512 2048 \
+  --decode-batch-sizes 1 8 32 128 \
+  --decode-context-len 512 \
+  --continuation-context-len 512 \
+  --include-continuation-prefill \
+  --include-mixed \
+  --max-model-len 4096 \
+  --max-batch-size 129 \
+  --output-dir data/profiling
+```
+
+The profiler runs vLLM in eager mode, records the input projections, phase-
+specific GDN core, output projection, and complete layer separately, and
+checks numerical equivalence before writing a CSV. The runtime stack and
+standard/AITER dispatch choice are part of every row's compatibility
+contract. Do not merge measurements produced by different runtime stack
+signatures.
+
+For a serving-faithful TP=8 profile, SGLang's static-batch runner can capture
+the real Quark-weighted Qwen3.8 kernels. The importer recognizes the filenames
+written by `sglang.benchmark.one_batch`, excludes the decoder input norm and
+the post-GDN TP all-reduce, and writes the kernel-only predictor dataset:
+
+```bash
+python -m frontier.profiling.gdn.sglang_trace \
+  --model Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --device mi355x \
+  --tensor-parallel-size 8 \
+  --runtime-stack-signature 'sglang=<commit>;torch=<version>;rocm=<version>;aiter=<version>' \
+  --trace /path/outside/repo/prefill.trace.json.gz \
+  --trace /path/outside/repo/decode.trace.json.gz \
+  --output-dir data/profiling
+```
+
+The output is
+`data/profiling/compute/mi355x/Qwen3.8-2.4T-A95B-Quark-MXFP4/gdn_kernel_only.csv`.
+The trace must contain a whole number of 69-layer GDN passes. Decode graph
+profiling may omit a boundary replay, so the importer validates complete model
+passes rather than requiring the requested profiler-step count exactly.
+
+Enable AITER before importing vLLM, then profile the routed experts with the
+node's natural EP=8 distribution (64 local experts per device):
+
+```bash
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+
+python -m frontier.profiling.moe.main \
+  --disable_ray \
+  --num_gpus 1 \
+  --device mi355x \
+  --models Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+  --num_tensor_parallel_workers 1 \
+  --expert_parallel_sizes 8 \
+  --num_tokens_list 1 \
+  --load_distributions uniform \
+  --num_samples_per_distribution 1 \
+  --profile_method cuda_event \
+  --output_dir data/profiling \
+  --yes
+```
+
+The resulting MoE row must report
+`moe_grouped_gemm_backend=vllm_aiter_mxfp4` and a quantization signature ending
+in `operations=moe_grouped_gemm`. A BF16 `profiling_precision` value describes
+the base activation dtype; the quantization signature and backend identify the
+selective MXFP4 kernel.
+
+## RCCL collective smoke
+
+The local runner does not require Ray. To profile a two-GPU BF16 all-reduce:
+
+```bash
+export ROCR_VISIBLE_DEVICES=0,1
+unset HIP_VISIBLE_DEVICES CUDA_VISIBLE_DEVICES
+
+python -m frontier.profiling.collectives.main \
+  --disable_ray \
+  --num_gpus 2 \
+  --num_workers_per_node_combinations 2 \
+  --max_collective_size 1024 \
+  --collective all_reduce \
+  --precision BF16 \
+  --output_dir data/profiling
+```
+
+The CSV `size` column is bytes, so 1,024 BF16 elements are recorded as 2,048
+bytes. Frontier uses Kineto to capture the RCCL kernel time.
+
+## Current Qwen3.8 fidelity boundary
+
+For reproducible TP=8 batch capture, held-out GDN validation and native
+predictor replay, see [MI355X correlation](MI355X_CORRELATION.md).
+
+Frontier models Qwen3.8 as the exact 92-layer hybrid schedule: layers 3, 7,
+..., 91 use full attention and the other 69 layers use gated delta networks.
+Prediction aggregates each layer family independently. Memory planning counts
+the dense-attention KV cache only for the 23 full-attention layers and reserves
+the fixed convolution/recurrent GDN state for every active request.
+
+The standalone wrapper reserves cache block zero because vLLM defines it as
+`NULL_BLOCK_ID`; real request state uses blocks `1..N`. Assigning a request to
+zero makes the causal-convolution kernel skip that request and invalidates both
+correctness and timing results.
+
+Record numerical-equivalence checks, selected kernel backends, fallback paths,
+runtime commit identities, tuning availability and all measured timings in the
+external experiment directory. Do not commit generated traces, profiles,
+latency ratios or backend performance conclusions to the source repository.

--- a/frontier/config/config.py
+++ b/frontier/config/config.py
@@ -2138,6 +2138,10 @@ class BaseExecutionTimePredictorConfig(BasePolyConfig):
         default="./data/profiling/compute/{DEVICE}/{MODEL}/attention.csv",
         metadata={"help": "Path to the attention input file."},
     )
+    gdn_input_file: str = field(
+        default="./data/profiling/compute/{DEVICE}/{MODEL}/gdn.csv",
+        metadata={"help": "Path to the eager GDN profiling input file."},
+    )
     all_reduce_input_file: str = field(
         default="./data/profiling/network/{NETWORK_DEVICE}/all_reduce.csv",
         metadata={"help": "Path to the all reduce input file."},
@@ -2183,6 +2187,10 @@ class BaseExecutionTimePredictorConfig(BasePolyConfig):
     atten_kernel_only_input_file: str = field(
         default="./data/profiling/compute/{DEVICE}/{MODEL}/attention_kernel_only.csv",
         metadata={"help": "Path to the kernel-only attention input file."},
+    )
+    gdn_kernel_only_input_file: str = field(
+        default="./data/profiling/compute/{DEVICE}/{MODEL}/gdn_kernel_only.csv",
+        metadata={"help": "Path to the kernel-only GDN profiling input file."},
     )
     moe_kernel_only_input_file: str = field(
         default="./data/profiling/compute/{DEVICE}/{MODEL}/moe_kernel_only.csv",

--- a/frontier/config/device_sku_config.py
+++ b/frontier/config/device_sku_config.py
@@ -94,3 +94,14 @@ class RtxPro6000DeviceSKUConfig(BaseDeviceSKUConfig):
     @staticmethod
     def get_type():
         return DeviceSKUType.RTX_PRO_6000
+
+
+@dataclass
+class MI355XDeviceSKUConfig(BaseDeviceSKUConfig):
+    # AMD Instinct MI355X dense FP16/BF16 matrix throughput and HBM3E capacity.
+    fp16_tflops: int = 2516
+    total_memory_gb: int = 288
+
+    @staticmethod
+    def get_type():
+        return DeviceSKUType.MI355X

--- a/frontier/config/model_config.py
+++ b/frontier/config/model_config.py
@@ -8,6 +8,11 @@ from frontier.attention.model_binding import bind_attention_family
 from frontier.attention.ops import AttentionMemoryLayout
 from frontier.config.base_fixed_config import BaseFixedConfig
 from frontier.config.precision_type import PrecisionType
+from frontier.gdn import (
+    GatedDeltaNetConfig,
+    SequenceMixerType,
+    build_sequence_mixer_schedule,
+)
 from frontier.logger import init_logger
 from frontier.model_architectures import (
     MODEL_ARCHITECTURE_REGISTRY,
@@ -27,7 +32,7 @@ class QuantizationConfig:
     """Configuration for model quantization, aligned with stepfun-vllm Fp8Config semantics.
 
     Attributes:
-        quant_method: Quantization method (None for no quantization, "fp8" for FP8)
+        quant_method: Canonical quantization precision (for example, "fp8" or "fp4")
         activation_scheme: Activation quantization scheme ("dynamic" or "static")
         is_checkpoint_fp8_serialized: Whether checkpoint has pre-quantized FP8 weights
         weight_block_size: Block dimensions for block-wise quantization, e.g., (128, 128)
@@ -38,6 +43,7 @@ class QuantizationConfig:
     is_checkpoint_fp8_serialized: bool = False
     weight_block_size: Optional[Tuple[int, int]] = None
     ignored_layers: List[str] = field(default_factory=list)
+    quantized_operations: Optional[List[str]] = None
 
     @staticmethod
     def _normalize_quant_method(quant_method: Optional[str]) -> Optional[str]:
@@ -54,11 +60,25 @@ class QuantizationConfig:
         self.quant_method = self._normalize_quant_method(self.quant_method)
 
         # Validate quant_method
-        valid_quant_methods = {None, "fp8"}
+        valid_quant_methods = {None, "fp8", "fp4"}
         if self.quant_method not in valid_quant_methods:
             raise ValueError(
                 f"Invalid quant_method '{self.quant_method}'. "
                 f"Must be one of: {valid_quant_methods}"
+            )
+
+        if self.quantized_operations is not None:
+            if not all(
+                isinstance(operation, str) and operation.strip()
+                for operation in self.quantized_operations
+            ):
+                raise ValueError(
+                    "quantized_operations must contain non-empty operation names"
+                )
+            self.quantized_operations = list(
+                dict.fromkeys(
+                    operation.strip() for operation in self.quantized_operations
+                )
             )
 
         # Validate activation_scheme
@@ -115,6 +135,10 @@ class QuantizationConfig:
         if self.ignored_layers:
             sorted_ignored = sorted(self.ignored_layers)
             parts.append(f"ignored={','.join(sorted_ignored)}")
+        if self.quantized_operations is not None:
+            parts.append(
+                f"operations={','.join(sorted(self.quantized_operations))}"
+            )
 
         signature_str = "|".join(parts)
         return signature_str
@@ -140,12 +164,42 @@ class QuantizationConfig:
                     f"got {weight_block_size}"
                 )
 
+        quant_method = cls._normalize_quant_method(
+            config_dict.get("quant_method")
+        )
+        activation_scheme = config_dict.get("activation_scheme")
+        if quant_method == "quark":
+            global_quant_config = config_dict.get("global_quant_config") or {}
+            weight_config = global_quant_config.get("weight") or {}
+            input_config = global_quant_config.get("input_tensors") or {}
+            if (
+                str(weight_config.get("dtype", "")).lower() == "fp4"
+                and str(input_config.get("dtype", "")).lower() == "fp4"
+            ):
+                quant_method = "fp4"
+                if activation_scheme is None:
+                    activation_scheme = (
+                        "dynamic" if input_config.get("is_dynamic") else "static"
+                    )
+
+        quantized_operations = config_dict.get(
+            "frontier_quantized_operations",
+            config_dict.get("quantized_operations"),
+        )
+
         return cls(
-            quant_method=cls._normalize_quant_method(config_dict.get("quant_method")),
-            activation_scheme=config_dict.get("activation_scheme"),
+            quant_method=quant_method,
+            activation_scheme=activation_scheme,
             is_checkpoint_fp8_serialized=bool(config_dict.get("is_checkpoint_fp8_serialized", False)),
             weight_block_size=weight_block_size,
-            ignored_layers=list(config_dict.get("ignored_layers", [])),
+            ignored_layers=list(
+                config_dict.get("ignored_layers", config_dict.get("exclude", []))
+            ),
+            quantized_operations=(
+                list(quantized_operations)
+                if quantized_operations is not None
+                else None
+            ),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -156,6 +210,7 @@ class QuantizationConfig:
             "is_checkpoint_fp8_serialized": self.is_checkpoint_fp8_serialized,
             "weight_block_size": list(self.weight_block_size) if self.weight_block_size else None,
             "ignored_layers": self.ignored_layers,
+            "quantized_operations": self.quantized_operations,
         }
 
 
@@ -181,6 +236,7 @@ FUSED_ADD_NORM_MODEL_TYPE_ALLOWLIST = {
     "qwen2",
     "qwen2_moe",
     "qwen3_moe",
+    "qwen3_5_moe_text",
     "step2_mini",
     "step3_text",
 }
@@ -190,6 +246,7 @@ NON_FUSED_ADD_NORM_MODEL_TYPE_ALLOWLIST = {
 QK_NORM_MODEL_TYPE_ALLOWLIST = {
     "qwen3_moe",
     "qwen3_next",
+    "qwen3_5_moe_text",
 }
 
 
@@ -199,11 +256,14 @@ def _infer_attn_output_gate_from_hf_config(cfg: Dict[str, Any]) -> bool:
         return bool(explicit_value)
 
     model_type = str(cfg.get("model_type", "")).lower()
-    if model_type == "qwen3_next":
+    if model_type in {"qwen3_next", "qwen3_5_moe_text"}:
         return True
 
     architectures = [str(value).lower() for value in cfg.get("architectures", [])]
-    return any("qwen3next" in architecture for architecture in architectures)
+    return any(
+        "qwen3next" in architecture or "qwen3_5" in architecture
+        for architecture in architectures
+    )
 
 
 def _infer_use_qk_norm_from_hf_config(cfg: Dict[str, Any]) -> bool:
@@ -216,7 +276,10 @@ def _infer_use_qk_norm_from_hf_config(cfg: Dict[str, Any]) -> bool:
         return True
 
     architectures = [str(value).lower() for value in cfg.get("architectures", [])]
-    return any("qwen3next" in architecture for architecture in architectures)
+    return any(
+        "qwen3next" in architecture or "qwen3_5" in architecture
+        for architecture in architectures
+    )
 
 
 def _infer_share_expert_dim_from_hf_config(
@@ -290,6 +353,18 @@ class BaseModelConfig(BaseFixedConfig):
     qk_head_dim: Optional[int] = None
     v_head_dim: Optional[int] = None
 
+    # Hybrid sequence-mixer topology. Hugging Face Qwen3.5 configs may provide
+    # an explicit layer_types list; full_attention_interval is the canonical
+    # fallback used by older configs.
+    layer_types: Optional[Tuple[str, ...]] = None
+    full_attention_interval: Optional[int] = None
+    linear_conv_kernel_dim: Optional[int] = None
+    linear_key_head_dim: Optional[int] = None
+    linear_value_head_dim: Optional[int] = None
+    linear_num_key_heads: Optional[int] = None
+    linear_num_value_heads: Optional[int] = None
+    gdn_output_gate_type: str = "silu"
+
     # Default model precision from model config (e.g., torch_dtype in HF config)
     torch_dtype: str = "float16"
 
@@ -309,6 +384,9 @@ class BaseModelConfig(BaseFixedConfig):
     _moe_layer_ids_cache: Optional[List[int]] = field(
         default=None, compare=False, hash=False, repr=False
     )
+    _sequence_mixer_types_cache: Optional[Tuple[SequenceMixerType, ...]] = field(
+        default=None, compare=False, hash=False, repr=False
+    )
 
     def __post_init__(self):
         """Validate model configuration after initialization."""
@@ -316,6 +394,51 @@ class BaseModelConfig(BaseFixedConfig):
             self.model_type = str(self.model_type).lower()
         if self.model_architecture_profile is not None:
             self.model_architecture_profile = str(self.model_architecture_profile).lower()
+
+        if self.layer_types is not None:
+            self.layer_types = tuple(str(value) for value in self.layer_types)
+        if self.full_attention_interval is not None:
+            self.full_attention_interval = int(self.full_attention_interval)
+
+        gdn_shape_values = (
+            self.linear_conv_kernel_dim,
+            self.linear_key_head_dim,
+            self.linear_value_head_dim,
+            self.linear_num_key_heads,
+            self.linear_num_value_heads,
+        )
+        has_any_gdn_shape = any(value is not None for value in gdn_shape_values)
+        has_complete_gdn_shape = all(value is not None for value in gdn_shape_values)
+        if has_any_gdn_shape and not has_complete_gdn_shape:
+            missing_fields = [
+                field_name
+                for field_name, value in zip(
+                    (
+                        "linear_conv_kernel_dim",
+                        "linear_key_head_dim",
+                        "linear_value_head_dim",
+                        "linear_num_key_heads",
+                        "linear_num_value_heads",
+                    ),
+                    gdn_shape_values,
+                )
+                if value is None
+            ]
+            raise ValueError(
+                "GDN model configuration is incomplete; missing fields: "
+                f"{missing_fields}"
+            )
+        if has_complete_gdn_shape:
+            # Constructing the immutable value object performs dimension and
+            # output-gate validation once at config admission.
+            self.get_gdn_config()
+
+        self._sequence_mixer_types_cache = build_sequence_mixer_schedule(
+            num_layers=self.num_layers,
+            layer_types=self.layer_types,
+            full_attention_interval=self.full_attention_interval,
+            has_gated_delta_net=has_complete_gdn_shape,
+        )
 
         # Validate model_arch
         if self.model_arch not in ModelArch.VALID_ARCHS:
@@ -426,6 +549,93 @@ class BaseModelConfig(BaseFixedConfig):
     def get_attention_family(self):
         """Return the bound attention family for runtime cache semantics."""
         return bind_attention_family(self).family
+
+    def get_gdn_config(self) -> Optional[GatedDeltaNetConfig]:
+        """Return the validated GDN shape contract, when configured."""
+
+        values = (
+            self.linear_conv_kernel_dim,
+            self.linear_key_head_dim,
+            self.linear_value_head_dim,
+            self.linear_num_key_heads,
+            self.linear_num_value_heads,
+        )
+        if all(value is None for value in values):
+            return None
+        if any(value is None for value in values):
+            raise ValueError("GDN shape configuration is incomplete")
+        return GatedDeltaNetConfig(
+            conv_kernel_size=int(self.linear_conv_kernel_dim),
+            key_head_dim=int(self.linear_key_head_dim),
+            value_head_dim=int(self.linear_value_head_dim),
+            num_key_heads=int(self.linear_num_key_heads),
+            num_value_heads=int(self.linear_num_value_heads),
+            output_gate_type=self.gdn_output_gate_type,
+        )
+
+    def get_sequence_mixer_types(self) -> Tuple[SequenceMixerType, ...]:
+        """Return the immutable, model-owned decoder layer schedule."""
+
+        if self._sequence_mixer_types_cache is None:
+            self._sequence_mixer_types_cache = build_sequence_mixer_schedule(
+                num_layers=self.num_layers,
+                layer_types=self.layer_types,
+                full_attention_interval=self.full_attention_interval,
+                has_gated_delta_net=self.get_gdn_config() is not None,
+            )
+        return self._sequence_mixer_types_cache
+
+    def get_sequence_mixer_type(self, layer_id: int) -> SequenceMixerType:
+        if type(layer_id) is not int or not 0 <= layer_id < self.num_layers:
+            raise ValueError(
+                f"layer_id {layer_id!r} out of range for num_layers={self.num_layers}"
+            )
+        return self.get_sequence_mixer_types()[layer_id]
+
+    def get_sequence_mixer_layer_ids(
+        self,
+        mixer_type: SequenceMixerType,
+        *,
+        start_layer_id: int = 0,
+        end_layer_id: Optional[int] = None,
+    ) -> List[int]:
+        """Return matching global layer IDs in a validated half-open range."""
+
+        normalized_type = SequenceMixerType.from_config_value(mixer_type)
+        end = self.num_layers if end_layer_id is None else end_layer_id
+        if (
+            type(start_layer_id) is not int
+            or type(end) is not int
+            or start_layer_id < 0
+            or end < start_layer_id
+            or end > self.num_layers
+        ):
+            raise ValueError(
+                "Invalid sequence-mixer layer range: "
+                f"[{start_layer_id!r}, {end!r}) for num_layers={self.num_layers}"
+            )
+        schedule = self.get_sequence_mixer_types()
+        return [
+            layer_id
+            for layer_id in range(start_layer_id, end)
+            if schedule[layer_id] is normalized_type
+        ]
+
+    def get_num_gdn_layers(self) -> int:
+        return len(
+            self.get_sequence_mixer_layer_ids(SequenceMixerType.GATED_DELTA_NET)
+        )
+
+    def get_num_full_attention_layers(self) -> int:
+        return len(
+            self.get_sequence_mixer_layer_ids(SequenceMixerType.FULL_ATTENTION)
+        )
+
+    def is_gdn_layer(self, layer_id: int) -> bool:
+        return (
+            self.get_sequence_mixer_type(layer_id)
+            is SequenceMixerType.GATED_DELTA_NET
+        )
 
     def uses_mla(self) -> bool:
         """Return whether this model uses vLLM-style MLA cache semantics."""
@@ -617,6 +827,12 @@ class BaseModelConfig(BaseFixedConfig):
 
         rope_theta = cfg.get("rope_theta")
         rope_scaling = cfg.get("rope_scaling")
+        partial_rotary_factor = float(cfg.get("partial_rotary_factor", 1.0))
+        if not 0.0 < partial_rotary_factor <= 1.0:
+            raise ValueError(
+                "partial_rotary_factor must be in (0, 1], got "
+                f"{partial_rotary_factor} in {file_path}"
+            )
 
         # Parse model architecture (for op_name isolation)
         model_arch = cfg.get("model_arch")
@@ -683,6 +899,19 @@ class BaseModelConfig(BaseFixedConfig):
         if v_head_dim is not None:
             v_head_dim = int(v_head_dim)
 
+        layer_types = cfg.get("layer_types")
+        if layer_types is not None:
+            if not isinstance(layer_types, (list, tuple)):
+                raise ValueError(
+                    f"layer_types must be a list in {file_path}, got "
+                    f"{type(layer_types).__name__}"
+                )
+            layer_types = tuple(str(value) for value in layer_types)
+
+        def optional_int(field_name: str) -> Optional[int]:
+            value = cfg.get(field_name)
+            return None if value is None else int(value)
+
         # Parse quantization configuration
         quant_config_dict = cfg.get("quantization_config")
         quantization_config = QuantizationConfig.from_dict(quant_config_dict)
@@ -706,6 +935,7 @@ class BaseModelConfig(BaseFixedConfig):
             vocab_size=vocab_size,
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
+            partial_rotary_factor=partial_rotary_factor,
             model_type=model_type_lower or None,
             model_architecture_profile=cfg.get("model_architecture_profile"),
             model_arch=model_arch,
@@ -721,6 +951,14 @@ class BaseModelConfig(BaseFixedConfig):
             qk_rope_head_dim=qk_rope_head_dim,
             qk_head_dim=qk_head_dim,
             v_head_dim=v_head_dim,
+            layer_types=layer_types,
+            full_attention_interval=optional_int("full_attention_interval"),
+            linear_conv_kernel_dim=optional_int("linear_conv_kernel_dim"),
+            linear_key_head_dim=optional_int("linear_key_head_dim"),
+            linear_value_head_dim=optional_int("linear_value_head_dim"),
+            linear_num_key_heads=optional_int("linear_num_key_heads"),
+            linear_num_value_heads=optional_int("linear_num_value_heads"),
+            gdn_output_gate_type=str(cfg.get("output_gate_type", "silu")),
             torch_dtype=torch_dtype,
             quantization_config=quantization_config,
             fused_add_norm_capability=fused_add_norm_capability,

--- a/frontier/config/node_sku_config.py
+++ b/frontier/config/node_sku_config.py
@@ -100,3 +100,13 @@ class H20DgxNodeSKUConfig(BaseNodeSKUConfig):
     @staticmethod
     def get_type():
         return NodeSKUType.H20_DGX
+
+
+@dataclass
+class MI355XUBBNodeSKUConfig(BaseNodeSKUConfig):
+    device_sku_type: DeviceSKUType = DeviceSKUType.MI355X
+    num_devices_per_node: int = 8
+
+    @staticmethod
+    def get_type():
+        return NodeSKUType.MI355X_UBB

--- a/frontier/config/quantization_manager.py
+++ b/frontier/config/quantization_manager.py
@@ -199,7 +199,12 @@ class QuantizationManager:
             quant_config = model_config.quantization_config
             if quant_config is not None and quant_config.quant_method is not None:
                 quant_precision = PrecisionType.from_string(quant_config.quant_method)
-                for op_name in self.MODEL_CONFIG_QUANT_OPS:
+                quantized_operations = (
+                    quant_config.quantized_operations
+                    if quant_config.quantized_operations is not None
+                    else sorted(self.MODEL_CONFIG_QUANT_OPS)
+                )
+                for op_name in quantized_operations:
                     if not self._is_operation_supported(op_name):
                         registry_path = self.DEFAULT_CONFIG_DIR / self.REGISTRY_FILE
                         raise ValueError(

--- a/frontier/entities/time_components.py
+++ b/frontier/entities/time_components.py
@@ -10,6 +10,8 @@ from functools import cache
 from typing import Mapping
 
 from frontier.attention.families import iter_execution_enabled_families
+from frontier.gdn.family import GATED_DELTA_NET_FAMILY
+from frontier.operators.sglang_family import SGLANG_RUNTIME_FAMILY, runtime_operator_attrs
 from frontier.operators.families import (
     COMM_FAMILY,
     FFN_FAMILY,
@@ -22,10 +24,10 @@ from frontier.operators.families import (
 def _attention_operator_execution_time_attrs() -> dict[str, str]:
     return {
         operator.name: operator.execution_time_attr
-        for family in iter_execution_enabled_families()
+        for family in (*iter_execution_enabled_families(), GATED_DELTA_NET_FAMILY)
         for operator in family.e2e_trace_ops()
         if operator.execution_time_attr is not None
-    }
+    } | runtime_operator_attrs("attention")
 
 
 def _mlp_operator_execution_time_attrs() -> dict[str, str]:
@@ -59,7 +61,7 @@ def _moe_operator_execution_time_attrs() -> dict[str, str]:
             "share_expert_act_time",
             "share_expert_down_proj_time",
         }
-    }
+    } | runtime_operator_attrs("moe")
 
 
 def _communication_operator_execution_time_attrs() -> dict[str, str]:
@@ -67,7 +69,7 @@ def _communication_operator_execution_time_attrs() -> dict[str, str]:
         operator.name: operator.execution_time_attr
         for operator in COMM_FAMILY.e2e_trace_ops()
         if operator.execution_time_attr is not None
-    }
+    } | runtime_operator_attrs("communication")
 
 
 @cache
@@ -75,11 +77,13 @@ def _canonical_operator_execution_time_attr_items() -> tuple[tuple[str, str], ..
     operator_attrs: dict[str, str] = {}
     for family in (
         *tuple(iter_execution_enabled_families()),
+        GATED_DELTA_NET_FAMILY,
         MEMORY_FAMILY,
         FFN_FAMILY,
         MOE_FAMILY,
         SHARE_EXPERT_FAMILY,
         COMM_FAMILY,
+        SGLANG_RUNTIME_FAMILY,
     ):
         for operator in family.e2e_trace_ops():
             if operator.execution_time_attr is None:
@@ -281,10 +285,12 @@ class AttentionOperatorTimes:
     def legacy_covered_time(self, attention_time: "AttentionTime") -> float:
         covered_time_ms = 0.0
         attention_operator_attrs = _attention_operator_execution_time_attrs()
+        covered_attrs = set()
         for op_name in self.op_times:
             attr_name = attention_operator_attrs.get(op_name)
-            if attr_name is not None:
+            if attr_name is not None and attr_name not in covered_attrs:
                 covered_time_ms += float(getattr(attention_time, attr_name))
+                covered_attrs.add(attr_name)
         return covered_time_ms
 
 
@@ -376,9 +382,15 @@ class MoEOperatorTimes:
     def legacy_covered_time(self, moe_time: "MoETime") -> float:
         covered_time_ms = 0.0
         moe_operator_attrs = _moe_operator_execution_time_attrs()
+        covered_attrs = set()
         for op_name in self.op_times:
             attr_name = moe_operator_attrs[op_name]
+            # Several physical runtime scopes can share an aggregate legacy
+            # carrier. Subtract the carrier once, then add each scope once.
+            if attr_name in covered_attrs:
+                continue
             covered_time_ms += float(getattr(moe_time, attr_name))
+            covered_attrs.add(attr_name)
         return covered_time_ms
 
 

--- a/frontier/execution_time_predictor/shared_prediction_model_manager.py
+++ b/frontier/execution_time_predictor/shared_prediction_model_manager.py
@@ -4510,10 +4510,27 @@ class ExecutionTimePredictionModelManager:
         linear_op_file = execution_time_predictor_config.linear_op_input_file
         if not linear_op_file and execution_time_predictor_config.mlp_input_file:
             linear_op_file = execution_time_predictor_config.mlp_input_file
+        get_num_gdn_layers = getattr(
+            replica_config.model_config,
+            "get_num_gdn_layers",
+            None,
+        )
+        has_gdn_layers = (
+            callable(get_num_gdn_layers) and int(get_num_gdn_layers()) > 0
+        )
 
         return {
             'compute_input_file': _resolve(linear_op_file),
             'attention_input_file': _resolve(execution_time_predictor_config.atten_input_file),
+            **(
+                {
+                    'gdn_input_file': _resolve(
+                        execution_time_predictor_config.gdn_input_file
+                    )
+                }
+                if has_gdn_layers
+                else {}
+            ),
             'moe_input_file': _resolve(execution_time_predictor_config.moe_input_file),
             'all_reduce_input_file': _resolve(execution_time_predictor_config.all_reduce_input_file),
             'send_recv_input_file': _resolve(execution_time_predictor_config.send_recv_input_file),
@@ -4533,6 +4550,15 @@ class ExecutionTimePredictionModelManager:
             ),
             'compute_kernel_only_input_file': _resolve(execution_time_predictor_config.linear_op_kernel_only_input_file),
             'attention_kernel_only_input_file': _resolve(execution_time_predictor_config.atten_kernel_only_input_file),
+            **(
+                {
+                    'gdn_kernel_only_input_file': _resolve(
+                        execution_time_predictor_config.gdn_kernel_only_input_file
+                    )
+                }
+                if has_gdn_layers
+                else {}
+            ),
             'moe_kernel_only_input_file': _resolve(execution_time_predictor_config.moe_kernel_only_input_file),
         }
 

--- a/frontier/execution_time_predictor/sklearn_execution_time_predictor.py
+++ b/frontier/execution_time_predictor/sklearn_execution_time_predictor.py
@@ -77,6 +77,7 @@ from frontier.execution_time_predictor.attention_tp_policy import (
 from frontier.execution_time_predictor.attention_dataset_contract import (
     enforce_mixed_attention_input_contract,
 )
+from frontier.gdn.predictor import ProfiledGDNPredictor
 from frontier.logger import init_logger
 from frontier.moe_gating_runtime import get_moe_gating_base_model_name
 from frontier.model_architectures import ModelArchitectureProfile, ResolvedLayerContract
@@ -427,6 +428,9 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         self._attention_tp_warning_cache: Set[str] = set()
 
         self._initialize_file_paths(training_file_paths)
+        self._gdn_profile_predictors: Dict[
+            tuple[str, MeasurementType], ProfiledGDNPredictor
+        ] = {}
         self._pp_stage_boundary_lookup: Dict[Tuple[int, int, int, int, int, int], float] = {}
         self._pp_stage_boundary_profile_rows: List[
             Tuple[Tuple[int, int, int, int, int, int], float]
@@ -799,6 +803,28 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         self._attention_input_file = self._attention_input_file_eager
         self._moe_input_file = self._moe_input_file_eager
 
+        def resolve_gdn_path(path_template: str) -> str:
+            return (
+                str(path_template)
+                .replace("{DEVICE}", self._replica_config.device)
+                .replace("{MODEL}", self._model_config.get_name())
+                .replace("{NETWORK_DEVICE}", self._replica_config.network_device)
+            )
+
+        self._gdn_input_file_eager = (
+            training_file_paths.get("gdn_input_file", "")
+            if training_file_paths
+            else ""
+        ) or resolve_gdn_path(getattr(self._config, "gdn_input_file", ""))
+        self._gdn_input_file_kernel_only = (
+            training_file_paths.get("gdn_kernel_only_input_file", "")
+            if training_file_paths
+            else ""
+        ) or resolve_gdn_path(
+            getattr(self._config, "gdn_kernel_only_input_file", "")
+        )
+        self._gdn_input_file = self._gdn_input_file_eager
+
     def _get_input_files(
         self, measurement_type: MeasurementType = MeasurementType.CUDA_EVENT
     ) -> Tuple[str, str, str, str, str, str]:
@@ -950,12 +976,18 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
             self._moe_input_file = self._moe_input_file_eager
             self._models = self._models_eager
             self._predictions = self._predictions_eager
+            self._gdn_input_file = getattr(self, "_gdn_input_file_eager", "")
         elif measurement_type == MeasurementType.KERNEL_ONLY:
             self._compute_input_file = self._compute_input_file_kernel_only
             self._attention_input_file = self._attention_input_file_kernel_only
             self._moe_input_file = self._moe_input_file_kernel_only
             self._models = self._models_kernel_only
             self._predictions = self._predictions_kernel_only
+            self._gdn_input_file = getattr(
+                self,
+                "_gdn_input_file_kernel_only",
+                "",
+            )
         else:
             raise ValueError(f"Unsupported measurement_type={measurement_type!r}")
 
@@ -6939,10 +6971,13 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
             "active_measurement_type": self._active_measurement_type.value,
             "compute_input_file": self._compute_input_file,
             "attention_input_file": self._attention_input_file,
+            "gdn_input_file": self._gdn_input_file,
             "compute_input_file_eager": self._compute_input_file_eager,
             "attention_input_file_eager": self._attention_input_file_eager,
+            "gdn_input_file_eager": self._gdn_input_file_eager,
             "compute_input_file_kernel_only": self._compute_input_file_kernel_only,
             "attention_input_file_kernel_only": self._attention_input_file_kernel_only,
+            "gdn_input_file_kernel_only": self._gdn_input_file_kernel_only,
             "all_reduce_input_file": self._all_reduce_input_file,
             "send_recv_input_file": self._send_recv_input_file,
             "cpu_overhead_input_file": self._cpu_overhead_input_file,
@@ -7331,6 +7366,197 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         )
         return AttentionTime(operator_times=operator_times)
 
+    def _model_has_gdn_layers(self) -> bool:
+        getter = getattr(self._model_config, "get_num_gdn_layers", None)
+        return callable(getter) and int(getter()) > 0
+
+    def _is_gdn_layer(self, layer_id: int) -> bool:
+        if type(layer_id) is not int:
+            raise ValueError(f"layer_id must be an exact integer, got {layer_id!r}")
+        predicate = getattr(self._model_config, "is_gdn_layer", None)
+        if not callable(predicate):
+            return False
+        return bool(predicate(layer_id))
+
+    def _get_profiled_gdn_predictor(self) -> ProfiledGDNPredictor:
+        if not self._model_has_gdn_layers():
+            raise ValueError("GDN predictor requested for a model without GDN layers")
+        measurement_type = getattr(
+            self,
+            "_active_measurement_type",
+            MeasurementType.CUDA_EVENT,
+        )
+        path = str(getattr(self, "_gdn_input_file", ""))
+        if not path:
+            raise ValueError(
+                f"No GDN profiling file configured for {measurement_type.value}"
+            )
+        cache_key = (path, measurement_type)
+        predictor = self._gdn_profile_predictors.get(cache_key)
+        if predictor is None:
+            predictor = ProfiledGDNPredictor.from_csv(
+                path,
+                model_config=self._model_config,
+                device=self._replica_config.device,
+                tensor_parallel_size=self._replica_config.attn_tensor_parallel_size,
+                measurement_type=measurement_type,
+            )
+            self._gdn_profile_predictors[cache_key] = predictor
+        return predictor
+
+    def _predict_gdn_attention_layer_time(
+        self,
+        batch: Batch,
+        layer_id: int,
+        cluster_type: ClusterType,
+    ) -> AttentionTime:
+        norm_time = self._get_attn_norm_layer_act_execution_time(batch)
+        attention_time = self._get_profiled_gdn_predictor().predict_attention_time(
+            batch,
+            norm_time_ms=norm_time,
+        )
+        cluster_name = cluster_type.name
+        for op_name, predicted_time_ms in attention_time.operator_times.op_times.items():
+            logger.info(
+                "[OP-TRACE][%s][GDN][%s] batch_id=%s, layer_id=%s, "
+                "predicted_time_ms=%.6f",
+                cluster_name,
+                op_name,
+                batch.id,
+                layer_id,
+                predicted_time_ms,
+            )
+        logger.info(
+            "[OP-TRACE][%s][GDN][TOTAL] batch_id=%s, layer_id=%s, "
+            "total_attention_time_ms=%.6f",
+            cluster_name,
+            batch.id,
+            layer_id,
+            attention_time.total_time(),
+        )
+        return attention_time
+
+    def _resolve_stage_layer_ids(
+        self,
+        *,
+        stage_id: int,
+        num_layers: int,
+        layer_id: int,
+    ) -> tuple[int, ...]:
+        if type(stage_id) is not int or stage_id < 0:
+            raise ValueError(f"stage_id must be a non-negative integer, got {stage_id!r}")
+        if type(num_layers) is not int or num_layers <= 0:
+            raise ValueError(f"num_layers must be a positive integer, got {num_layers!r}")
+        if type(layer_id) is not int or layer_id < 0:
+            raise ValueError(f"layer_id must be a non-negative integer, got {layer_id!r}")
+        if num_layers == 1:
+            layer_ids = (layer_id,)
+        elif layer_id != 0:
+            layer_ids = tuple(range(layer_id, layer_id + num_layers))
+        else:
+            first_layer_id = stage_id * self._num_layers_per_pipeline_stage
+            layer_ids = tuple(range(first_layer_id, first_layer_id + num_layers))
+        if layer_ids[-1] >= int(self._model_config.num_layers):
+            raise ValueError(
+                "Stage layer range exceeds model depth: "
+                f"layer_ids={layer_ids[0]}..{layer_ids[-1]}, "
+                f"num_layers={self._model_config.num_layers}"
+            )
+        return layer_ids
+
+    @staticmethod
+    def _average_attention_times(
+        attention_times: List[AttentionTime],
+    ) -> AttentionTime:
+        if not attention_times:
+            raise ValueError("Cannot average an empty attention-time collection")
+        count = float(len(attention_times))
+        numeric_fields = (
+            "attention_prefill_execution_time",
+            "attention_decode_execution_time",
+            "attention_layer_pre_proj_execution_time",
+            "attention_layer_post_proj_execution_time",
+            "attention_rope_execution_time",
+            "attention_kv_cache_save_execution_time",
+            "attn_mla_kv_cache_save_time",
+            "attn_mla_prefill_kv_up_proj_time",
+            "attn_mla_prefill_time",
+            "attn_mla_decode_q_latent_proj_time",
+            "attn_mla_decode_time",
+            "attn_mla_v_up_proj_time",
+            "attn_norm_time",
+            "attn_inter_norm_time",
+            "attn_wq_proj_time",
+        )
+        averaged = {
+            field_name: sum(
+                float(getattr(attention_time, field_name))
+                for attention_time in attention_times
+            )
+            / count
+            for field_name in numeric_fields
+        }
+
+        # Structured maps can be averaged only when every layer exposes the
+        # same physical family. A hybrid full-attention/GDN stage deliberately
+        # falls back to its exact averaged legacy carriers to avoid subtracting
+        # one family's projection field from another family's timing.
+        operator_maps = [
+            attention_time.operator_times for attention_time in attention_times
+        ]
+        operator_times = None
+        if all(mapping is not None for mapping in operator_maps):
+            key_sets = [set(mapping.op_times) for mapping in operator_maps]
+            if all(keys == key_sets[0] for keys in key_sets[1:]):
+                operator_times = AttentionOperatorTimes(
+                    {
+                        op_name: sum(
+                            float(mapping.op_times[op_name])
+                            for mapping in operator_maps
+                        )
+                        / count
+                        for op_name in sorted(key_sets[0])
+                    }
+                )
+        return AttentionTime(operator_times=operator_times, **averaged)
+
+    def _predict_stage_attention_time(
+        self,
+        *,
+        batch: Batch,
+        stage_id: int,
+        num_layers: int,
+        layer_id: int,
+        cluster_type: ClusterType,
+    ) -> AttentionTime:
+        if not self._model_has_gdn_layers():
+            return self.predict_attention_layer_time(
+                batch=batch,
+                layer_id=layer_id,
+                cluster_type=cluster_type,
+            )
+        layer_ids = self._resolve_stage_layer_ids(
+            stage_id=stage_id,
+            num_layers=num_layers,
+            layer_id=layer_id,
+        )
+        if len(layer_ids) == 1:
+            return self.predict_attention_layer_time(
+                batch=batch,
+                layer_id=layer_ids[0],
+                cluster_type=cluster_type,
+            )
+        return self._average_attention_times(
+            [
+                self.predict_attention_layer_time(
+                    batch=batch,
+                    layer_id=current_layer_id,
+                    cluster_type=cluster_type,
+                )
+                for current_layer_id in layer_ids
+            ]
+        )
+
     def predict_attention_layer_time(
         self, batch: Batch, layer_id: int, cluster_type: ClusterType
     ) -> AttentionTime:
@@ -7381,6 +7607,13 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         if not self._supports_operation("attention"):
             raise NotImplementedError(
                 f"Attention operations not supported for cluster type {cluster_type}"
+            )
+
+        if self._is_gdn_layer(layer_id):
+            return self._predict_gdn_attention_layer_time(
+                batch=batch,
+                layer_id=layer_id,
+                cluster_type=cluster_type,
             )
 
         if attention_family.family_id == LATENT_MLA_ATTENTION_FAMILY.family_id:
@@ -7993,8 +8226,10 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         # IMPORTANT: attention must come from predict_attention_layer_time()
         # so the main execution path consumes speculative verify routing and
         # proposer-overhead logic implemented there.
-        attention_time = self.predict_attention_layer_time(
+        attention_time = self._predict_stage_attention_time(
             batch=batch,
+            stage_id=stage_id,
+            num_layers=num_layers,
             layer_id=layer_id,
             cluster_type=cluster_type,
         )

--- a/frontier/execution_time_predictor/sklearn_moe_execution_time_predictor.py
+++ b/frontier/execution_time_predictor/sklearn_moe_execution_time_predictor.py
@@ -2164,6 +2164,7 @@ class SklearnMoEExecutionTimePredictor(SklearnExecutionTimePredictor):
         include_ffn: bool = True,
         include_attention: bool = True,
         layer_id: int = 0,
+        attention_time_override: Optional[AttentionTime] = None,
     ) -> "ExecutionTime":
         """
         Calculate execution time for a pipeline stage.
@@ -2208,14 +2209,22 @@ class SklearnMoEExecutionTimePredictor(SklearnExecutionTimePredictor):
             include_moe=include_moe,
         )
 
-        attention_time = (
-            self.predict_attention_layer_time(
-                batch=batch,
-                layer_id=layer_id,
-                cluster_type=self._cluster_type,
+        if attention_time_override is not None and not include_attention:
+            raise ValueError(
+                "attention_time_override requires include_attention=True"
             )
-            if include_attention
-            else AttentionTime()
+        attention_time = (
+            attention_time_override
+            if attention_time_override is not None
+            else (
+                self.predict_attention_layer_time(
+                    batch=batch,
+                    layer_id=layer_id,
+                    cluster_type=self._cluster_type,
+                )
+                if include_attention
+                else AttentionTime()
+            )
         )
 
         communication_operator_times: dict[str, float] = {}
@@ -3306,6 +3315,16 @@ class SklearnMoEExecutionTimePredictor(SklearnExecutionTimePredictor):
                 layer_id,
             )
 
+        attention_time_override = None
+        if include_attention and num_layers > 1 and self._model_has_gdn_layers():
+            attention_time_override = self._predict_stage_attention_time(
+                batch=batch,
+                stage_id=stage_id,
+                num_layers=num_layers,
+                layer_id=layer_id,
+                cluster_type=cluster_type,
+            )
+
         base_execution_time = self._get_execution_time_internal(
             batch,
             stage_id,
@@ -3314,6 +3333,7 @@ class SklearnMoEExecutionTimePredictor(SklearnExecutionTimePredictor):
             include_ffn=include_ffn,
             include_attention=include_attention,
             layer_id=layer_id,
+            attention_time_override=attention_time_override,
         )
 
         # Communication OP-TRACE: log per-layer allreduce times for op-level comparison

--- a/frontier/gdn/__init__.py
+++ b/frontier/gdn/__init__.py
@@ -1,0 +1,18 @@
+"""Gated-delta-network structural contracts."""
+
+from frontier.gdn.config import (
+    GatedDeltaNetConfig,
+    GatedDeltaNetStateLayout,
+    SequenceMixerType,
+    build_sequence_mixer_schedule,
+)
+from frontier.gdn.family import GATED_DELTA_NET_FAMILY, GatedDeltaNetFamilySpec
+
+__all__ = [
+    "GatedDeltaNetConfig",
+    "GatedDeltaNetStateLayout",
+    "SequenceMixerType",
+    "build_sequence_mixer_schedule",
+    "GATED_DELTA_NET_FAMILY",
+    "GatedDeltaNetFamilySpec",
+]

--- a/frontier/gdn/config.py
+++ b/frontier/gdn/config.py
@@ -1,0 +1,250 @@
+"""Model-owned gated-delta-network shape and layer-schedule contracts.
+
+The simulator and profiler both consume these helpers.  Keeping the schedule
+normalization and state-shape arithmetic here prevents the two configuration
+types from developing subtly different Qwen3.5 semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+
+class SequenceMixerType(str, Enum):
+    """The sequence-mixing block used by one decoder layer."""
+
+    FULL_ATTENTION = "full_attention"
+    GATED_DELTA_NET = "gated_delta_net"
+
+    @classmethod
+    def from_config_value(cls, value: object) -> "SequenceMixerType":
+        if isinstance(value, cls):
+            return value
+        normalized = str(value).strip().lower()
+        aliases = {
+            "full_attention": cls.FULL_ATTENTION,
+            "attention": cls.FULL_ATTENTION,
+            "linear_attention": cls.GATED_DELTA_NET,
+            "gated_delta_net": cls.GATED_DELTA_NET,
+            "gdn": cls.GATED_DELTA_NET,
+        }
+        try:
+            return aliases[normalized]
+        except KeyError as exc:
+            raise ValueError(
+                "Unsupported sequence-mixer layer type "
+                f"{value!r}; expected one of {sorted(aliases)}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class GatedDeltaNetStateLayout:
+    """Per-worker mutable state shapes for one GDN layer and request slot."""
+
+    conv_state_shape: tuple[int, int]
+    recurrent_state_shape: tuple[int, int, int]
+    conv_bytes_per_element: int
+    recurrent_bytes_per_element: int
+
+    def __post_init__(self) -> None:
+        if any(dimension <= 0 for dimension in self.conv_state_shape):
+            raise ValueError(
+                f"conv_state_shape must be positive, got {self.conv_state_shape}"
+            )
+        if any(dimension <= 0 for dimension in self.recurrent_state_shape):
+            raise ValueError(
+                "recurrent_state_shape must be positive, got "
+                f"{self.recurrent_state_shape}"
+            )
+        if self.conv_bytes_per_element <= 0:
+            raise ValueError(
+                "conv_bytes_per_element must be positive, got "
+                f"{self.conv_bytes_per_element}"
+            )
+        if self.recurrent_bytes_per_element <= 0:
+            raise ValueError(
+                "recurrent_bytes_per_element must be positive, got "
+                f"{self.recurrent_bytes_per_element}"
+            )
+
+    @staticmethod
+    def _num_elements(shape: Iterable[int]) -> int:
+        result = 1
+        for dimension in shape:
+            result *= int(dimension)
+        return result
+
+    @property
+    def conv_state_elements(self) -> int:
+        return self._num_elements(self.conv_state_shape)
+
+    @property
+    def recurrent_state_elements(self) -> int:
+        return self._num_elements(self.recurrent_state_shape)
+
+    @property
+    def total_elements(self) -> int:
+        return self.conv_state_elements + self.recurrent_state_elements
+
+    @property
+    def total_bytes(self) -> int:
+        return (
+            self.conv_state_elements * self.conv_bytes_per_element
+            + self.recurrent_state_elements * self.recurrent_bytes_per_element
+        )
+
+
+@dataclass(frozen=True)
+class GatedDeltaNetConfig:
+    """Architecture parameters required to model a Qwen-style GDN layer."""
+
+    conv_kernel_size: int
+    key_head_dim: int
+    value_head_dim: int
+    num_key_heads: int
+    num_value_heads: int
+    output_gate_type: str = "silu"
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "conv_kernel_size",
+            "key_head_dim",
+            "value_head_dim",
+            "num_key_heads",
+            "num_value_heads",
+        ):
+            value = int(getattr(self, field_name))
+            if value <= 0:
+                raise ValueError(f"GDN {field_name} must be positive, got {value}")
+        normalized_gate = str(self.output_gate_type).strip().lower()
+        if normalized_gate == "swish":
+            normalized_gate = "silu"
+        if normalized_gate not in {"silu", "sigmoid"}:
+            raise ValueError(
+                "GDN output_gate_type must be silu/swish or sigmoid, got "
+                f"{self.output_gate_type!r}"
+            )
+        object.__setattr__(self, "output_gate_type", normalized_gate)
+
+    @property
+    def key_dim(self) -> int:
+        return self.num_key_heads * self.key_head_dim
+
+    @property
+    def value_dim(self) -> int:
+        return self.num_value_heads * self.value_head_dim
+
+    @property
+    def conv_dim(self) -> int:
+        return 2 * self.key_dim + self.value_dim
+
+    def get_state_layout(
+        self,
+        *,
+        tensor_parallel_size: int,
+        num_speculative_tokens: int = 0,
+        conv_bytes_per_element: int = 2,
+        recurrent_bytes_per_element: int = 4,
+    ) -> GatedDeltaNetStateLayout:
+        """Match vLLM's Qwen GDN conv and recurrent cache shapes.
+
+        The physical conv-state orientation is runtime-configurable in vLLM;
+        orientation does not affect its element or byte count, so Frontier uses
+        the stable ``(width, channels)`` representation.
+        """
+
+        tp_size = int(tensor_parallel_size)
+        if tp_size <= 0:
+            raise ValueError(
+                f"tensor_parallel_size must be positive, got {tensor_parallel_size}"
+            )
+        if int(num_speculative_tokens) < 0:
+            raise ValueError(
+                "num_speculative_tokens must be non-negative, got "
+                f"{num_speculative_tokens}"
+            )
+        if self.num_key_heads % tp_size != 0:
+            raise ValueError(
+                "GDN key heads must be divisible by tensor_parallel_size: "
+                f"num_key_heads={self.num_key_heads}, tp={tp_size}"
+            )
+        if self.num_value_heads % tp_size != 0:
+            raise ValueError(
+                "GDN value heads must be divisible by tensor_parallel_size: "
+                f"num_value_heads={self.num_value_heads}, tp={tp_size}"
+            )
+        if self.conv_dim % tp_size != 0:
+            raise ValueError(
+                "GDN convolution channels must be divisible by "
+                f"tensor_parallel_size: conv_dim={self.conv_dim}, tp={tp_size}"
+            )
+
+        conv_width = self.conv_kernel_size - 1 + int(num_speculative_tokens)
+        return GatedDeltaNetStateLayout(
+            conv_state_shape=(conv_width, self.conv_dim // tp_size),
+            recurrent_state_shape=(
+                self.num_value_heads // tp_size,
+                self.value_head_dim,
+                self.key_head_dim,
+            ),
+            # vLLM 0.28 resolves Qwen3.5's default ``auto`` cache policy to
+            # BF16 convolution state and FP32 recurrent state. Callers may
+            # override these independently when profiling another policy.
+            conv_bytes_per_element=int(conv_bytes_per_element),
+            recurrent_bytes_per_element=int(recurrent_bytes_per_element),
+        )
+
+
+def build_sequence_mixer_schedule(
+    *,
+    num_layers: int,
+    layer_types: Sequence[object] | None,
+    full_attention_interval: int | None,
+    has_gated_delta_net: bool,
+) -> tuple[SequenceMixerType, ...]:
+    """Normalize explicit or interval-derived decoder layer types."""
+
+    normalized_num_layers = int(num_layers)
+    if normalized_num_layers <= 0:
+        raise ValueError(f"num_layers must be positive, got {num_layers}")
+
+    if layer_types is not None:
+        schedule = tuple(
+            SequenceMixerType.from_config_value(layer_type)
+            for layer_type in layer_types
+        )
+        if len(schedule) != normalized_num_layers:
+            raise ValueError(
+                "layer_types length must equal num_layers: "
+                f"len(layer_types)={len(schedule)}, num_layers={normalized_num_layers}"
+            )
+    elif full_attention_interval is not None:
+        interval = int(full_attention_interval)
+        if interval <= 0:
+            raise ValueError(
+                "full_attention_interval must be positive, got "
+                f"{full_attention_interval}"
+            )
+        schedule = tuple(
+            SequenceMixerType.GATED_DELTA_NET
+            if (layer_id + 1) % interval
+            else SequenceMixerType.FULL_ATTENTION
+            for layer_id in range(normalized_num_layers)
+        )
+    else:
+        schedule = (SequenceMixerType.FULL_ATTENTION,) * normalized_num_layers
+
+    contains_gdn = SequenceMixerType.GATED_DELTA_NET in schedule
+    if contains_gdn and not has_gated_delta_net:
+        raise ValueError(
+            "The decoder layer schedule contains gated-delta-network layers, "
+            "but the GDN shape configuration is incomplete"
+        )
+    if has_gated_delta_net and not contains_gdn:
+        raise ValueError(
+            "GDN shape fields are configured, but layer_types/full_attention_interval "
+            "does not select any gated-delta-network layers"
+        )
+    return schedule

--- a/frontier/gdn/family.py
+++ b/frontier/gdn/family.py
@@ -1,0 +1,113 @@
+"""Declarative operator family for gated-delta-network sequence mixing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from frontier.operators.spec import (
+    OperatorFamilySpec,
+    OperatorPhase,
+    OperatorRole,
+    OperatorSpec,
+    ProjectionOwnership,
+    ResourceClass,
+)
+
+
+@dataclass(frozen=True)
+class GatedDeltaNetFamilySpec(OperatorFamilySpec):
+    """GDN operator catalog plus its profiling feature contract."""
+
+    required_profiling_feature_columns: tuple[str, ...] = ()
+
+
+_ALL_PHASES = (
+    OperatorPhase.PREFILL,
+    OperatorPhase.DECODE,
+    OperatorPhase.MIXED,
+)
+
+
+GATED_DELTA_NET_FAMILY = GatedDeltaNetFamilySpec(
+    family_id="gated_delta_net",
+    display_name="Gated Delta Network",
+    supported_variants=("qwen3_5",),
+    operators=(
+        OperatorSpec(
+            name="gdn_input_projections",
+            role=OperatorRole.PROJECTION,
+            phases=_ALL_PHASES,
+            execution_time_attr="attention_layer_pre_proj_execution_time",
+            resource_class=ResourceClass.COMP,
+            projection_ownership=ProjectionOwnership.OUTSIDE_ATTENTION,
+        ),
+        OperatorSpec(
+            name="gdn_core_prefill",
+            role=OperatorRole.PREFILL_KERNEL,
+            phases=(OperatorPhase.PREFILL,),
+            execution_time_attr="attention_prefill_execution_time",
+            resource_class=ResourceClass.COMP,
+        ),
+        OperatorSpec(
+            name="gdn_core_decode",
+            role=OperatorRole.DECODE_KERNEL,
+            phases=(OperatorPhase.DECODE,),
+            execution_time_attr="attention_decode_execution_time",
+            resource_class=ResourceClass.COMP,
+        ),
+        OperatorSpec(
+            name="gdn_core_mixed",
+            role=OperatorRole.MIXED_KERNEL,
+            phases=(OperatorPhase.MIXED,),
+            # The structured operator map owns the physical identity.  The
+            # legacy prefill field is used only as a compatibility carrier.
+            execution_time_attr="attention_prefill_execution_time",
+            resource_class=ResourceClass.COMP,
+        ),
+        OperatorSpec(
+            name="gdn_output_projection",
+            role=OperatorRole.PROJECTION,
+            phases=_ALL_PHASES,
+            execution_time_attr="attention_layer_post_proj_execution_time",
+            resource_class=ResourceClass.COMP,
+            projection_ownership=ProjectionOwnership.OUTSIDE_ATTENTION,
+        ),
+    ),
+    resource_class=ResourceClass.COMP,
+    profiling_order=(
+        "gdn_input_projections",
+        "gdn_core_prefill",
+        "gdn_core_decode",
+        "gdn_core_mixed",
+        "gdn_output_projection",
+    ),
+    required_profiling_feature_columns=(
+        "measurement_type",
+        "model_architecture_profile",
+        "quant_signature",
+        "device",
+        "runtime_stack_signature",
+        "gdn_runtime_backend",
+        "gdn_rank_aggregation",
+        "gdn_prefill_backend",
+        "gdn_decode_backend",
+        "gqa_interleaved_layout",
+        "packed_recurrent_decode",
+        "model_dtype",
+        "conv_state_dtype",
+        "recurrent_state_dtype",
+        "num_tensor_parallel_workers",
+        "hidden_size",
+        "conv_kernel_size",
+        "key_head_dim",
+        "value_head_dim",
+        "num_key_heads",
+        "num_value_heads",
+        "batch_size",
+        "batch_num_tokens",
+        "batch_num_prefill_tokens",
+        "batch_num_decode_tokens",
+        "max_query_len",
+        "has_initial_state",
+    ),
+)

--- a/frontier/gdn/predictor.py
+++ b/frontier/gdn/predictor.py
@@ -1,0 +1,381 @@
+"""Profile-backed execution-time prediction for gated-delta-network layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+
+from frontier.entities.time_components import AttentionOperatorTimes, AttentionTime
+from frontier.gdn.family import GATED_DELTA_NET_FAMILY
+from frontier.gdn.profiling_schema import validate_gdn_profiling_dataframe
+from frontier.types import MeasurementType
+
+
+_FEATURE_COLUMNS = (
+    "batch_size",
+    "batch_num_tokens",
+    "batch_num_prefill_tokens",
+    "batch_num_decode_tokens",
+    "max_query_len",
+    "has_initial_state",
+)
+
+
+def _coerce_bool(value: Any, *, field_name: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
+        return bool(value)
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1"}:
+        return True
+    if normalized in {"false", "0"}:
+        return False
+    raise ValueError(f"{field_name} must contain boolean values, got {value!r}")
+
+
+@dataclass(frozen=True)
+class GDNBatchFeatures:
+    """Runtime features shared by the profiler and prediction path."""
+
+    batch_size: int
+    batch_num_tokens: int
+    batch_num_prefill_tokens: int
+    batch_num_decode_tokens: int
+    max_query_len: int
+    has_initial_state: bool
+
+    def __post_init__(self) -> None:
+        if self.batch_size <= 0:
+            raise ValueError("GDN prediction batch_size must be positive")
+        if self.batch_num_tokens <= 0:
+            raise ValueError("GDN prediction batch_num_tokens must be positive")
+        if self.batch_num_prefill_tokens < 0 or self.batch_num_decode_tokens < 0:
+            raise ValueError("GDN prediction token counts must be non-negative")
+        if (
+            self.batch_num_prefill_tokens + self.batch_num_decode_tokens
+            != self.batch_num_tokens
+        ):
+            raise ValueError("GDN prefill/decode token counts must sum to total tokens")
+        if self.max_query_len <= 0:
+            raise ValueError("GDN prediction max_query_len must be positive")
+
+    @property
+    def phase(self) -> str:
+        if self.batch_num_prefill_tokens and self.batch_num_decode_tokens:
+            return "mixed"
+        if self.batch_num_prefill_tokens:
+            return "prefill"
+        return "decode"
+
+    def as_vector(self) -> np.ndarray:
+        # Log scaling keeps token and batch axes useful on the wide profiling
+        # grids used by inference workloads while preserving exact row lookup.
+        return np.asarray(
+            [
+                np.log1p(self.batch_size),
+                np.log1p(self.batch_num_tokens),
+                np.log1p(self.batch_num_prefill_tokens),
+                np.log1p(self.batch_num_decode_tokens),
+                np.log1p(self.max_query_len),
+                float(self.has_initial_state),
+            ],
+            dtype=np.float64,
+        )
+
+    def exact_key(self) -> tuple[int, int, int, int, int, bool]:
+        return (
+            self.batch_size,
+            self.batch_num_tokens,
+            self.batch_num_prefill_tokens,
+            self.batch_num_decode_tokens,
+            self.max_query_len,
+            self.has_initial_state,
+        )
+
+    @classmethod
+    def from_batch(cls, batch: Any) -> "GDNBatchFeatures":
+        query_lens = tuple(int(value) for value in batch.num_tokens)
+        requests = tuple(batch.requests)
+        if not requests or len(query_lens) != len(requests):
+            raise ValueError(
+                "GDN prediction requires one scheduled query length per request"
+            )
+        batch_size = len(requests)
+        prefill_tokens = int(batch.num_prefill_tokens)
+        decode_tokens = int(batch.num_decode_tokens)
+        metadata = getattr(batch, "decode_cuda_graph_metadata", None)
+        if metadata is not None and metadata.runtime_mode == "FULL":
+            # Packed recurrent kernels execute every captured graph lane, even
+            # when only a subset represents real requests. Match the profiled
+            # physical shape while leaving request progress/padding untouched.
+            if prefill_tokens:
+                raise ValueError("Full decode GDN graphs cannot contain prefill tokens")
+            batch_size = int(metadata.padded_decode_batch_size)
+            decode_tokens = int(metadata.padded_total_tokens)
+            if batch_size < len(requests) or decode_tokens != batch_size:
+                raise ValueError("Invalid padded shape for non-speculative GDN decode")
+        return cls(
+            batch_size=batch_size,
+            batch_num_tokens=prefill_tokens + decode_tokens,
+            batch_num_prefill_tokens=prefill_tokens,
+            batch_num_decode_tokens=decode_tokens,
+            max_query_len=max(query_lens),
+            has_initial_state=any(
+                int(getattr(request, "num_processed_tokens", 0)) > 0
+                or bool(getattr(request, "is_prefill_complete", False))
+                for request in requests
+            ),
+        )
+
+    def batch_scaling_key(self) -> tuple[int, bool, float, float]:
+        """Only interpolate batches with identical per-request work/state."""
+        return (self.max_query_len, self.has_initial_state,
+                self.batch_num_prefill_tokens / self.batch_size,
+                self.batch_num_decode_tokens / self.batch_size)
+
+
+@dataclass
+class _OperatorModel:
+    estimator: RandomForestRegressor
+    exact_lookup: Mapping[tuple[int, int, int, int, int, bool], float]
+    batch_scaling_curves: Mapping[tuple[int, bool, float, float], tuple[np.ndarray, np.ndarray]]
+
+    def predict(self, features: GDNBatchFeatures) -> float:
+        exact = self.exact_lookup.get(features.exact_key())
+        if exact is not None:
+            return float(exact)
+        curve = self.batch_scaling_curves.get(features.batch_scaling_key())
+        if curve is not None:
+            sizes, times = curve
+            if len(sizes) >= 2 and sizes[0] <= features.batch_size <= sizes[-1]:
+                # Bounded interpolation preserves the measured endpoints on a
+                # one-dimensional batch sweep. RF bootstrap averages can be
+                # strongly biased on the two-row grids used during bring-up.
+                return float(np.interp(features.batch_size, sizes, times))
+        prediction = float(self.estimator.predict(features.as_vector()[None, :])[0])
+        if not np.isfinite(prediction) or prediction < 0.0:
+            raise ValueError(f"GDN prediction produced invalid time {prediction!r}")
+        return prediction
+
+
+class ProfiledGDNPredictor:
+    """Fit per-operator regressors over one runtime-homogeneous GDN CSV."""
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        *,
+        model_config: Any,
+        device: str,
+        tensor_parallel_size: int,
+        measurement_type: MeasurementType,
+    ) -> None:
+        validate_gdn_profiling_dataframe(dataframe)
+        frame = dataframe.copy()
+        frame["measurement_type"] = frame["measurement_type"].map(
+            lambda value: MeasurementType.from_string(value).value
+        )
+        frame["has_initial_state"] = frame["has_initial_state"].map(
+            lambda value: _coerce_bool(value, field_name="has_initial_state")
+        )
+
+        architecture_profile = (
+            model_config.get_model_architecture_profile().profile_id
+        )
+        expected = {
+            "measurement_type": measurement_type.value,
+            "model_architecture_profile": architecture_profile,
+            "quant_signature": model_config.get_quant_signature(),
+            "device": str(device),
+            "num_tensor_parallel_workers": int(tensor_parallel_size),
+        }
+        for column, expected_value in expected.items():
+            frame = frame[frame[column] == expected_value]
+        if frame.empty:
+            raise ValueError(
+                "GDN profiling data has no rows matching runtime contract: "
+                f"{expected}"
+            )
+
+        gdn_config = model_config.get_gdn_config()
+        if gdn_config is None:
+            raise ValueError("ProfiledGDNPredictor requires GDN model dimensions")
+        dimension_contract = {
+            "hidden_size": int(model_config.embedding_dim),
+            "conv_kernel_size": int(gdn_config.conv_kernel_size),
+            "key_head_dim": int(gdn_config.key_head_dim),
+            "value_head_dim": int(gdn_config.value_head_dim),
+            "num_key_heads": int(gdn_config.num_key_heads),
+            "num_value_heads": int(gdn_config.num_value_heads),
+        }
+        for column, expected_value in dimension_contract.items():
+            mismatches = frame[frame[column].astype(int) != expected_value]
+            if not mismatches.empty:
+                raise ValueError(
+                    f"GDN profiling {column} does not match model: "
+                    f"expected {expected_value}"
+                )
+
+        runtime_columns = (
+            "runtime_stack_signature",
+            "gdn_runtime_backend",
+            "gdn_rank_aggregation",
+            "gdn_prefill_backend",
+            "gdn_decode_backend",
+            "gqa_interleaved_layout",
+            "packed_recurrent_decode",
+            "model_dtype",
+            "conv_state_dtype",
+            "recurrent_state_dtype",
+            "weight_source",
+        )
+        ambiguous = {
+            column: sorted(str(value) for value in frame[column].dropna().unique())
+            for column in runtime_columns
+            if frame[column].nunique(dropna=False) != 1
+        }
+        if ambiguous:
+            raise ValueError(
+                "GDN profiling rows mix incompatible runtime contracts: "
+                f"{ambiguous}"
+            )
+        self.runtime_contract = {
+            column: frame.iloc[0][column] for column in runtime_columns
+        }
+        self.measurement_type = measurement_type
+        self._models: dict[tuple[str, str], _OperatorModel] = {}
+        phases = frame.apply(self._row_phase, axis=1)
+        for phase in ("prefill", "decode", "mixed"):
+            operator_frame = frame[phases == phase]
+            if operator_frame.empty:
+                continue
+            for operator in GATED_DELTA_NET_FAMILY.predictor_ops():
+                if operator.name.startswith("gdn_core_") and operator.name != f"gdn_core_{phase}":
+                    continue
+                # Even shared projection names need phase-specific fits. With
+                # sparse grids, a bootstrap tree can contain only prefill rows
+                # and inject millisecond projections into microsecond decode.
+                # Exact rows retain their existing lookup values.
+                target_column = f"time_stats.{operator.profiling_name()}.median"
+                self._models[(operator.name, phase)] = self._fit_operator_model(
+                    operator_frame, target_column,
+                )
+
+    @staticmethod
+    def _row_phase(row: pd.Series) -> str:
+        if int(row["batch_num_prefill_tokens"]) > 0 and int(
+            row["batch_num_decode_tokens"]
+        ) > 0:
+            return "mixed"
+        if int(row["batch_num_prefill_tokens"]) > 0:
+            return "prefill"
+        return "decode"
+
+    @staticmethod
+    def _row_features(row: pd.Series) -> GDNBatchFeatures:
+        return GDNBatchFeatures(
+            batch_size=int(row["batch_size"]),
+            batch_num_tokens=int(row["batch_num_tokens"]),
+            batch_num_prefill_tokens=int(row["batch_num_prefill_tokens"]),
+            batch_num_decode_tokens=int(row["batch_num_decode_tokens"]),
+            max_query_len=int(row["max_query_len"]),
+            has_initial_state=bool(row["has_initial_state"]),
+        )
+
+    @classmethod
+    def _fit_operator_model(
+        cls,
+        dataframe: pd.DataFrame,
+        target_column: str,
+    ) -> _OperatorModel:
+        if target_column not in dataframe.columns:
+            raise ValueError(f"GDN profiling data is missing target {target_column}")
+        features = [cls._row_features(row) for _, row in dataframe.iterrows()]
+        targets = dataframe[target_column].astype(float).to_numpy()
+        if not np.isfinite(targets).all() or (targets < 0.0).any():
+            raise ValueError(f"GDN target {target_column} contains invalid timings")
+        estimator = RandomForestRegressor(
+            n_estimators=128,
+            max_depth=16,
+            random_state=0,
+            n_jobs=1,
+        )
+        estimator.fit(np.vstack([feature.as_vector() for feature in features]), targets)
+        exact_lookup: dict[tuple[int, int, int, int, int, bool], float] = {}
+        for feature, target in zip(features, targets):
+            key = feature.exact_key()
+            target_value = float(target)
+            previous = exact_lookup.get(key)
+            if previous is not None and not np.isclose(previous, target_value):
+                raise ValueError(
+                    "GDN profiling data has conflicting duplicate feature rows: "
+                    f"key={key}, values=({previous}, {target_value})"
+                )
+            exact_lookup[key] = target_value
+        curves: dict[tuple[int, bool, float, float], dict[int, float]] = {}
+        for feature, target in zip(features, targets):
+            curves.setdefault(feature.batch_scaling_key(), {})[feature.batch_size] = float(target)
+        return _OperatorModel(
+            estimator=estimator, exact_lookup=exact_lookup,
+            batch_scaling_curves={key: (np.asarray(sorted(values)),
+                                        np.asarray([values[size] for size in sorted(values)]))
+                                  for key, values in curves.items()},
+        )
+
+    @classmethod
+    def from_csv(
+        cls,
+        path: str,
+        **kwargs: Any,
+    ) -> "ProfiledGDNPredictor":
+        profile_path = Path(path)
+        if not profile_path.is_file():
+            raise FileNotFoundError(
+                f"GDN profiling file does not exist: {profile_path}"
+            )
+        return cls(pd.read_csv(profile_path), **kwargs)
+
+    def predict_operator_times(self, features: GDNBatchFeatures) -> dict[str, float]:
+        required_names = (
+            "gdn_input_projections",
+            f"gdn_core_{features.phase}",
+            "gdn_output_projection",
+        )
+        missing = [name for name in required_names if (name, features.phase) not in self._models]
+        if missing:
+            raise ValueError(
+                f"GDN profile does not support {features.phase} prediction: {missing}"
+            )
+        return {
+            name: self._models[(name, features.phase)].predict(features) for name in required_names
+        }
+
+    def predict_attention_time(self, batch: Any, *, norm_time_ms: float) -> AttentionTime:
+        features = GDNBatchFeatures.from_batch(batch)
+        op_times = self.predict_operator_times(features)
+        core_name = f"gdn_core_{features.phase}"
+        return AttentionTime(
+            attention_prefill_execution_time=(
+                op_times[core_name] if features.phase != "decode" else 0.0
+            ),
+            attention_decode_execution_time=(
+                op_times[core_name] if features.phase == "decode" else 0.0
+            ),
+            attention_layer_pre_proj_execution_time=op_times[
+                "gdn_input_projections"
+            ],
+            attention_layer_post_proj_execution_time=op_times[
+                "gdn_output_projection"
+            ],
+            attn_norm_time=float(norm_time_ms),
+            operator_times=AttentionOperatorTimes(op_times),
+        )
+
+
+__all__ = ["GDNBatchFeatures", "ProfiledGDNPredictor"]

--- a/frontier/gdn/profiling_schema.py
+++ b/frontier/gdn/profiling_schema.py
@@ -1,0 +1,61 @@
+"""Stable CSV schema helpers for GDN profiling and training."""
+
+from __future__ import annotations
+
+from frontier.gdn.family import GATED_DELTA_NET_FAMILY, GatedDeltaNetFamilySpec
+from frontier.types import MeasurementType
+
+
+_TIME_STAT_SUFFIXES = ("min", "max", "mean", "median", "std", "count")
+
+
+def get_gdn_profiling_metric_names(
+    family: GatedDeltaNetFamilySpec = GATED_DELTA_NET_FAMILY,
+) -> tuple[str, ...]:
+    return tuple(operator.profiling_name() for operator in family.profiling_ops())
+
+
+def get_gdn_profiling_time_stat_columns(
+    family: GatedDeltaNetFamilySpec = GATED_DELTA_NET_FAMILY,
+) -> tuple[str, ...]:
+    return tuple(
+        f"time_stats.{operator_name}.{suffix}"
+        for operator_name in get_gdn_profiling_metric_names(family)
+        for suffix in _TIME_STAT_SUFFIXES
+    )
+
+
+def get_required_gdn_profiling_columns(
+    family: GatedDeltaNetFamilySpec = GATED_DELTA_NET_FAMILY,
+) -> tuple[str, ...]:
+    return (
+        *family.required_profiling_feature_columns,
+        *get_gdn_profiling_time_stat_columns(family),
+        # Validation-only direct module timing. It is deliberately absent
+        # from the predictor operator family to prevent double counting.
+        "time_stats.gdn_layer_e2e.min",
+        "time_stats.gdn_layer_e2e.max",
+        "time_stats.gdn_layer_e2e.mean",
+        "time_stats.gdn_layer_e2e.median",
+        "time_stats.gdn_layer_e2e.std",
+        "time_stats.gdn_layer_e2e.count",
+    )
+
+
+def validate_gdn_profiling_dataframe(
+    dataframe,
+    family: GatedDeltaNetFamilySpec = GATED_DELTA_NET_FAMILY,
+) -> None:
+    missing = [
+        column
+        for column in get_required_gdn_profiling_columns(family)
+        if column not in dataframe.columns
+    ]
+    if missing:
+        raise ValueError(
+            "GDN profiling dataframe is missing required columns: "
+            f"{missing}"
+        )
+
+    for value in dataframe["measurement_type"]:
+        MeasurementType.from_string(value)

--- a/frontier/kv_cache_transfer/analytical_kv_cache_transfer_predictor.py
+++ b/frontier/kv_cache_transfer/analytical_kv_cache_transfer_predictor.py
@@ -37,17 +37,27 @@ class AnalyticalKVCacheTransferPredictor(BaseKVCacheTransferPredictor):
 
     def get_kv_cache_size(self, batch: "Batch", replica_config: "ReplicaConfig") -> int:
         total_tokens = sum(req.num_prefill_tokens for req in batch.requests)
-        return self._calculate_kv_cache_size_for_tokens(total_tokens, replica_config)
+        return self._calculate_kv_cache_size_for_tokens(
+            total_tokens,
+            replica_config,
+            num_requests=len(batch.requests),
+        )
 
     def get_kv_cache_size_for_request(
         self, request: "Request", replica_config: "ReplicaConfig"
     ) -> int:
         return self._calculate_kv_cache_size_for_tokens(
-            request.num_prefill_tokens, replica_config
+            request.num_prefill_tokens,
+            replica_config,
+            num_requests=1,
         )
 
     def _calculate_kv_cache_size_for_tokens(
-        self, num_tokens: int, replica_config: "ReplicaConfig"
+        self,
+        num_tokens: int,
+        replica_config: "ReplicaConfig",
+        *,
+        num_requests: int = 1,
     ) -> int:
         model_config = replica_config.model_config
         family = bind_attention_family(model_config).family
@@ -56,6 +66,16 @@ class AnalyticalKVCacheTransferPredictor(BaseKVCacheTransferPredictor):
             if self._config.override_num_layers is not None
             else model_config.num_layers
         )
+        get_num_gdn_layers = getattr(model_config, "get_num_gdn_layers", None)
+        num_gdn_layers = (
+            int(get_num_gdn_layers()) if callable(get_num_gdn_layers) else 0
+        )
+        if num_gdn_layers and self._config.override_num_layers is not None:
+            raise ValueError(
+                "override_num_layers is ambiguous for a hybrid GDN model; "
+                "use the model-owned full-attention/GDN schedule"
+            )
+        num_full_attention_layers = int(num_layers) - num_gdn_layers
         # Runtime KV layout is family-aware: dense uses (num_kv_heads, head_dim, kv_factor=2);
         # latent MLA collapses to (1, kv_lora_rank + qk_rope_head_dim, kv_factor=1). Overrides,
         # when set, replace the head count / head size but the family still owns kv_factor.
@@ -75,14 +95,32 @@ class AnalyticalKVCacheTransferPredictor(BaseKVCacheTransferPredictor):
             runtime_head_size=head_dim,
         )
         dtype_size = self._get_kv_cache_dtype_size_bytes()
-        return int(
+        dense_kv_bytes = int(
             num_tokens
-            * num_layers
+            * num_full_attention_layers
             * layout.runtime_num_kv_heads_per_worker
             * layout.runtime_head_size
             * layout.kv_factor
             * dtype_size
         )
+        gdn_state_bytes = 0
+        if num_gdn_layers:
+            if num_requests <= 0:
+                raise ValueError(
+                    f"num_requests must be positive for GDN transfer, got={num_requests}"
+                )
+            gdn_config = model_config.get_gdn_config()
+            if gdn_config is None:
+                raise ValueError("GDN layer count is non-zero but dimensions are absent")
+            # Transfer accounting covers the whole model state across TP shards,
+            # so use TP=1 for the total logical state size.
+            state_bytes_per_layer = gdn_config.get_state_layout(
+                tensor_parallel_size=1,
+            ).total_bytes
+            gdn_state_bytes = (
+                int(num_requests) * num_gdn_layers * state_bytes_per_layer
+            )
+        return dense_kv_bytes + gdn_state_bytes
 
     def _get_kv_cache_dtype_size_bytes(self) -> float:
         quant_manager = get_quantization_manager()

--- a/frontier/model_architectures.py
+++ b/frontier/model_architectures.py
@@ -422,6 +422,7 @@ class ModelArchitectureProfile:
     share_expert_tensor_parallel_allreduce_op: str | None = None
     always_supports_share_expert: bool = False
     counts_share_expert_param_memory: bool = False
+    sequence_mixer_family_ids: tuple[str, ...] = ("dense_attention",)
     structural_requirements: tuple[StructuralRequirement, ...] = ()
     match: ArchitectureMatcher = field(default=lambda _config: False, repr=False, compare=False)
     layer_contracts: tuple[LayerContractSpec, ...] = field(
@@ -433,6 +434,20 @@ class ModelArchitectureProfile:
             raise ValueError("model architecture profile_id must be non-empty")
         if not self.display_name:
             raise ValueError("model architecture display_name must be non-empty")
+        if not self.sequence_mixer_family_ids or any(
+            not family_id for family_id in self.sequence_mixer_family_ids
+        ):
+            raise ValueError(
+                "model architecture sequence_mixer_family_ids must contain "
+                "non-empty identifiers"
+            )
+        if len(set(self.sequence_mixer_family_ids)) != len(
+            self.sequence_mixer_family_ids
+        ):
+            raise ValueError(
+                "model architecture sequence_mixer_family_ids contains duplicates: "
+                f"{self.sequence_mixer_family_ids}"
+            )
         if self.attention_shape_log_kind is not None and not self.attention_shape_log_kind:
             raise ValueError(
                 "model architecture attention_shape_log_kind must be non-empty "
@@ -590,6 +605,35 @@ class ModelArchitectureProfile:
                     activation_predicate=_shared_layer_contract_active,
                 ),
             ),
+        )
+
+    @classmethod
+    def qwen3_5_moe(
+        cls,
+        profile_id: str = "qwen3_5_moe",
+        match: ArchitectureMatcher | None = None,
+    ) -> "ModelArchitectureProfile":
+        """Qwen3.5 hybrid GDN/full-attention decoder contract."""
+
+        return cls(
+            profile_id=profile_id,
+            display_name="Qwen3.5 MoE Hybrid GDN",
+            linear_attention=LinearAttentionProfile(
+                # ``linear_attention`` here is the historical Frontier name
+                # for model projection profiling, not the GDN mixer itself.
+                sharded_impl=LinearAttentionImplementation.GENERIC,
+                sharded_ops=(
+                    "attn_pre_proj",
+                    "attn_rope",
+                    "attn_post_proj",
+                ),
+            ),
+            expert_parallel_collective=ExpertParallelCollective.ALLTOALL,
+            sequence_mixer_family_ids=("gated_delta_net", "dense_attention"),
+            structural_requirements=(
+                _requires_qwen3_5_hybrid_gdn_contract(),
+            ),
+            match=match or _matches_qwen3_5_moe,
         )
 
     def validate_structural_requirements(self, config: Any) -> None:
@@ -1005,6 +1049,38 @@ def _matches_step3_text(config: Any) -> bool:
     return _normalized_attr(config, "model_type") == "step3_text"
 
 
+def _matches_qwen3_5_moe(config: Any) -> bool:
+    return _normalized_attr(config, "model_type") == "qwen3_5_moe_text"
+
+
+def _requires_qwen3_5_hybrid_gdn_contract() -> StructuralRequirement:
+    def predicate(config: Any) -> bool:
+        get_gdn_config = getattr(config, "get_gdn_config", None)
+        get_num_gdn_layers = getattr(config, "get_num_gdn_layers", None)
+        get_num_full_attention_layers = getattr(
+            config, "get_num_full_attention_layers", None
+        )
+        return (
+            bool(getattr(config, "is_moe", False))
+            and callable(get_gdn_config)
+            and get_gdn_config() is not None
+            and callable(get_num_gdn_layers)
+            and int(get_num_gdn_layers()) > 0
+            and callable(get_num_full_attention_layers)
+            and int(get_num_full_attention_layers()) > 0
+        )
+
+    return StructuralRequirement(
+        name="requires_qwen3_5_hybrid_gdn_contract",
+        predicate=predicate,
+        message=lambda profile, config: (
+            f"{profile.display_name} profile {profile.profile_id} requires an "
+            "MoE model with complete GDN dimensions and both gated-delta-net "
+            f"and full-attention layers. Model: {_model_identifier(config)}"
+        ),
+    )
+
+
 class ModelArchitectureRegistry:
     """Ordered plugin registry for model architecture profiles."""
 
@@ -1050,6 +1126,7 @@ MODEL_ARCHITECTURE_REGISTRY = ModelArchitectureRegistry()
 for _profile in (
     ModelArchitectureProfile.step3_text(),
     ModelArchitectureProfile.step2_mini(),
+    ModelArchitectureProfile.qwen3_5_moe(),
     ModelArchitectureProfile.generic(),
 ):
     MODEL_ARCHITECTURE_REGISTRY.register(_profile)

--- a/frontier/operators/families.py
+++ b/frontier/operators/families.py
@@ -11,7 +11,9 @@ from frontier.config.parallel_semantics import (
     resolve_shared_expert_tensor_parallel_mode,
     resolve_shared_expert_tensor_parallel_size,
 )
+from frontier.gdn.family import GATED_DELTA_NET_FAMILY
 from frontier.operators.registry import OperatorRegistry
+from frontier.operators.sglang_family import SGLANG_RUNTIME_FAMILY
 from frontier.operators.spec import (
     CommOperatorSpec,
     CommPayloadContext,
@@ -635,12 +637,14 @@ for _family in (
     DENSE_ATTENTION_FAMILY,
     LATENT_MLA_ATTENTION_FAMILY,
     DSA_ATTENTION_FAMILY,
+    GATED_DELTA_NET_FAMILY,
     MEMORY_FAMILY,
     FFN_FAMILY,
     MOE_FAMILY,
     SHARE_EXPERT_FAMILY,
     COMM_FAMILY,
     KV_TRANSFER_FAMILY,
+    SGLANG_RUNTIME_FAMILY,
 ):
     OPERATOR_REGISTRY.register(_family)
 

--- a/frontier/operators/sglang_family.py
+++ b/frontier/operators/sglang_family.py
@@ -1,0 +1,75 @@
+"""Physical SGLang Qwen hybrid boundaries, selected only by the runtime adapter.
+
+Legacy attributes are aggregation carriers, not claims that fused work is the
+corresponding unfused operator. The structured names retain physical identity.
+Registering this family does not select it for existing model profiles.
+"""
+
+from frontier.operators.spec import (
+    OperatorFamilySpec, OperatorPhase, OperatorRole, OperatorSpec,
+    ResourceClass, TensorParallelMode, TraceKind,
+)
+
+
+SGLANG_RUNTIME_CONTRACT = "sglang_qwen35_rocm_separate_shared_v1"
+
+# component, legacy carrier, component group
+_BOUNDARIES = (
+    ("input_layernorm", "attn_norm_time", "attention"),
+    ("gdn_input_projections", "attention_layer_pre_proj_execution_time", "attention"),
+    ("gdn_core_decode", "attention_decode_execution_time", "attention"),
+    ("gdn_output_projection", "attention_layer_post_proj_execution_time", "attention"),
+    ("attn_pre_proj_qknorm", "attention_layer_pre_proj_execution_time", "attention"),
+    ("attn_rope", "attention_rope_execution_time", "attention"),
+    ("attn_kv_cache_write", "attention_kv_cache_save_execution_time", "attention"),
+    ("attn_decode", "attention_decode_execution_time", "attention"),
+    ("attn_post_proj_gate", "attention_layer_post_proj_execution_time", "attention"),
+    ("attention_tp_allreduce", "attn_tensor_parallel_allreduce_time", "communication"),
+    ("post_attention_layernorm", "mlp_norm_time", "moe"),
+    ("shared_expert_gate_up", "share_expert_up_proj_time", "moe"),
+    ("shared_expert_activation", "share_expert_act_time", "moe"),
+    ("shared_expert_down", "share_expert_down_proj_time", "moe"),
+    ("moe_router_linear", "moe_gating_linear_time", "moe"),
+    ("moe_routing_topk", "moe_gating_routing_topk_time", "moe"),
+    ("moe_sorting", "moe_shuffling_time", "moe"),
+    ("moe_experts_quant_gemm_combine", "moe_grouped_gemm_time", "moe"),
+    ("shared_gate_sigmoid_mul_add", "share_expert_act_time", "moe"),
+    # ONE reduction after combining routed and shared expert output. The
+    # independent shared-expert reduction carrier must remain zero.
+    ("mlp_tp_allreduce", "moe_tensor_parallel_allreduce_time", "communication"),
+)
+_BOUNDARY_NAMES = frozenset(row[0] for row in _BOUNDARIES)
+
+
+def runtime_operator_name(component: str) -> str:
+    if component not in _BOUNDARY_NAMES:
+        raise ValueError(f"Unsupported SGLang runtime boundary: {component}")
+    return f"sglang_{component}"
+
+
+def runtime_operator_attrs(group: str | None = None) -> dict[str, str]:
+    return {runtime_operator_name(name): attr for name, attr, owner in _BOUNDARIES
+            if group is None or owner == group}
+
+
+SGLANG_RUNTIME_FAMILY = OperatorFamilySpec(
+    family_id="sglang_runtime", display_name="SGLang Qwen Hybrid Runtime",
+    supported_variants=(SGLANG_RUNTIME_CONTRACT,),
+    operators=tuple(OperatorSpec(
+        name=runtime_operator_name(name),
+        role=OperatorRole.COMMUNICATION if group == "communication" else OperatorRole.DECODE_KERNEL,
+        phases=(OperatorPhase.DECODE,),
+        execution_time_attr=attr,
+        resource_class=ResourceClass.COMM if group == "communication" else ResourceClass.COMP,
+        trace_kind=TraceKind.COMM if group == "communication" else TraceKind.COMPUTE,
+        # This family has its own strict profile contract, not linear_op.csv
+        # aliases or automatic generic profiling/training targets.
+        profiling_target=False, predictor_target=False,
+        tp_mode=(TensorParallelMode.REPLICATED if name in {
+            "input_layernorm", "post_attention_layernorm", "moe_router_linear",
+            "moe_routing_topk", "shared_gate_sigmoid_mul_add",
+        } else TensorParallelMode.MOE_TP if name in {
+            "moe_sorting", "moe_experts_quant_gemm_combine", "mlp_tp_allreduce",
+        } else TensorParallelMode.ATTENTION_TP),
+    ) for name, attr, group in _BOUNDARIES),
+)

--- a/frontier/operators/spec.py
+++ b/frontier/operators/spec.py
@@ -19,6 +19,7 @@ class OperatorRole(Enum):
     CACHE_WRITE = "cache_write"
     PREFILL_KERNEL = "prefill_kernel"
     DECODE_KERNEL = "decode_kernel"
+    MIXED_KERNEL = "mixed_kernel"
     PROJECTION = "projection"
     ACTIVATION = "activation"
     NORMALIZATION = "normalization"

--- a/frontier/profiling/attention/backends/__init__.py
+++ b/frontier/profiling/attention/backends/__init__.py
@@ -8,6 +8,7 @@ class AttentionBackend(Enum):
     """Attention backend types for profiling."""
 
     FLASHINFER = "FLASHINFER"
+    VLLM_ROCM = "VLLM_ROCM"
     NO_OP = "NO_OP"
 
 
@@ -50,6 +51,12 @@ def get_attention_wrapper():
         )
 
         return FlashinferAttentionWrapper.get_instance()
+    elif ATTENTION_BACKEND == AttentionBackend.VLLM_ROCM:
+        from frontier.profiling.attention.backends.vllm_rocm_attention_wrapper import (
+            VllmRocmAttentionWrapper,
+        )
+
+        return VllmRocmAttentionWrapper.get_instance()
     elif ATTENTION_BACKEND == AttentionBackend.NO_OP:
         from frontier.profiling.attention.backends.no_op_attention_wrapper import (
             NoOpAttentionWrapper,
@@ -79,6 +86,12 @@ def __getattr__(name: str):
         )
 
         return NoOpAttentionWrapper
+    if name == "VllmRocmAttentionWrapper":
+        from frontier.profiling.attention.backends.vllm_rocm_attention_wrapper import (
+            VllmRocmAttentionWrapper,
+        )
+
+        return VllmRocmAttentionWrapper
     raise AttributeError(name)
 
 
@@ -86,6 +99,7 @@ __all__ = [
     "AttentionBackend",
     "BaseAttentionWrapper",
     "FlashinferAttentionWrapper",
+    "VllmRocmAttentionWrapper",
     "NoOpAttentionWrapper",
     "set_attention_backend",
     "get_attention_wrapper",

--- a/frontier/profiling/attention/backends/vllm_rocm_attention_wrapper.py
+++ b/frontier/profiling/attention/backends/vllm_rocm_attention_wrapper.py
@@ -1,0 +1,324 @@
+"""vLLM ROCm attention backend for Frontier profiling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import List, Optional
+
+import torch
+
+from frontier.attention.model_binding import bind_attention_family
+from frontier.attention.ops import AttentionMemoryLayout
+from frontier.profiling.attention.backends.base_attention_wrapper import (
+    BaseAttentionWrapper,
+)
+from frontier.profiling.attention.sequence_metadata import SequenceMetadata
+from frontier.profiling.common.constants import OperationMetrics
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.common.parallel_config import ParallelConfig
+
+
+@dataclass(frozen=True)
+class RocmSequencePlan:
+    """CPU-side metadata needed to materialize one ROCm attention call."""
+
+    query_lengths: List[int]
+    sequence_lengths: List[int]
+    block_tables: List[List[int]]
+    slot_mapping: List[int]
+
+
+def build_rocm_sequence_plan(
+    seq_metadata_list: List[SequenceMetadata],
+    block_size: int,
+) -> RocmSequencePlan:
+    query_lengths: List[int] = []
+    sequence_lengths: List[int] = []
+    block_tables: List[List[int]] = []
+    slot_mapping: List[int] = []
+
+    for seq_metadata in seq_metadata_list:
+        if seq_metadata.block_table is None:
+            raise ValueError("ROCm attention profiling requires a block table.")
+
+        if seq_metadata.is_prompt:
+            query_len = int(seq_metadata.prompt_chunk_len)
+            processed_len = int(
+                seq_metadata.seq.get_num_prompt_tokens_processed()
+            )
+            sequence_len = processed_len + query_len
+            first_token = processed_len
+        else:
+            query_len = 1
+            sequence_len = int(seq_metadata.seq.get_len())
+            first_token = sequence_len - 1
+
+        if query_len <= 0 or sequence_len <= 0:
+            raise ValueError(
+                "ROCm attention sequence lengths must be positive: "
+                f"query_len={query_len}, sequence_len={sequence_len}."
+            )
+
+        blocks_in_use = (sequence_len + block_size - 1) // block_size
+        block_table = list(seq_metadata.block_table[:blocks_in_use])
+        if len(block_table) != blocks_in_use:
+            raise ValueError(
+                "Block table is too short for ROCm attention sequence: "
+                f"required={blocks_in_use}, available={len(block_table)}."
+            )
+
+        query_lengths.append(query_len)
+        sequence_lengths.append(sequence_len)
+        block_tables.append(block_table)
+        for token_idx in range(first_token, first_token + query_len):
+            block_number = block_table[token_idx // block_size]
+            block_offset = token_idx % block_size
+            slot_mapping.append(block_number * block_size + block_offset)
+
+    return RocmSequencePlan(
+        query_lengths=query_lengths,
+        sequence_lengths=sequence_lengths,
+        block_tables=block_tables,
+        slot_mapping=slot_mapping,
+    )
+
+
+class VllmRocmAttentionWrapper(BaseAttentionWrapper):
+    """Profile vLLM's native ROCm paged-attention implementation."""
+
+    _inst = None
+
+    def init(
+        self,
+        model_config: ModelConfig,
+        parallel_config: ParallelConfig,
+        block_size: int,
+        device: torch.device,
+    ):
+        if not torch.version.hip:
+            raise RuntimeError(
+                "VLLM_ROCM attention requires a ROCm-enabled PyTorch build."
+            )
+
+        attention_family = bind_attention_family(model_config).family
+        if attention_family.memory_layout is AttentionMemoryLayout.LATENT_MLA:
+            raise NotImplementedError(
+                "VLLM_ROCM profiling currently supports dense paged KV cache, "
+                "not latent MLA cache layouts."
+            )
+
+        try:
+            from vllm.v1.attention.backends.rocm_attn import (
+                RocmAttentionImpl,
+                RocmAttentionMetadata,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "The installed vLLM build does not provide its ROCm attention "
+                "backend. Use a current vLLM ROCm image with gfx950 support."
+            ) from exc
+
+        super().init(model_config, parallel_config, block_size, device)
+        if block_size % 16 != 0:
+            raise ValueError(
+                "vLLM ROCm paged attention requires block_size to be a "
+                f"multiple of 16, got {block_size}."
+            )
+
+        self._metadata_cls = RocmAttentionMetadata
+        self._scale = 1.0 / (self.head_dim**0.5)
+        self._impl = RocmAttentionImpl(
+            num_heads=self.num_q_heads,
+            head_size=self.head_dim,
+            scale=self._scale,
+            num_kv_heads=self.num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+        )
+        self._layer = SimpleNamespace(
+            _k_scale=torch.tensor(1.0, dtype=torch.float32, device=device),
+            _v_scale=torch.tensor(1.0, dtype=torch.float32, device=device),
+            _k_scale_float=1.0,
+            _v_scale_float=1.0,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+        )
+        self.contains_prefill = False
+        self.contains_decode = False
+        self._prefill_metadata = None
+        self._decode_metadata = None
+        self._slot_mapping = None
+        self._num_prefill_tokens = 0
+
+    def get_cache_block(self, num_blocks: int, **kwargs) -> torch.Tensor:
+        return torch.randn(
+            2,
+            num_blocks,
+            self.block_size,
+            self.num_kv_heads,
+            self.head_dim,
+            **kwargs,
+        )
+
+    def _materialize_metadata(self, plan: RocmSequencePlan):
+        query_start = [0]
+        for query_len in plan.query_lengths:
+            query_start.append(query_start[-1] + query_len)
+
+        max_blocks = max(len(table) for table in plan.block_tables)
+        padded_block_tables = [
+            table + [0] * (max_blocks - len(table))
+            for table in plan.block_tables
+        ]
+        return self._metadata_cls(
+            num_actual_tokens=query_start[-1],
+            max_query_len=max(plan.query_lengths),
+            query_start_loc=torch.tensor(
+                query_start, dtype=torch.int32, device=self.device
+            ),
+            max_seq_len=max(plan.sequence_lengths),
+            seq_lens=torch.tensor(
+                plan.sequence_lengths, dtype=torch.int32, device=self.device
+            ),
+            block_table=torch.tensor(
+                padded_block_tables, dtype=torch.int32, device=self.device
+            ),
+            slot_mapping=torch.tensor(
+                plan.slot_mapping, dtype=torch.long, device=self.device
+            ),
+            use_cascade=False,
+            common_prefix_len=0,
+            cu_prefix_query_lens=None,
+            prefix_kv_lens=None,
+            suffix_kv_lens=None,
+            prefix_scheduler_metadata=None,
+            causal=True,
+        )
+
+    def begin_forward(
+        self,
+        seq_metadata_list: List[SequenceMetadata],
+    ) -> None:
+        prefill_sequences = [seq for seq in seq_metadata_list if seq.is_prompt]
+        decode_sequences = [seq for seq in seq_metadata_list if not seq.is_prompt]
+        ordered_sequences = prefill_sequences + decode_sequences
+        plan = build_rocm_sequence_plan(ordered_sequences, self.block_size)
+
+        self.contains_prefill = bool(prefill_sequences)
+        self.contains_decode = bool(decode_sequences)
+        self._num_prefill_tokens = sum(
+            int(seq.prompt_chunk_len) for seq in prefill_sequences
+        )
+        self._slot_mapping = torch.tensor(
+            plan.slot_mapping, dtype=torch.long, device=self.device
+        )
+        self._prefill_metadata = (
+            self._materialize_metadata(
+                build_rocm_sequence_plan(prefill_sequences, self.block_size)
+            )
+            if prefill_sequences
+            else None
+        )
+        self._decode_metadata = (
+            self._materialize_metadata(
+                build_rocm_sequence_plan(decode_sequences, self.block_size)
+            )
+            if decode_sequences
+            else None
+        )
+
+    def end_forward(self):
+        self._prefill_metadata = None
+        self._decode_metadata = None
+        self._slot_mapping = None
+
+    def _run_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        metadata,
+        output: torch.Tensor,
+    ) -> None:
+        self._impl.forward(
+            self._layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            metadata,
+            output,
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        softmax_scale: float = 1.0,
+        layer_id: Optional[int] = None,
+    ) -> torch.Tensor:
+        if self._slot_mapping is None:
+            raise RuntimeError("ROCm attention metadata is not initialized.")
+        if softmax_scale != self._scale:
+            raise ValueError(
+                f"softmax_scale mismatch: expected {self._scale}, got "
+                f"{softmax_scale}."
+            )
+
+        with self.get_timer(OperationMetrics.ATTN_INPUT_RESHAPE, layer_id):
+            query = query.contiguous().reshape(
+                -1, self.num_q_heads, self.head_dim
+            )
+            key = key.contiguous().reshape(-1, self.num_kv_heads, self.head_dim)
+            value = value.contiguous().reshape(
+                -1, self.num_kv_heads, self.head_dim
+            )
+
+        with self.get_timer(OperationMetrics.ATTN_KV_CACHE_SAVE, layer_id):
+            self._impl.do_kv_cache_update(
+                self._layer,
+                key,
+                value,
+                kv_cache,
+                self._slot_mapping,
+            )
+
+        output = torch.empty_like(query)
+        prefill_end = self._num_prefill_tokens
+        with self.get_timer(OperationMetrics.ATTN_PREFILL, layer_id):
+            if self._prefill_metadata is not None:
+                self._run_attention(
+                    query[:prefill_end],
+                    key[:prefill_end],
+                    value[:prefill_end],
+                    kv_cache,
+                    self._prefill_metadata,
+                    output[:prefill_end],
+                )
+
+        with self.get_timer(OperationMetrics.ATTN_DECODE, layer_id):
+            if self._decode_metadata is not None:
+                self._run_attention(
+                    query[prefill_end:],
+                    key[prefill_end:],
+                    value[prefill_end:],
+                    kv_cache,
+                    self._decode_metadata,
+                    output[prefill_end:],
+                )
+
+        with self.get_timer(OperationMetrics.ATTN_OUTPUT_RESHAPE, layer_id):
+            output = output.reshape(-1, self.num_q_heads * self.head_dim)
+        return output
+
+
+__all__ = [
+    "RocmSequencePlan",
+    "VllmRocmAttentionWrapper",
+    "build_rocm_sequence_plan",
+]

--- a/frontier/profiling/attention/main.py
+++ b/frontier/profiling/attention/main.py
@@ -63,6 +63,10 @@ from frontier.attention.profiling_mapping import (
 from frontier.attention.string_coercion import coerce_truthy_bool
 from frontier.model_architectures import MODEL_ARCHITECTURE_REGISTRY
 from frontier.profiling.attention.backends import AttentionBackend
+from frontier.profiling.common.accelerator import (
+    get_available_gpu_ids,
+    set_process_visible_device,
+)
 from frontier.profiling.common.parallel_config import ParallelConfig
 
 from frontier.profiling.attention.attention_input import AttentionInput
@@ -95,64 +99,8 @@ def _ensure_torch_available():
 
 
 def _get_available_gpus(num_gpus: int) -> List[int]:
-    """
-    Get list of available GPU IDs based on CUDA_VISIBLE_DEVICES and num_gpus.
-
-    IMPORTANT: This function avoids calling torch.cuda.device_count() in the main
-    process to prevent early CUDA initialization, which can interfere with
-    multi-GPU multiprocessing.
-
-    Returns:
-        List of GPU IDs to use for profiling
-    """
-    # Check CUDA_VISIBLE_DEVICES
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-    if cuda_visible:
-        # Parse CUDA_VISIBLE_DEVICES
-        available = [int(x.strip()) for x in cuda_visible.split(",") if x.strip()]
-    else:
-        # Avoid calling torch.cuda.device_count() in main process.
-        # Require nvidia-smi evidence instead of guessing GPU indices.
-        try:
-            import subprocess
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                available = [
-                    int(x.strip()) for x in result.stdout.strip().split("\n") if x.strip()
-                ]
-            else:
-                raise RuntimeError(
-                    "Unable to discover GPUs with nvidia-smi. Set "
-                    "CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi before "
-                    "running attention profiling. "
-                    f"nvidia-smi stderr: {result.stderr.strip()}"
-                )
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because nvidia-smi was "
-                "not found. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running attention profiling."
-            ) from exc
-
-        if not available:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because it returned no "
-                "GPU indices. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running attention profiling."
-            )
-
-    if len(available) < num_gpus:
-        raise RuntimeError(
-            f"Requested {num_gpus} GPUs but only found {len(available)} visible GPUs "
-            f"(CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES', '')})."
-        )
-
-    return available[:num_gpus]
+    """Discover GPUs without initializing torch in the parent process."""
+    return get_available_gpu_ids(num_gpus)
 
 
 # Global variable to track if CUDA has been initialized in this process
@@ -1306,8 +1254,10 @@ def profile_model(
                 executor.shutdown(wait=True, cancel_futures=True)
     else:
         # Single-GPU sequential mode
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(available_gpus[0])
         torch_module = _ensure_torch_available()
+        set_process_visible_device(
+            available_gpus[0], torch_module=torch_module
+        )
         torch_module.cuda.set_device(0)
 
         wrapper = AttentionWrapper(
@@ -1513,8 +1463,10 @@ def profile_mixed_prefill(
                 executor.shutdown(wait=True, cancel_futures=True)
     else:
         # Single-GPU sequential mode
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(available_gpus[0])
         torch_module = _ensure_torch_available()
+        set_process_visible_device(
+            available_gpus[0], torch_module=torch_module
+        )
         torch_module.cuda.set_device(0)
 
         wrapper = AttentionWrapper(
@@ -1684,8 +1636,10 @@ def profile_true_mixed_batches(
             for executor in executors:
                 executor.shutdown(wait=True, cancel_futures=True)
     else:
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(available_gpus[0])
         torch_module = _ensure_torch_available()
+        set_process_visible_device(
+            available_gpus[0], torch_module=torch_module
+        )
         torch_module.cuda.set_device(0)
         wrapper = AttentionWrapper(
             model_config=model_config,
@@ -1743,6 +1697,10 @@ def main():
         else:
             print(f"\n=== Single-GPU Mode ===")
             print(f"Using GPU: {available_gpus[0]}")
+            torch_module = _ensure_torch_available()
+            set_process_visible_device(
+                available_gpus[0], torch_module=torch_module
+            )
     else:
         if not RAY_AVAILABLE:
             raise RuntimeError("Ray is not available. Use --disable_ray flag.")

--- a/frontier/profiling/collectives/benchmark_runner.py
+++ b/frontier/profiling/collectives/benchmark_runner.py
@@ -8,8 +8,24 @@ import torch
 from frontier.logger import init_logger
 from frontier.profiling.collectives.collectives_input import CollectivesInput
 from frontier.profiling.collectives.collectives_wrapper import CollectiveWrapper
+from frontier.profiling.common.accelerator import set_process_visible_device
 
 logger = init_logger(__name__)
+
+
+def _precision_to_dtype(precision: str) -> torch.dtype:
+    supported = {
+        "FP16": torch.float16,
+        "BF16": torch.bfloat16,
+        "FP32": torch.float32,
+    }
+    try:
+        return supported[precision.upper()]
+    except KeyError as exc:
+        raise ValueError(
+            f"Collective profiling does not support precision {precision!r}; "
+            f"choose one of {sorted(supported)}."
+        ) from exc
 
 
 @ray.remote(num_gpus=1)
@@ -17,14 +33,15 @@ class BenchmarkRunner:
     def __init__(self, gpu_id: int, max_gpus_per_node: int, head_ip: str) -> None:
         self._gpu_id = gpu_id
         self._max_devices_per_node = max_gpus_per_node
-        self._set_cuda_visible_devices()
+        self._accelerator_visibility = self._set_accelerator_visible_device()
         self._last_num_workers_per_node = None
         self._last_num_workers = None
         self._head_ip = head_ip
 
-    def _set_cuda_visible_devices(self) -> None:
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(
-            self._gpu_id % self._max_devices_per_node
+    def _set_accelerator_visible_device(self) -> str:
+        visibility = set_process_visible_device(
+            self._gpu_id % self._max_devices_per_node,
+            torch_module=torch,
         )
         # set additional nccl env vars
         # This env var set by Ray causes exceptions with graph building.
@@ -33,6 +50,7 @@ class BenchmarkRunner:
         os.environ["NCCL_GRAPH_MIXING_SUPPORT"] = "0"
         os.environ["KINETO_LOG_LEVEL"] = "5"
         os.environ["NCCL_IGNORE_DISABLED_P2P"] = "1"
+        return visibility
 
     def run_collective(
         self,
@@ -71,6 +89,7 @@ class BenchmarkRunner:
             collectives_input.collective,
             collectives_input.num_workers_per_node,
             self._max_devices_per_node,
+            dtype=_precision_to_dtype(collectives_input.precision),
         )
         stats = wrapper.profile()
         del wrapper
@@ -83,7 +102,7 @@ class BenchmarkRunner:
         logger.info(
             f"Initializing gpu id: {self._gpu_id}, Rank: {rank}, num_workers: {num_workers}, comm_id: {comm_id}, "
             f"devices_per_node: {devices_per_node}, max_devices_per_node: {self._max_devices_per_node}, "
-            f"ip_addr: {ray.util.get_node_ip_address()}, CUDA_VISIBLE_DEVICES: {os.environ['CUDA_VISIBLE_DEVICES']}"
+            f"ip_addr: {ray.util.get_node_ip_address()}, visibility: {self._accelerator_visibility}"
         )
 
         torch.distributed.init_process_group(

--- a/frontier/profiling/collectives/collectives_impl.py
+++ b/frontier/profiling/collectives/collectives_impl.py
@@ -16,6 +16,7 @@ class GraphedCollective:
         dtype: torch.dtype = torch.float16,
     ) -> None:
         self._size = size
+        self._dtype = dtype
         self._disable_graph = disable_graph
         self._collective_fn = self._get_collective_fn(collective)
 
@@ -101,3 +102,7 @@ class GraphedCollective:
             self._collective_fn()
         else:
             self._graph.replay()
+
+    @property
+    def element_size(self) -> int:
+        return self._buffer.element_size()

--- a/frontier/profiling/collectives/collectives_input.py
+++ b/frontier/profiling/collectives/collectives_input.py
@@ -10,11 +10,13 @@ class CollectivesInput:
         num_workers_per_node: int,
         collective_size: int,
         collective: str,
+        precision: str = "FP16",
     ):
         self.num_workers = num_workers
         self.num_workers_per_node = num_workers_per_node
         self.collective_size = collective_size
         self.collective = collective
+        self.precision = precision
         self.comm_id = self._get_comm_id()
 
     @classmethod
@@ -32,10 +34,10 @@ class CollectivesInput:
         if self.collective == "send_recv" and self.num_workers != 2:
             return False
 
-        if (
-            self.num_workers > self.num_workers_per_node
-            and self.num_workers % self.num_workers_per_node != 0
-        ):
+        if self.num_workers < self.num_workers_per_node:
+            return False
+
+        if self.num_workers % self.num_workers_per_node != 0:
             return False
 
         num_nodes_required = self.num_workers // self.num_workers_per_node

--- a/frontier/profiling/collectives/collectives_wrapper.py
+++ b/frontier/profiling/collectives/collectives_wrapper.py
@@ -21,6 +21,7 @@ class CollectiveWrapper:
         collective: str,
         devices_per_node: int,
         max_devices_per_node: int,
+        dtype: torch.dtype = torch.float16,
     ) -> None:
         self._rank = rank
         self._num_workers = num_workers
@@ -31,7 +32,11 @@ class CollectiveWrapper:
         self._max_devices_per_node = max_devices_per_node
 
         self._graphed_collective = GraphedCollective(
-            num_workers, size, collective=collective, disable_graph=DISABLE_GRAPH
+            num_workers,
+            size,
+            collective=collective,
+            disable_graph=DISABLE_GRAPH,
+            dtype=dtype,
         )
 
         self.timer_stats_store = TimerStatsStore(profile_method="kineto")
@@ -61,7 +66,7 @@ class CollectiveWrapper:
             "time_stats": self.timer_stats_store.get_stats(),
             "rank": self._rank,
             "num_workers": self._num_workers,
-            "size": self._size * 2,  # bytes
+            "size": self._size * self._graphed_collective.element_size,
             "collective": self._collective,
             "devices_per_node": self._devices_per_node,
             "max_devices_per_node": self._max_devices_per_node,

--- a/frontier/profiling/collectives/main.py
+++ b/frontier/profiling/collectives/main.py
@@ -1,21 +1,47 @@
+"""Collective profiling entrypoint for CUDA/NCCL and ROCm/RCCL systems."""
+
+from __future__ import annotations
+
 import argparse
 import datetime
 import os
+import socket
+from typing import Any
 
 import pandas as pd
-import ray
 from tqdm import tqdm
 
-from frontier.config.precision_type import PrecisionType
+try:
+    import ray
+
+    RAY_AVAILABLE = True
+except ImportError:
+    ray = None
+    RAY_AVAILABLE = False
+
 from frontier.logger import init_logger
-from frontier.profiling.collectives.benchmark_runner import BenchmarkRunner
+from frontier.profiling.collectives.collectives_input import CollectivesInput
+from frontier.profiling.common.accelerator import get_available_gpu_ids
 from frontier.profiling.utils import get_collectives_inputs
 
 logger = init_logger(__name__)
 
+SUPPORTED_COLLECTIVE_PRECISIONS = ("FP16", "BF16", "FP32")
+
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="MLP Profiling")
+    parser = argparse.ArgumentParser(description="GPU collective profiling")
+    parser.add_argument(
+        "--disable_ray",
+        action="store_true",
+        help="Use local multiprocessing instead of Ray (single-node only).",
+    )
+    parser.add_argument(
+        "--num_gpus",
+        type=int,
+        default=8,
+        help="Number of visible GPUs available to the local runner.",
+    )
     parser.add_argument(
         "--num_workers_per_node_combinations",
         type=int,
@@ -44,96 +70,221 @@ def parse_args():
         "--precision",
         type=str,
         default="FP16",
-        choices=[p.name for p in PrecisionType],
+        choices=SUPPORTED_COLLECTIVE_PRECISIONS,
         help="Profiling precision type (default: %(default)s)",
     )
     parser.add_argument(
         "--dtype",
         dest="precision",
         type=str,
-        choices=[p.name for p in PrecisionType],
+        choices=SUPPORTED_COLLECTIVE_PRECISIONS,
         help="Alias for --precision.",
     )
     args = parser.parse_args()
 
-    args.output_dir = f"{args.output_dir}/collective/{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-    os.makedirs(args.output_dir, exist_ok=True)
+    if args.num_gpus <= 0:
+        parser.error("--num_gpus must be positive")
+    if any(value <= 0 for value in args.num_workers_per_node_combinations):
+        parser.error("--num_workers_per_node_combinations must be positive")
 
+    args.output_dir = os.path.join(
+        args.output_dir,
+        "collective",
+        datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S"),
+    )
+    os.makedirs(args.output_dir, exist_ok=True)
     return args
 
 
-def create_runner_pool():
+def _precision_to_dtype(precision: str):
+    import torch
+
+    return {
+        "FP16": torch.float16,
+        "BF16": torch.bfloat16,
+        "FP32": torch.float32,
+    }[precision.upper()]
+
+
+def _configure_collective_environment() -> None:
+    # Ray can set this variable, but graph/profiler combinations in the legacy
+    # runner reject it. These NCCL names are also honored by RCCL on ROCm.
+    os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
+    os.environ["NCCL_GRAPH_MIXING_SUPPORT"] = "0"
+    os.environ["KINETO_LOG_LEVEL"] = "5"
+    os.environ["NCCL_IGNORE_DISABLED_P2P"] = "1"
+
+
+def _find_free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _local_collective_worker(
+    rank: int,
+    collectives_input: CollectivesInput,
+    max_devices_per_node: int,
+    master_port: int,
+    result_queue: Any,
+) -> None:
+    import torch
+
+    from frontier.profiling.collectives.collectives_wrapper import CollectiveWrapper
+
+    _configure_collective_environment()
+    torch.cuda.set_device(rank)
+    try:
+        torch.distributed.init_process_group(
+            backend="nccl",
+            rank=rank,
+            world_size=collectives_input.num_workers,
+            init_method=f"tcp://127.0.0.1:{master_port}",
+        )
+        wrapper = CollectiveWrapper(
+            rank=rank,
+            num_workers=collectives_input.num_workers,
+            comm_id=master_port,
+            size=collectives_input.collective_size,
+            collective=collectives_input.collective,
+            devices_per_node=collectives_input.num_workers_per_node,
+            max_devices_per_node=max_devices_per_node,
+            dtype=_precision_to_dtype(collectives_input.precision),
+        )
+        result = wrapper.profile()
+        if rank == 0:
+            if not result["time_stats"]:
+                raise RuntimeError(
+                    "The GPU profiler did not capture a collective kernel. "
+                    "Check Kineto NCCL/RCCL tracing support in this PyTorch build."
+                )
+            result_queue.put(result)
+        torch.distributed.barrier()
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _run_local_collective(
+    collectives_input: CollectivesInput,
+    max_devices_per_node: int,
+) -> dict:
+    import torch.multiprocessing as mp
+
+    context = mp.get_context("spawn")
+    result_queue = context.SimpleQueue()
+    mp.spawn(
+        _local_collective_worker,
+        args=(
+            collectives_input,
+            max_devices_per_node,
+            _find_free_local_port(),
+            result_queue,
+        ),
+        nprocs=collectives_input.num_workers,
+        join=True,
+    )
+    return result_queue.get()
+
+
+def _create_ray_runner_pool():
+    from frontier.profiling.collectives.benchmark_runner import BenchmarkRunner
+
     total_gpus_available = int(ray.cluster_resources()["GPU"])
-    logger.info(f"Total GPUs available: {total_gpus_available}")
+    logger.info("Total GPUs available: %s", total_gpus_available)
+    if total_gpus_available <= 0:
+        raise RuntimeError("No GPUs are available to Ray.")
 
-    assert total_gpus_available > 0, "No GPUs available"
-
-    all_node_ips = [x["NodeName"] for x in ray.nodes()]
-    logger.info(f"All node IPs: {all_node_ips}")
-
-    assert len(all_node_ips) > 0, "No nodes available"
+    all_node_ips = [node["NodeName"] for node in ray.nodes()]
+    logger.info("All node IPs: %s", all_node_ips)
+    if not all_node_ips:
+        raise RuntimeError("Ray did not report any nodes.")
 
     num_nodes = len(all_node_ips)
-    gpus_per_node = total_gpus_available // len(all_node_ips)
-
+    gpus_per_node = total_gpus_available // num_nodes
     runner_pool = []
     for gpu_id in range(total_gpus_available):
         node_ip = all_node_ips[gpu_id // gpus_per_node]
         runner_pool.append(
             BenchmarkRunner.options(
-                resources={
-                    f"node:{node_ip}": 0.01,
-                }
+                resources={f"node:{node_ip}": 0.01}
             ).remote(gpu_id, gpus_per_node, all_node_ips[0])
         )
     return total_gpus_available, num_nodes, runner_pool
 
 
+def _profile_with_ray(collectives_inputs, runner_pool) -> list[dict]:
+    all_results = []
+    for collectives_input in tqdm(collectives_inputs):
+        promises = [
+            runner.run_collective.remote(collectives_input)
+            for runner in runner_pool
+        ]
+        results = ray.get(promises)
+        if results and results[0] is not None:
+            all_results.append(results[0])
+    return all_results
+
+
+def _profile_locally(collectives_inputs, num_gpus: int) -> list[dict]:
+    return [
+        _run_local_collective(collectives_input, num_gpus)
+        for collectives_input in tqdm(collectives_inputs)
+    ]
+
+
+def _write_results(all_results: list[dict], args) -> str:
+    if not all_results:
+        raise RuntimeError("No valid collective profiling configurations were generated.")
+    frame = pd.DataFrame(all_results)
+    frame = (
+        pd.json_normalize(frame["time_stats"])
+        .add_prefix("time_stats.")
+        .join(frame.drop(columns=["time_stats"]))
+    )
+    frame["profiling_precision"] = args.precision
+    output_path = os.path.join(args.output_dir, f"{args.collective}.csv")
+    frame.to_csv(output_path, index=False)
+    return output_path
+
+
 def main():
     args = parse_args()
 
-    ray.init()
-
-    total_gpus_available, num_nodes, runner_pool = create_runner_pool()
-
-    all_results = []
+    if args.disable_ray:
+        available_gpus = get_available_gpu_ids(args.num_gpus)
+        logger.info(
+            "Local collective profiling on %s visible GPUs: %s",
+            len(available_gpus),
+            available_gpus,
+        )
+        total_gpus_available = len(available_gpus)
+        num_nodes = 1
+        runner_pool = None
+    else:
+        if not RAY_AVAILABLE:
+            raise RuntimeError(
+                "Ray is not installed. Use --disable_ray for native single-node "
+                "multiprocessing."
+            )
+        ray.init()
+        total_gpus_available, num_nodes, runner_pool = _create_ray_runner_pool()
 
     collectives_inputs = get_collectives_inputs(
-        num_nodes,
-        args.num_workers_per_node_combinations,
-        args.max_collective_size,
-        args.collective,
-        total_gpus_available,
+        num_nodes=num_nodes,
+        num_workers_per_node_combinations=args.num_workers_per_node_combinations,
+        max_collective_size=args.max_collective_size,
+        collective=args.collective,
+        total_gpus_available=total_gpus_available,
+        precision=args.precision,
     )
+    if args.disable_ray:
+        all_results = _profile_locally(collectives_inputs, total_gpus_available)
+    else:
+        all_results = _profile_with_ray(collectives_inputs, runner_pool)
 
-    for collectives_input in tqdm(collectives_inputs):
-        promises = []
-        for gpu_id in range(total_gpus_available):
-            promise = runner_pool[gpu_id].run_collective.remote(collectives_input)
-            promises.append(promise)
-
-        for gpu_id in range(int(total_gpus_available)):
-            result = ray.get([promises[gpu_id]])[0]
-            if result and gpu_id == 0:
-                all_results.append(result)
-
-        ray.get(promises)
-
-    # filter none results
-    all_results = [x for x in all_results if x is not None]
-
-    df = pd.DataFrame(all_results)
-    # the time_stats column is a dict, so we need to expand it into columns recursively and add prefix
-
-    df = (
-        pd.json_normalize(df["time_stats"])
-        .add_prefix("time_stats.")
-        .join(df.drop(columns=["time_stats"]))
-    )
-    df["profiling_precision"] = args.precision
-
-    # write results to a csv file
-    df.to_csv(f"{args.output_dir}/{args.collective}.csv")
+    output_path = _write_results(all_results, args)
+    logger.info("Wrote collective profiling results to %s", output_path)
 
 
 if __name__ == "__main__":

--- a/frontier/profiling/common/accelerator.py
+++ b/frontier/profiling/common/accelerator.py
@@ -1,0 +1,209 @@
+"""Platform-neutral accelerator discovery helpers for profiling entrypoints."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Callable, List, Optional
+
+
+VISIBLE_DEVICE_ENV_VARS = (
+    "ROCR_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+)
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def accelerator_platform(torch_module: Any) -> str:
+    """Return the accelerator platform exposed by a torch module."""
+    version = getattr(torch_module, "version", None)
+    if getattr(version, "hip", None):
+        return "rocm"
+    if getattr(version, "cuda", None):
+        return "cuda"
+    return "cpu"
+
+
+def _active_visibility(
+    environ: Mapping[str, str],
+) -> tuple[Optional[str], Optional[str]]:
+    for name in VISIBLE_DEVICE_ENV_VARS:
+        value = environ.get(name, "").strip()
+        if value:
+            return name, value
+    return None, None
+
+
+def _parse_visible_device_ids(name: str, value: str) -> List[int]:
+    tokens = [token.strip() for token in value.split(",") if token.strip()]
+    if not tokens or tokens == ["-1"]:
+        return []
+
+    try:
+        device_ids = [int(token) for token in tokens]
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{name} must contain comma-separated integer GPU IDs for Frontier "
+            f"profiling, got {value!r}."
+        ) from exc
+
+    if any(device_id < 0 for device_id in device_ids):
+        raise RuntimeError(
+            f"{name} contains a negative GPU ID: {value!r}."
+        )
+    if len(set(device_ids)) != len(device_ids):
+        raise RuntimeError(f"{name} contains duplicate GPU IDs: {value!r}.")
+    return device_ids
+
+
+def _run_discovery_command(
+    command: list[str],
+    command_runner: CommandRunner,
+) -> Optional[subprocess.CompletedProcess[str]]:
+    try:
+        return command_runner(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+
+
+def _discover_with_amd_smi(command_runner: CommandRunner) -> List[int]:
+    result = _run_discovery_command(
+        ["amd-smi", "list", "--json"], command_runner
+    )
+    if result is not None and result.returncode == 0:
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, list):
+            device_ids = [
+                int(entry["gpu"])
+                for entry in payload
+                if isinstance(entry, dict) and "gpu" in entry
+            ]
+            if device_ids:
+                return device_ids
+
+    result = _run_discovery_command(["amd-smi", "list"], command_runner)
+    if result is None or result.returncode != 0:
+        return []
+    return [
+        int(match.group(1))
+        for line in result.stdout.splitlines()
+        if (match := re.match(r"^\s*GPU:\s*(\d+)\s*$", line))
+    ]
+
+
+def _discover_with_nvidia_smi(command_runner: CommandRunner) -> List[int]:
+    result = _run_discovery_command(
+        ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+        command_runner,
+    )
+    if result is None or result.returncode != 0:
+        return []
+    try:
+        return [
+            int(line.strip())
+            for line in result.stdout.splitlines()
+            if line.strip()
+        ]
+    except ValueError:
+        return []
+
+
+def get_available_gpu_ids(
+    num_gpus: int,
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    command_runner: CommandRunner = subprocess.run,
+) -> List[int]:
+    """Discover physical GPU IDs without initializing the torch runtime.
+
+    ROCm visibility variables are checked before the CUDA-compatible variable.
+    With no explicit visibility constraint, ``amd-smi`` and then ``nvidia-smi``
+    provide external inventory evidence so multiprocessing remains safe.
+    """
+    if num_gpus <= 0:
+        raise ValueError(f"num_gpus must be positive, got {num_gpus!r}")
+
+    effective_environ = os.environ if environ is None else environ
+    visibility_name, visibility_value = _active_visibility(effective_environ)
+    if visibility_name is not None and visibility_value is not None:
+        available = _parse_visible_device_ids(visibility_name, visibility_value)
+        source = f"{visibility_name}={visibility_value!r}"
+    else:
+        available = _discover_with_amd_smi(command_runner)
+        source = "amd-smi"
+        if not available:
+            available = _discover_with_nvidia_smi(command_runner)
+            source = "nvidia-smi"
+
+    if not available:
+        visibility_hint = ", ".join(VISIBLE_DEVICE_ENV_VARS)
+        raise RuntimeError(
+            "Unable to discover any GPUs with accelerator visibility variables, "
+            f"amd-smi, or nvidia-smi. Set one of {visibility_hint} explicitly."
+        )
+    if len(available) < num_gpus:
+        raise RuntimeError(
+            f"Requested {num_gpus} GPUs but only found {len(available)} from "
+            f"{source}: {available}."
+        )
+    return available[:num_gpus]
+
+
+def set_process_visible_device(
+    device_id: int,
+    *,
+    torch_module: Any,
+    environ: Optional[MutableMapping[str, str]] = None,
+) -> str:
+    """Bind a not-yet-initialized process to one CUDA or ROCm device.
+
+    PyTorch retains the ``torch.cuda`` API on ROCm, but current vLLM warns
+    when ROCm jobs use ``CUDA_VISIBLE_DEVICES``. Set the native visibility
+    variables before the first runtime call and remove variables for the
+    other platform.
+    """
+    if device_id < 0:
+        raise ValueError(f"device_id must be non-negative, got {device_id!r}")
+
+    effective_environ = os.environ if environ is None else environ
+    value = str(device_id)
+    platform = accelerator_platform(torch_module)
+    if platform == "rocm":
+        effective_environ["ROCR_VISIBLE_DEVICES"] = value
+        # Do not set both ROCm variables: HIP_VISIBLE_DEVICES is interpreted
+        # after ROCR_VISIBLE_DEVICES by some runtime versions, which can hide
+        # nonzero devices through a second round of index remapping.
+        effective_environ.pop("HIP_VISIBLE_DEVICES", None)
+        effective_environ.pop("CUDA_VISIBLE_DEVICES", None)
+        return f"ROCR_VISIBLE_DEVICES={value}"
+    if platform == "cuda":
+        effective_environ["CUDA_VISIBLE_DEVICES"] = value
+        effective_environ.pop("ROCR_VISIBLE_DEVICES", None)
+        effective_environ.pop("HIP_VISIBLE_DEVICES", None)
+        return f"CUDA_VISIBLE_DEVICES={value}"
+    raise RuntimeError(
+        "Cannot bind a GPU visibility variable because torch exposes no CUDA "
+        "or ROCm runtime."
+    )
+
+
+__all__ = [
+    "VISIBLE_DEVICE_ENV_VARS",
+    "accelerator_platform",
+    "get_available_gpu_ids",
+    "set_process_visible_device",
+]

--- a/frontier/profiling/common/layers/layernorm.py
+++ b/frontier/profiling/common/layers/layernorm.py
@@ -6,7 +6,9 @@ import torch
 import torch.nn as nn
 
 from frontier.profiling.common.cuda_timer import CudaTimer
+from frontier.profiling.common.vllm_compat import vllm_config_context
 
+VllmRMSNorm = None
 try:
     from vllm.model_executor.layers.layernorm import (
         GemmaRMSNorm as VllmGemmaRMSNorm,
@@ -16,8 +18,16 @@ try:
 
     HAS_VLLM_RMSNORM = True
 except ImportError:
-    HAS_VLLM_RMSNORM = False
-    VllmGemmaRMSNorm = None
+    try:
+        from vllm.model_executor.layers.layernorm import (
+            GemmaRMSNorm as VllmGemmaRMSNorm,
+            RMSNorm as VllmRMSNorm,
+        )
+
+        HAS_VLLM_RMSNORM = True
+    except ImportError:
+        HAS_VLLM_RMSNORM = False
+        VllmGemmaRMSNorm = None
     vllm_rms_norm = None
     vllm_fused_add_rms_norm = None
 
@@ -37,9 +47,21 @@ class RMSNorm(nn.Module):
         layer_id: Optional[int] = None,
     ) -> None:
         super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self._impl = None
+        if VllmRMSNorm is not None:
+            with vllm_config_context():
+                self._impl = VllmRMSNorm(hidden_size, eps=eps)
+            self.register_parameter("_weight", None)
+        else:
+            self._weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
         self._norm_timer = CudaTimer(norm_name, layer_id=layer_id)
+
+    @property
+    def weight(self) -> nn.Parameter:
+        if self._impl is not None:
+            return self._impl.weight
+        return self._weight
 
     def forward(
         self, x: torch.Tensor, residual: Optional[torch.Tensor] = None
@@ -51,6 +73,8 @@ class RMSNorm(nn.Module):
                     "vLLM is required for RMSNorm profiling. "
                     "Install vllm or set PYTHONPATH to the vllm source tree."
                 )
+            if self._impl is not None:
+                return self._impl(x, residual)
             if residual is None:
                 return vllm_rms_norm(x, self.weight.data, self.variance_epsilon)
             return vllm_fused_add_rms_norm(
@@ -75,7 +99,8 @@ class GemmaRMSNorm(nn.Module):
                 "vLLM is required for GemmaRMSNorm profiling. "
                 "Install vllm or set PYTHONPATH to the vllm source tree."
             )
-        self._impl = VllmGemmaRMSNorm(hidden_size, eps=eps)
+        with vllm_config_context():
+            self._impl = VllmGemmaRMSNorm(hidden_size, eps=eps)
 
     @property
     def weight(self) -> nn.Parameter:

--- a/frontier/profiling/common/layers/rotary_embedding.py
+++ b/frontier/profiling/common/layers/rotary_embedding.py
@@ -23,12 +23,14 @@
 """Rotary Positional Embeddings for profiling."""
 import math
 import os
+import inspect
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 from frontier.profiling.common.timer_stats_store import TimerStatsStore
+from frontier.profiling.common.vllm_compat import vllm_config_context
 
 
 _VLLM_GET_ROPE = None
@@ -95,6 +97,57 @@ def _load_vllm_get_rope():
 
     _VLLM_GET_ROPE = vllm_get_rope
     return _VLLM_GET_ROPE
+
+
+def _call_vllm_get_rope(
+    vllm_get_rope,
+    *,
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: Union[int, float],
+    is_neox_style: bool,
+    rope_scaling: Optional[Dict[str, Any]],
+    dtype: torch.dtype,
+):
+    """Call either the vLLM 0.10 or current RoPE factory contract."""
+    parameters = inspect.signature(vllm_get_rope).parameters
+    if "rope_parameters" in parameters:
+        rope_parameters = dict(rope_scaling or {})
+        rope_parameters.setdefault("rope_type", "default")
+        rope_parameters["rope_theta"] = base
+        if rotary_dim != head_size:
+            rope_parameters["rope_dim"] = rotary_dim
+
+        def create_rope():
+            return vllm_get_rope(
+                head_size=head_size,
+                max_position=max_position,
+                is_neox_style=is_neox_style,
+                rope_parameters=rope_parameters,
+                dtype=dtype,
+            )
+
+        # Current vLLM custom ops select their implementation when constructed
+        # and require a VllmConfig context even in standalone profiling tools.
+        if getattr(vllm_get_rope, "__module__", "").startswith("vllm."):
+            with vllm_config_context():
+                return create_rope()
+        return create_rope()
+    if "rotary_dim" in parameters:
+        return vllm_get_rope(
+            head_size=head_size,
+            rotary_dim=rotary_dim,
+            max_position=max_position,
+            base=base,
+            is_neox_style=is_neox_style,
+            rope_scaling=rope_scaling,
+            dtype=dtype,
+        )
+    raise TypeError(
+        "Unsupported vLLM get_rope signature; expected rope_parameters or "
+        "rotary_dim keyword support."
+    )
 
 
 def _load_vllm_custom_ops():
@@ -576,7 +629,8 @@ def get_rope(
     if not _should_prefer_torch_rope_fallback():
         vllm_get_rope = _load_vllm_get_rope()
         if vllm_get_rope is not None:
-            return vllm_get_rope(
+            return _call_vllm_get_rope(
+                vllm_get_rope,
                 head_size=head_size,
                 rotary_dim=rotary_dim,
                 max_position=max_position,

--- a/frontier/profiling/common/model_config.py
+++ b/frontier/profiling/common/model_config.py
@@ -14,6 +14,11 @@ from frontier.config.model_config import (
     _infer_share_expert_dim_from_hf_config,
     _infer_use_qk_norm_from_hf_config,
 )
+from frontier.gdn import (
+    GatedDeltaNetConfig,
+    SequenceMixerType,
+    build_sequence_mixer_schedule,
+)
 from frontier.model_architectures import get_model_architecture_profile
 from frontier.profiling.common.parallel_config import ParallelConfig
 from frontier.types import ActivationType, NormType
@@ -65,6 +70,14 @@ class ModelConfig:
         qk_rope_head_dim: Optional[int] = None,
         qk_head_dim: Optional[int] = None,
         v_head_dim: Optional[int] = None,
+        layer_types: Optional[tuple[str, ...] | list[str]] = None,
+        full_attention_interval: Optional[int] = None,
+        linear_conv_kernel_dim: Optional[int] = None,
+        linear_key_head_dim: Optional[int] = None,
+        linear_value_head_dim: Optional[int] = None,
+        linear_num_key_heads: Optional[int] = None,
+        linear_num_value_heads: Optional[int] = None,
+        gdn_output_gate_type: str = "silu",
         # Quantization config for metadata tracking
         quantization_config: Optional[QuantizationConfig] = None,
         # Whether lm_head shares weights with embed_tokens (HF standard field)
@@ -144,6 +157,42 @@ class ModelConfig:
         self.qk_rope_head_dim = qk_rope_head_dim
         self.qk_head_dim = qk_head_dim
         self.v_head_dim = v_head_dim
+        self.layer_types = (
+            tuple(str(value) for value in layer_types)
+            if layer_types is not None
+            else None
+        )
+        self.full_attention_interval = (
+            int(full_attention_interval)
+            if full_attention_interval is not None
+            else None
+        )
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_key_head_dim = linear_key_head_dim
+        self.linear_value_head_dim = linear_value_head_dim
+        self.linear_num_key_heads = linear_num_key_heads
+        self.linear_num_value_heads = linear_num_value_heads
+        self.gdn_output_gate_type = str(gdn_output_gate_type)
+
+        gdn_shape_values = (
+            self.linear_conv_kernel_dim,
+            self.linear_key_head_dim,
+            self.linear_value_head_dim,
+            self.linear_num_key_heads,
+            self.linear_num_value_heads,
+        )
+        has_any_gdn_shape = any(value is not None for value in gdn_shape_values)
+        has_complete_gdn_shape = all(value is not None for value in gdn_shape_values)
+        if has_any_gdn_shape and not has_complete_gdn_shape:
+            raise ValueError("GDN profiling model configuration is incomplete")
+        if has_complete_gdn_shape:
+            self.get_gdn_config()
+        self._sequence_mixer_types = build_sequence_mixer_schedule(
+            num_layers=self.num_layers,
+            layer_types=self.layer_types,
+            full_attention_interval=self.full_attention_interval,
+            has_gated_delta_net=has_complete_gdn_shape,
+        )
 
         # Quantization config for metadata tracking
         if quantization_config is not None and not isinstance(
@@ -241,6 +290,76 @@ class ModelConfig:
         """Return the bound attention family for profiling runtime semantics."""
         return bind_attention_family(self).family
 
+    def get_gdn_config(self) -> Optional[GatedDeltaNetConfig]:
+        values = (
+            self.linear_conv_kernel_dim,
+            self.linear_key_head_dim,
+            self.linear_value_head_dim,
+            self.linear_num_key_heads,
+            self.linear_num_value_heads,
+        )
+        if all(value is None for value in values):
+            return None
+        if any(value is None for value in values):
+            raise ValueError("GDN profiling shape configuration is incomplete")
+        return GatedDeltaNetConfig(
+            conv_kernel_size=int(self.linear_conv_kernel_dim),
+            key_head_dim=int(self.linear_key_head_dim),
+            value_head_dim=int(self.linear_value_head_dim),
+            num_key_heads=int(self.linear_num_key_heads),
+            num_value_heads=int(self.linear_num_value_heads),
+            output_gate_type=self.gdn_output_gate_type,
+        )
+
+    def get_sequence_mixer_types(self) -> tuple[SequenceMixerType, ...]:
+        return self._sequence_mixer_types
+
+    def get_sequence_mixer_type(self, layer_id: int) -> SequenceMixerType:
+        if type(layer_id) is not int or not 0 <= layer_id < self.num_layers:
+            raise ValueError(
+                f"layer_id {layer_id!r} out of range for num_layers={self.num_layers}"
+            )
+        return self._sequence_mixer_types[layer_id]
+
+    def get_sequence_mixer_layer_ids(
+        self,
+        mixer_type: SequenceMixerType,
+        *,
+        start_layer_id: int = 0,
+        end_layer_id: Optional[int] = None,
+    ) -> List[int]:
+        normalized_type = SequenceMixerType.from_config_value(mixer_type)
+        end = self.num_layers if end_layer_id is None else end_layer_id
+        if (
+            type(start_layer_id) is not int
+            or type(end) is not int
+            or start_layer_id < 0
+            or end < start_layer_id
+            or end > self.num_layers
+        ):
+            raise ValueError(
+                "Invalid sequence-mixer layer range: "
+                f"[{start_layer_id!r}, {end!r}) for num_layers={self.num_layers}"
+            )
+        return [
+            layer_id
+            for layer_id in range(start_layer_id, end)
+            if self._sequence_mixer_types[layer_id] is normalized_type
+        ]
+
+    def get_num_gdn_layers(self) -> int:
+        return len(
+            self.get_sequence_mixer_layer_ids(SequenceMixerType.GATED_DELTA_NET)
+        )
+
+    def get_num_full_attention_layers(self) -> int:
+        return len(
+            self.get_sequence_mixer_layer_ids(SequenceMixerType.FULL_ATTENTION)
+        )
+
+    def is_gdn_layer(self, layer_id: int) -> bool:
+        return self.get_sequence_mixer_type(layer_id) is SequenceMixerType.GATED_DELTA_NET
+
     def get_runtime_num_kv_heads(self) -> int:
         """Return runtime KV heads for cache allocation."""
         family = self.get_attention_family()
@@ -306,6 +425,7 @@ class ModelConfig:
         unsupported_fields = [
             '_model_name',
             '_moe_layer_ids_cache',
+            '_sequence_mixer_types_cache',
             'norm_expert_weight',  # Expert normalization field not used in profiling
             'torch_dtype',
         ]
@@ -377,9 +497,19 @@ class ModelConfig:
                 'qk_rope_head_dim',
                 'qk_head_dim',
                 'v_head_dim',
+                'layer_types',
+                'full_attention_interval',
+                'linear_conv_kernel_dim',
+                'linear_key_head_dim',
+                'linear_value_head_dim',
+                'linear_num_key_heads',
+                'linear_num_value_heads',
             ]:
                 if field_name in json_cfg:
                     model_config_dict[field_name] = json_cfg[field_name]
+            model_config_dict['gdn_output_gate_type'] = json_cfg.get(
+                'output_gate_type', model_config_dict.get('gdn_output_gate_type', 'silu')
+            )
             if (
                 'use_mla' not in model_config_dict
                 and str(json_cfg.get('model_type', '')).lower()
@@ -568,6 +698,14 @@ class ModelConfig:
             "qk_rope_head_dim": self.qk_rope_head_dim,
             "qk_head_dim": self.qk_head_dim,
             "v_head_dim": self.v_head_dim,
+            "layer_types": list(self.layer_types) if self.layer_types is not None else None,
+            "full_attention_interval": self.full_attention_interval,
+            "linear_conv_kernel_dim": self.linear_conv_kernel_dim,
+            "linear_key_head_dim": self.linear_key_head_dim,
+            "linear_value_head_dim": self.linear_value_head_dim,
+            "linear_num_key_heads": self.linear_num_key_heads,
+            "linear_num_value_heads": self.linear_num_value_heads,
+            "gdn_output_gate_type": self.gdn_output_gate_type,
             # Quantization config
             "quantization_config": asdict(self.quantization_config) if self.quantization_config else None,
             # LM head weight sharing

--- a/frontier/profiling/common/timer_stats_store.py
+++ b/frontier/profiling/common/timer_stats_store.py
@@ -20,14 +20,27 @@ class TimerStatsStore(metaclass=Singleton):
     def clear_stats(self):
         self.TIMING_STATS = {}
 
-    def get_stats(self):
-        stats = {}
-        for name, times in self.TIMING_STATS.items():
-            times = [
-                (time if isinstance(time, float) else time[0].elapsed_time(time[1]))
+    def get_times(self):
+        """Materialize recorded samples as plain milliseconds."""
+
+        return {
+            name: [
+                float(
+                    time
+                    if isinstance(time, float)
+                    else time[0].elapsed_time(time[1])
+                )
                 for time in times
             ]
+            for name, times in self.TIMING_STATS.items()
+        }
 
+    @staticmethod
+    def get_stats_from_times(times_by_name):
+        """Summarize already-materialized timing samples."""
+
+        stats = {}
+        for name, times in times_by_name.items():
             stats[name] = {
                 "min": np.min(times),
                 "max": np.max(times),
@@ -38,3 +51,6 @@ class TimerStatsStore(metaclass=Singleton):
             }
 
         return stats
+
+    def get_stats(self):
+        return self.get_stats_from_times(self.get_times())

--- a/frontier/profiling/common/vllm_compat.py
+++ b/frontier/profiling/common/vllm_compat.py
@@ -1,0 +1,37 @@
+"""Small compatibility helpers for standalone use of current vLLM custom ops."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Optional
+
+
+@contextmanager
+def vllm_config_context(*, model_config: Optional[Any] = None):
+    """Provide a standalone vLLM config only when none is active.
+
+    ``model_config`` is used by current quantized kernels whose backend oracle
+    reads dtype and quantization choices from the active vLLM configuration.
+    """
+    try:
+        from vllm.config import (
+            VllmConfig,
+            get_current_vllm_config_or_none,
+            set_current_vllm_config,
+        )
+    except ImportError:
+        yield
+        return
+
+    if get_current_vllm_config_or_none() is not None:
+        yield
+        return
+
+    standalone_config = VllmConfig()
+    if model_config is not None:
+        standalone_config.model_config = model_config
+    with set_current_vllm_config(standalone_config):
+        yield
+
+
+__all__ = ["vllm_config_context"]

--- a/frontier/profiling/gdn/README.md
+++ b/frontier/profiling/gdn/README.md
@@ -1,0 +1,35 @@
+# Qwen3.5 GDN profiler
+
+This profiler measures the gated-delta-network layer used by the Qwen3.5
+family, including the hybrid Qwen3.8 checkpoint. It constructs vLLM's real
+`QwenGatedDeltaNetAttention` module, disables the checkpoint's unrelated Quark
+quantizer, and initializes synthetic BF16 projection weights. `A_log` and the
+recurrent state remain FP32, matching the runtime contract. Launch TP profiles
+with `torchrun --nproc-per-node=<TP>` and the matching
+`--tensor-parallel-size`; every timing sample is reduced to the slowest rank.
+
+Run it inside the pinned ROCm container described in
+`docs/profiling/ROCM_MI355X.md`. For the AITER dispatch, set
+`VLLM_ROCM_USE_AITER=1` before Python imports vLLM. The output defaults to:
+
+```text
+data/profiling/compute/{DEVICE}/{MODEL}/gdn.csv
+```
+
+Configure Frontier's eager predictor with `gdn_input_file`; use
+`gdn_kernel_only_input_file` for a separately collected kernel-only dataset.
+The predictor rejects rows whose architecture, quantization, dimensions,
+state layout, or complete runtime stack do not agree.
+
+Before emitting a row, the profiler compares the complete vLLM layer with its
+input-projection, GDN-core, and output-projection decomposition, including both
+BF16 convolution state and FP32 recurrent state. A failed equivalence or
+non-finite output aborts profiling. Cache block zero is reserved as vLLM's null
+block; real request state begins at block one. Do not remove this offset—the
+causal-convolution kernel intentionally skips requests assigned to block zero.
+
+For serving-faithful SGLang measurements with checkpoint weights and graph
+decode, import `sglang.benchmark.one_batch` traces with
+`python -m frontier.profiling.gdn.sglang_trace`. This writes
+`gdn_kernel_only.csv` and deliberately excludes the decoder input norm and
+post-GDN TP all-reduce from the GDN operator samples.

--- a/frontier/profiling/gdn/__init__.py
+++ b/frontier/profiling/gdn/__init__.py
@@ -1,0 +1,5 @@
+"""Gated-delta-network profiling support."""
+
+from frontier.profiling.gdn.inputs import GDNProfileInput
+
+__all__ = ["GDNProfileInput"]

--- a/frontier/profiling/gdn/inputs.py
+++ b/frontier/profiling/gdn/inputs.py
@@ -1,0 +1,130 @@
+"""Workload descriptions for stateful GDN profiling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GDNProfileInput:
+    """One decode-first vLLM GDN batch.
+
+    vLLM's common attention metadata places single-token decodes before
+    multi-token prefills. Frontier makes that ordering explicit instead of
+    silently rearranging caller input.
+    """
+
+    query_lens: tuple[int, ...]
+    context_lens: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.query_lens:
+            raise ValueError("GDN profile input must contain at least one sequence")
+        if len(self.query_lens) != len(self.context_lens):
+            raise ValueError("query_lens and context_lens must have equal length")
+        if any(type(length) is not int or length <= 0 for length in self.query_lens):
+            raise ValueError(f"query_lens must be positive ints: {self.query_lens}")
+        if any(
+            type(length) is not int or length < 0 for length in self.context_lens
+        ):
+            raise ValueError(
+                f"context_lens must be non-negative ints: {self.context_lens}"
+            )
+
+        seen_prefill = False
+        for query_len in self.query_lens:
+            is_decode = query_len == 1
+            if not is_decode:
+                seen_prefill = True
+            elif seen_prefill:
+                raise ValueError(
+                    "GDN mixed batches must be decode-first: all query_len=1 "
+                    "sequences must precede multi-token prefills"
+                )
+
+    @property
+    def batch_size(self) -> int:
+        return len(self.query_lens)
+
+    @property
+    def num_tokens(self) -> int:
+        return sum(self.query_lens)
+
+    @property
+    def num_decode_tokens(self) -> int:
+        return sum(query_len == 1 for query_len in self.query_lens)
+
+    @property
+    def num_prefill_tokens(self) -> int:
+        return self.num_tokens - self.num_decode_tokens
+
+    @property
+    def phase(self) -> str:
+        if self.num_decode_tokens == self.num_tokens:
+            return "decode"
+        if self.num_decode_tokens == 0:
+            return "prefill"
+        return "mixed"
+
+    @property
+    def has_initial_state(self) -> bool:
+        return any(context_len > 0 for context_len in self.context_lens)
+
+    @property
+    def max_query_len(self) -> int:
+        return max(self.query_lens)
+
+    @property
+    def state_block_ids(self) -> tuple[int, ...]:
+        """Return request-state blocks with vLLM's null block reserved.
+
+        vLLM defines cache block zero as ``NULL_BLOCK_ID``. Real request state
+        must therefore start at block one; assigning a request to zero causes
+        the causal-convolution kernel to skip it.
+        """
+
+        return tuple(range(1, self.batch_size + 1))
+
+    @classmethod
+    def prefill(
+        cls,
+        *,
+        seq_len: int,
+        batch_size: int = 1,
+        context_len: int = 0,
+    ) -> "GDNProfileInput":
+        if seq_len <= 1:
+            raise ValueError("GDN prefill seq_len must be greater than one")
+        return cls(
+            query_lens=(int(seq_len),) * int(batch_size),
+            context_lens=(int(context_len),) * int(batch_size),
+        )
+
+    @classmethod
+    def decode(
+        cls,
+        *,
+        batch_size: int,
+        context_len: int,
+    ) -> "GDNProfileInput":
+        if context_len <= 0:
+            raise ValueError("GDN decode context_len must be positive")
+        return cls(
+            query_lens=(1,) * int(batch_size),
+            context_lens=(int(context_len),) * int(batch_size),
+        )
+
+    @classmethod
+    def mixed(
+        cls,
+        *,
+        decode_batch_size: int,
+        decode_context_len: int,
+        prefill_seq_len: int,
+        prefill_context_len: int = 0,
+    ) -> "GDNProfileInput":
+        return cls(
+            query_lens=(1,) * int(decode_batch_size) + (int(prefill_seq_len),),
+            context_lens=(int(decode_context_len),) * int(decode_batch_size)
+            + (int(prefill_context_len),),
+        )

--- a/frontier/profiling/gdn/main.py
+++ b/frontier/profiling/gdn/main.py
@@ -1,0 +1,121 @@
+"""CLI for profiling Qwen3.5 gated-delta-network layers."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from frontier.gdn.profiling_schema import validate_gdn_profiling_dataframe
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.gdn.inputs import GDNProfileInput
+from frontier.profiling.gdn.vllm_wrapper import VllmQwen35GDNWrapper
+from frontier.profiling.utils import build_profile_method_output_path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Frontier model config name")
+    parser.add_argument("--model-path", required=True, help="Local HF model directory")
+    parser.add_argument("--device", default="mi355x")
+    parser.add_argument("--output-dir", default="data/profiling")
+    parser.add_argument("--profile-method", default="cuda_event")
+    parser.add_argument("--prefill-seq-lens", nargs="+", type=int, default=[16, 128, 512])
+    parser.add_argument("--prefill-batch-sizes", nargs="+", type=int, default=[1])
+    parser.add_argument("--decode-batch-sizes", nargs="+", type=int, default=[1, 8, 32])
+    parser.add_argument("--decode-context-len", type=int, default=512)
+    parser.add_argument("--continuation-context-len", type=int, default=512)
+    parser.add_argument("--include-continuation-prefill", action="store_true")
+    parser.add_argument("--include-mixed", action="store_true")
+    parser.add_argument("--warmup-iterations", type=int, default=3)
+    parser.add_argument("--profile-iterations", type=int, default=10)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--max-batch-size", type=int, default=128)
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    return parser.parse_args()
+
+
+def build_profile_inputs(args: argparse.Namespace) -> list[GDNProfileInput]:
+    prefill_batch_sizes = getattr(args, "prefill_batch_sizes", [1])
+    inputs = [
+        GDNProfileInput.prefill(seq_len=seq_len, batch_size=batch_size)
+        for batch_size in prefill_batch_sizes
+        for seq_len in args.prefill_seq_lens
+    ]
+    if args.include_continuation_prefill:
+        inputs.extend(
+            GDNProfileInput.prefill(
+                seq_len=seq_len,
+                batch_size=batch_size,
+                context_len=args.continuation_context_len,
+            )
+            for batch_size in prefill_batch_sizes
+            for seq_len in args.prefill_seq_lens
+        )
+    inputs.extend(
+        GDNProfileInput.decode(
+            batch_size=batch_size,
+            context_len=args.decode_context_len,
+        )
+        for batch_size in args.decode_batch_sizes
+    )
+    if args.include_mixed:
+        inputs.append(
+            GDNProfileInput.mixed(
+                decode_batch_size=max(args.decode_batch_sizes),
+                decode_context_len=args.decode_context_len,
+                prefill_seq_len=max(args.prefill_seq_lens),
+            )
+        )
+    return inputs
+
+
+def main() -> None:
+    args = _parse_args()
+    model_config = ModelConfig.from_model_name(args.model)
+    rows = []
+    with VllmQwen35GDNWrapper(
+        frontier_model_config=model_config,
+        model_path=args.model_path,
+        device_name=args.device,
+        profile_method=args.profile_method,
+        max_model_len=args.max_model_len,
+        max_batch_size=args.max_batch_size,
+        tensor_parallel_size=args.tensor_parallel_size,
+    ) as wrapper:
+        for profile_input in build_profile_inputs(args):
+            rows.append(
+                wrapper.profile(
+                    profile_input,
+                    warmup_iterations=args.warmup_iterations,
+                    profile_iterations=args.profile_iterations,
+                )
+            )
+        writer_rank = wrapper.rank == 0
+
+    if not writer_rank:
+        return
+
+    dataframe = pd.DataFrame(rows)
+    dataframe = (
+        pd.json_normalize(dataframe["time_stats"])
+        .add_prefix("time_stats.")
+        .join(dataframe.drop(columns=["time_stats"]))
+    )
+    validate_gdn_profiling_dataframe(dataframe)
+    output_path = build_profile_method_output_path(
+        output_root=args.output_dir,
+        profiling_type="compute",
+        hardware=args.device,
+        model_name=args.model,
+        op_name="gdn",
+        profile_method=args.profile_method,
+    )
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    dataframe.to_csv(output_path, index=False)
+    print(f"Wrote {len(dataframe)} GDN profiling rows to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/profiling/gdn/sglang_trace.py
+++ b/frontier/profiling/gdn/sglang_trace.py
@@ -1,0 +1,330 @@
+"""Import SGLang torch-profiler traces as Frontier GDN kernel profiles."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+from frontier.gdn import GATED_DELTA_NET_FAMILY
+from frontier.gdn.profiling_schema import validate_gdn_profiling_dataframe
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.common.timer_stats_store import TimerStatsStore
+from frontier.profiling.utils import build_profile_method_output_path
+from frontier.types import MeasurementType
+
+
+_TRACE_FILENAME_RE = re.compile(
+    r"_batch(?P<batch_size>\d+)_input(?P<input_len>\d+)_output(?P<output_len>\d+)"
+    r"_(?P<phase>prefill|decode)\.trace\.json(?:\.gz)?$"
+)
+_INPUT_NORM_KERNELS = (
+    "_gemma_fused_add_rmsnorm_kernel",
+    "_gemma_rmsnorm_kernel",
+)
+_OUTPUT_NORM_KERNEL = "_layer_norm_fwd_1pass_kernel"
+_TRANSFORM_KERNEL = "elementwise_kernel_manual_unroll"
+_ALL_REDUCE_KERNELS = (
+    "quickreduce::allreduce",
+    "cross_device_reduce",
+)
+_PHASE_ANCHORS = {
+    "prefill": "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
+    "decode": "fused_recurrent_gated_delta_rule_packed_decode_kernel",
+}
+
+
+def _contains_any(name: str, fragments: Iterable[str]) -> bool:
+    return any(fragment in name for fragment in fragments)
+
+
+def _load_trace_events(path: str | Path) -> list[dict[str, Any]]:
+    trace_path = Path(path)
+    opener = gzip.open if trace_path.suffix == ".gz" else open
+    with opener(trace_path, "rt", encoding="utf-8") as stream:
+        trace = json.load(stream)
+    events = [
+        event
+        for event in trace.get("traceEvents", ())
+        if event.get("cat") == "kernel"
+        and event.get("ph") == "X"
+        and float(event.get("dur", 0.0)) >= 0.0
+    ]
+    if not events:
+        raise ValueError(f"SGLang trace contains no GPU kernel events: {trace_path}")
+    return sorted(events, key=lambda event: float(event["ts"]))
+
+
+def parse_sglang_trace_shape(path: str | Path) -> dict[str, int | str]:
+    """Read the static-batch shape and phase encoded by one_batch.py."""
+
+    match = _TRACE_FILENAME_RE.search(Path(path).name)
+    if match is None:
+        raise ValueError(
+            "SGLang trace filename must end in "
+            "_batchN_inputN_outputN_{prefill|decode}.trace.json[.gz]: "
+            f"{path}"
+        )
+    values: dict[str, int | str] = match.groupdict()
+    for name in ("batch_size", "input_len", "output_len"):
+        values[name] = int(values[name])
+    return values
+
+
+def _find_previous_input_norm(events: list[dict[str, Any]], anchor: int) -> int:
+    for index in range(anchor - 1, -1, -1):
+        if _contains_any(str(events[index]["name"]), _INPUT_NORM_KERNELS):
+            return index
+    raise ValueError("Could not find the decoder-layer input norm before a GDN anchor")
+
+
+def _find_next(
+    events: list[dict[str, Any]],
+    start: int,
+    predicate,
+    *,
+    description: str,
+) -> int:
+    for index in range(start, len(events)):
+        if predicate(str(events[index]["name"])):
+            return index
+    raise ValueError(f"Could not find {description} after a GDN anchor")
+
+
+def extract_sglang_gdn_samples(
+    path: str | Path,
+    *,
+    phase: str | None = None,
+) -> dict[str, list[float]]:
+    """Extract per-layer kernel milliseconds from an SGLang Kineto trace.
+
+    SGLang's Qwen3.5 layer keeps its input norm and TP all-reduce outside
+    ``Qwen3_5GatedDeltaNet``.  Those kernels are used as stable boundaries but
+    deliberately excluded from the returned GDN samples.
+    """
+
+    shape = parse_sglang_trace_shape(path)
+    trace_phase = str(shape["phase"])
+    if phase is not None and str(phase) != trace_phase:
+        raise ValueError(f"Trace phase {trace_phase!r} does not match {phase!r}")
+    events = _load_trace_events(path)
+    return extract_sglang_gdn_event_samples(events, phase=trace_phase)
+
+
+def extract_sglang_gdn_event_samples(
+    events: list[dict[str, Any]], *, phase: str
+) -> dict[str, list[float]]:
+    """Extract from one rank's ordered GPU kernels, including captured batches."""
+    if phase not in _PHASE_ANCHORS:
+        raise ValueError(f"Unsupported SGLang GDN trace phase: {phase}")
+    trace_phase = phase
+    anchor_fragment = _PHASE_ANCHORS[trace_phase]
+    anchor_indices = [
+        index
+        for index, event in enumerate(events)
+        if anchor_fragment in str(event["name"])
+    ]
+    if not anchor_indices:
+        raise ValueError(
+            f"SGLang {trace_phase} trace contains no GDN anchor {anchor_fragment!r}"
+        )
+
+    samples = {
+        "gdn_input_projections": [],
+        f"gdn_core_{trace_phase}": [],
+        "gdn_output_projection": [],
+        "gdn_layer_e2e": [],
+    }
+    for anchor in anchor_indices:
+        input_norm = _find_previous_input_norm(events, anchor)
+        layer_start = input_norm + 1
+        transform_start = _find_next(
+            events,
+            layer_start,
+            lambda name: _TRANSFORM_KERNEL in name,
+            description="the first GDN projection-output transform",
+        )
+        output_start = _find_next(
+            events,
+            anchor + 1,
+            lambda name: _OUTPUT_NORM_KERNEL in name,
+            description="the GDN gated output norm",
+        )
+        all_reduce = _find_next(
+            events,
+            output_start + 1,
+            lambda name: _contains_any(name, _ALL_REDUCE_KERNELS),
+            description="the post-GDN TP all-reduce",
+        )
+        layer_end = all_reduce - 1
+        if not (layer_start < transform_start <= anchor < output_start <= layer_end):
+            raise ValueError(
+                "Invalid SGLang GDN kernel ordering: "
+                f"start={layer_start}, transform={transform_start}, anchor={anchor}, "
+                f"output={output_start}, end={layer_end}"
+            )
+
+        def elapsed_ms(start: int, end: int) -> float:
+            # Kineto records GPU durations in microseconds.
+            return sum(float(events[index]["dur"]) for index in range(start, end + 1)) / 1000.0
+
+        input_ms = elapsed_ms(layer_start, transform_start - 1)
+        core_ms = elapsed_ms(transform_start, output_start - 1)
+        output_ms = elapsed_ms(output_start, layer_end)
+        samples["gdn_input_projections"].append(input_ms)
+        samples[f"gdn_core_{trace_phase}"].append(core_ms)
+        samples["gdn_output_projection"].append(output_ms)
+        samples["gdn_layer_e2e"].append(input_ms + core_ms + output_ms)
+
+    return samples
+
+
+def build_sglang_profile_row(
+    path: str | Path,
+    *,
+    model_config: ModelConfig,
+    device: str,
+    tensor_parallel_size: int,
+    runtime_stack_signature: str,
+) -> dict[str, Any]:
+    shape = parse_sglang_trace_shape(path)
+    return build_sglang_profile_row_from_samples(
+        extract_sglang_gdn_samples(path, phase=str(shape["phase"])),
+        shape=shape, trace_path=str(path), model_config=model_config, device=device,
+        tensor_parallel_size=tensor_parallel_size,
+        runtime_stack_signature=runtime_stack_signature,
+    )
+
+
+def build_sglang_profile_row_from_samples(
+    samples: dict[str, list[float]], *, shape: dict[str, Any], trace_path: str,
+    model_config: ModelConfig, device: str, tensor_parallel_size: int,
+    runtime_stack_signature: str,
+) -> dict[str, Any]:
+    """Share profile metadata/units between filename and batch-ledger imports."""
+    phase = str(shape["phase"])
+    if phase not in _PHASE_ANCHORS:
+        raise ValueError(f"Unsupported SGLang GDN profile phase: {phase}")
+    batch_size = int(shape["batch_size"])
+    input_len = int(shape["input_len"])
+    expected_layers = model_config.get_num_gdn_layers()
+    sample_count = len(samples["gdn_layer_e2e"])
+    if expected_layers <= 0 or sample_count <= 0 or sample_count % expected_layers != 0:
+        raise ValueError(
+            "SGLang GDN sample count must be a positive multiple of the model's "
+            f"GDN layer count: samples={sample_count}, layers={expected_layers}"
+        )
+
+    time_stats = TimerStatsStore.get_stats_from_times(samples)
+    sample_iterations = sample_count // expected_layers
+    for operator in GATED_DELTA_NET_FAMILY.operators:
+        time_stats.setdefault(
+            operator.profiling_name(),
+            {
+                "min": 0.0,
+                "max": 0.0,
+                "mean": 0.0,
+                "median": 0.0,
+                "std": 0.0,
+                "count": sample_count,
+            },
+        )
+
+    gdn_config = model_config.get_gdn_config()
+    if gdn_config is None:
+        raise ValueError("SGLang GDN trace import requires GDN model dimensions")
+    is_prefill = phase == "prefill"
+    return {
+        "measurement_type": MeasurementType.KERNEL_ONLY.value,
+        "model_architecture_profile": (
+            model_config.get_model_architecture_profile().profile_id
+        ),
+        "quant_signature": model_config.get_quant_signature(),
+        "device": str(device),
+        "runtime_stack_signature": str(runtime_stack_signature),
+        "gdn_runtime_backend": "sglang_rocm_aiter_trace",
+        "gdn_rank_aggregation": "single_rank_kernel_trace",
+        "gdn_prefill_backend": "triton_chunk_gated_delta_rule",
+        "gdn_decode_backend": "packed_recurrent_triton",
+        "gqa_interleaved_layout": False,
+        "packed_recurrent_decode": True,
+        "model_dtype": str(model_config.dtype),
+        "conv_state_dtype": "bfloat16",
+        "recurrent_state_dtype": "float32",
+        "weight_source": "checkpoint_quark_mxfp4",
+        "num_tensor_parallel_workers": int(tensor_parallel_size),
+        "hidden_size": model_config.embedding_dim,
+        "conv_kernel_size": gdn_config.conv_kernel_size,
+        "key_head_dim": gdn_config.key_head_dim,
+        "value_head_dim": gdn_config.value_head_dim,
+        "num_key_heads": gdn_config.num_key_heads,
+        "num_value_heads": gdn_config.num_value_heads,
+        "batch_size": batch_size,
+        "batch_num_tokens": batch_size * input_len if is_prefill else batch_size,
+        "batch_num_prefill_tokens": batch_size * input_len if is_prefill else 0,
+        "batch_num_decode_tokens": 0 if is_prefill else batch_size,
+        "max_query_len": input_len if is_prefill else 1,
+        "has_initial_state": not is_prefill,
+        "query_lens": [input_len] * batch_size if is_prefill else [1] * batch_size,
+        "context_lens": [0] * batch_size if is_prefill else [input_len] * batch_size,
+        "trace_path": trace_path,
+        "trace_profiled_iterations": sample_iterations,
+        "time_stats": time_stats,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace", action="append", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", default="mi355x")
+    parser.add_argument("--tensor-parallel-size", type=int, default=8)
+    parser.add_argument("--output-dir", default="data/profiling")
+    parser.add_argument(
+        "--runtime-stack-signature",
+        required=True,
+        help="Pinned SGLang/torch/ROCm/AITER revision signature",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    model_config = ModelConfig.from_model_name(args.model)
+    rows = [
+        build_sglang_profile_row(
+            path,
+            model_config=model_config,
+            device=args.device,
+            tensor_parallel_size=args.tensor_parallel_size,
+            runtime_stack_signature=args.runtime_stack_signature,
+        )
+        for path in args.trace
+    ]
+    dataframe = pd.DataFrame(rows)
+    dataframe = (
+        pd.json_normalize(dataframe["time_stats"])
+        .add_prefix("time_stats.")
+        .join(dataframe.drop(columns=["time_stats"]))
+    )
+    validate_gdn_profiling_dataframe(dataframe)
+    output_path = build_profile_method_output_path(
+        output_root=args.output_dir,
+        profiling_type="compute",
+        hardware=args.device,
+        model_name=args.model,
+        op_name="gdn",
+        profile_method="record_function",
+    )
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    dataframe.to_csv(output_path, index=False)
+    print(f"Wrote {len(dataframe)} SGLang GDN trace rows to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/profiling/gdn/vllm_wrapper.py
+++ b/frontier/profiling/gdn/vllm_wrapper.py
@@ -1,0 +1,586 @@
+"""Truth-backed Qwen3.5 GDN profiler for the pinned vLLM runtime."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+from contextlib import nullcontext
+from typing import Any
+
+from frontier.gdn import GATED_DELTA_NET_FAMILY
+from frontier.profiling.common.cuda_timer import CudaTimer
+from frontier.profiling.common.timer_stats_store import TimerStatsStore
+from frontier.profiling.gdn.inputs import GDNProfileInput
+from frontier.profiling.utils import profile_method_to_measurement_type
+
+
+class VllmQwen35GDNWrapper:
+    """Profile the actual vLLM Qwen GDN module with synthetic BF16 weights.
+
+    Multi-rank profiles use torchrun and aggregate the slowest rank for every
+    timing sample. The module is constructed with ``reduce_results=False`` so
+    Frontier can model TP collectives through its communication family.
+    """
+
+    def __init__(
+        self,
+        *,
+        frontier_model_config: Any,
+        model_path: str,
+        device_name: str,
+        profile_method: str = "cuda_event",
+        max_model_len: int = 4096,
+        max_batch_size: int = 128,
+        tensor_parallel_size: int = 1,
+    ) -> None:
+        tensor_parallel_size = int(tensor_parallel_size)
+        if tensor_parallel_size <= 0:
+            raise ValueError("tensor_parallel_size must be positive")
+        if frontier_model_config.get_gdn_config() is None:
+            raise ValueError("GDN profiler requires a model with GDN dimensions")
+        if frontier_model_config.get_num_gdn_layers() <= 0:
+            raise ValueError("GDN profiler requires at least one GDN layer")
+
+        import torch
+        import triton
+        import vllm
+        from vllm.config import (
+            CacheConfig,
+            CompilationConfig,
+            CompilationMode,
+            ModelConfig as VllmModelConfig,
+            ParallelConfig,
+            VllmConfig,
+            set_current_vllm_config,
+        )
+        from vllm.distributed import (
+            destroy_model_parallel,
+            init_distributed_environment,
+            initialize_model_parallel,
+            model_parallel_is_initialized,
+        )
+        from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+            GDN_AITER_TRITON_AVAILABLE,
+            QwenGatedDeltaNetAttention,
+            _encode_layer_name,
+        )
+        from vllm.utils.network_utils import get_open_port
+        from vllm.utils.torch_utils import set_default_torch_dtype
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("GDN profiling requires a CUDA/HIP device")
+        if getattr(torch.version, "hip", None) is None:
+            raise RuntimeError("This GDN profiler slice targets ROCm/gfx950")
+        self.torch = torch
+        self.frontier_model_config = frontier_model_config
+        self.model_path = str(model_path)
+        self.device_name = str(device_name)
+        self.profile_method = str(profile_method)
+        self.max_batch_size = int(max_batch_size)
+        self.tensor_parallel_size = tensor_parallel_size
+        distributed_world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        self.rank = int(os.environ.get("RANK", "0"))
+        self.local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        if distributed_world_size != self.tensor_parallel_size:
+            raise RuntimeError(
+                "GDN profiling world size must equal tensor parallel size: "
+                f"WORLD_SIZE={distributed_world_size}, "
+                f"tensor_parallel_size={self.tensor_parallel_size}. Use "
+                "torchrun --nproc-per-node=<tensor_parallel_size>."
+            )
+        self.prefix = "model.layers.0.linear_attn"
+        self.encoded_layer_name = _encode_layer_name(self.prefix)
+        self.use_aiter_dispatch = bool(GDN_AITER_TRITON_AVAILABLE)
+        self._owns_distributed = False
+        self._destroy_model_parallel = destroy_model_parallel
+
+        torch.cuda.set_device(self.local_rank)
+        vllm_model_config = VllmModelConfig(
+            model=self.model_path,
+            tokenizer=self.model_path,
+            skip_tokenizer_init=True,
+            dtype="bfloat16",
+            max_model_len=int(max_model_len),
+            enforce_eager=True,
+            # The checkpoint excludes every GDN projection from MXFP4. Avoid
+            # constructing unrelated Quark quantizers for this isolated layer.
+            hf_overrides={"quantization_config": None},
+        )
+        self.vllm_config = VllmConfig(
+            model_config=vllm_model_config,
+            cache_config=CacheConfig(
+                block_size=16,
+                enable_prefix_caching=False,
+                mamba_cache_dtype="auto",
+                mamba_ssm_cache_dtype="auto",
+            ),
+            parallel_config=ParallelConfig(
+                tensor_parallel_size=self.tensor_parallel_size
+            ),
+            compilation_config=CompilationConfig(mode=CompilationMode.NONE),
+        )
+        self._set_current_vllm_config = set_current_vllm_config
+
+        with set_current_vllm_config(self.vllm_config):
+            if not torch.distributed.is_initialized():
+                distributed_init_method = (
+                    "env://"
+                    if distributed_world_size > 1
+                    else f"tcp://127.0.0.1:{get_open_port()}"
+                )
+                init_distributed_environment(
+                    world_size=distributed_world_size,
+                    rank=self.rank,
+                    local_rank=self.local_rank,
+                    distributed_init_method=distributed_init_method,
+                )
+                self._owns_distributed = True
+            if not model_parallel_is_initialized():
+                initialize_model_parallel(
+                    tensor_model_parallel_size=self.tensor_parallel_size,
+                    pipeline_model_parallel_size=1,
+                )
+            with set_default_torch_dtype(torch.bfloat16):
+                self.layer = QwenGatedDeltaNetAttention(
+                    vllm_model_config.hf_config,
+                    self.vllm_config,
+                    prefix=self.prefix,
+                    gqa_interleaved_layout=False,
+                    reduce_results=False,
+                ).to(device="cuda")
+
+        self._initialize_synthetic_weights()
+        self.layer.requires_grad_(False)
+        self.layer.eval()
+        self.kv_cache_spec = self.layer.get_kv_cache_spec(self.vllm_config)
+        if self.kv_cache_spec is None:
+            raise RuntimeError("vLLM Qwen GDN layer did not expose a state-cache spec")
+        self.raw_state_pages = torch.zeros(
+            (self.max_batch_size + 1, 1, 1, self.kv_cache_spec.page_size_bytes),
+            dtype=torch.int8,
+            device="cuda",
+        )
+        self.layer.bind_kv_cache(self.raw_state_pages)
+
+        from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+
+        self.metadata_builder = GDNAttentionMetadataBuilder(
+            self.kv_cache_spec,
+            [self.prefix],
+            self.vllm_config,
+            torch.device("cuda"),
+        )
+        self.timer_stats_store = TimerStatsStore(profile_method=self.profile_method)
+        self.runtime_stack_signature = ";".join(
+            (
+                f"vllm={vllm.__version__}",
+                f"torch={torch.__version__}",
+                f"hip={torch.version.hip}",
+                f"triton={triton.__version__}",
+                f"aiter={self._package_version('amd-aiter')}",
+            )
+        )
+
+        actual_shapes = tuple(tuple(shape) for shape in self.layer.get_state_shape())
+        actual_dtypes = tuple(self.layer.get_state_dtype())
+        expected_layout = frontier_model_config.get_gdn_config().get_state_layout(
+            tensor_parallel_size=self.tensor_parallel_size,
+            conv_bytes_per_element=actual_dtypes[0].itemsize,
+            recurrent_bytes_per_element=actual_dtypes[1].itemsize,
+        )
+        expected_shapes = (
+            expected_layout.conv_state_shape,
+            expected_layout.recurrent_state_shape,
+        )
+        if actual_shapes != expected_shapes:
+            raise RuntimeError(
+                f"Frontier/vLLM GDN state-shape mismatch: {expected_shapes} != "
+                f"{actual_shapes}"
+            )
+        if int(self.kv_cache_spec.page_size_bytes) != expected_layout.total_bytes:
+            raise RuntimeError(
+                "Frontier/vLLM GDN state-byte mismatch: "
+                f"{expected_layout.total_bytes} != {self.kv_cache_spec.page_size_bytes}"
+            )
+
+    @staticmethod
+    def _package_version(package_name: str) -> str:
+        try:
+            return importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            return "unknown"
+
+    def _initialize_synthetic_weights(self) -> None:
+        torch = self.torch
+        with torch.no_grad():
+            for name, parameter in self.layer.named_parameters():
+                if name.endswith("A_log") or name.endswith("dt_bias"):
+                    parameter.zero_()
+                elif name.endswith("norm.weight"):
+                    parameter.fill_(1.0)
+                else:
+                    parameter.normal_(mean=0.0, std=0.01)
+
+    def _build_metadata(self, profile_input: GDNProfileInput):
+        if profile_input.batch_size > self.max_batch_size:
+            raise ValueError(
+                f"batch_size={profile_input.batch_size} exceeds configured "
+                f"max_batch_size={self.max_batch_size}"
+            )
+        torch = self.torch
+        from vllm.v1.attention.backend import CommonAttentionMetadata
+
+        query_start_loc_cpu = torch.zeros(
+            profile_input.batch_size + 1,
+            dtype=torch.int32,
+        )
+        torch.cumsum(
+            torch.tensor(profile_input.query_lens, dtype=torch.int32),
+            dim=0,
+            out=query_start_loc_cpu[1:],
+        )
+        seq_lens_cpu = torch.tensor(
+            [
+                query_len + context_len
+                for query_len, context_len in zip(
+                    profile_input.query_lens,
+                    profile_input.context_lens,
+                )
+            ],
+            dtype=torch.int32,
+        )
+        common_metadata = CommonAttentionMetadata(
+            query_start_loc=query_start_loc_cpu.cuda(),
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens_cpu.cuda(),
+            num_reqs=profile_input.batch_size,
+            num_actual_tokens=profile_input.num_tokens,
+            max_query_len=profile_input.max_query_len,
+            max_seq_len=int(seq_lens_cpu.max().item()),
+            # vLLM reserves block zero as NULL_BLOCK_ID. The extra state page
+            # allocated by the wrapper is the null page; requests begin at 1.
+            block_table_tensor=torch.tensor(
+                profile_input.state_block_ids,
+                dtype=torch.int32,
+                device="cuda",
+            ).view(-1, 1),
+            slot_mapping=torch.arange(
+                profile_input.num_tokens,
+                dtype=torch.int64,
+                device="cuda",
+            ),
+            _num_computed_tokens_cpu=torch.tensor(
+                profile_input.context_lens,
+                dtype=torch.int32,
+            ),
+        )
+        return self.metadata_builder.build(0, common_metadata)
+
+    def _forward_context(self, metadata, num_tokens: int):
+        from vllm.forward_context import set_forward_context
+
+        return set_forward_context(
+            {self.prefix: metadata},
+            self.vllm_config,
+            num_tokens=num_tokens,
+        )
+
+    def _run_e2e(self, hidden_states, metadata, *, timed: bool):
+        timer = CudaTimer("gdn_layer_e2e") if timed else nullcontext()
+        with self._set_current_vllm_config(self.vllm_config):
+            with self._forward_context(metadata, hidden_states.shape[0]):
+                with timer:
+                    if self.use_aiter_dispatch:
+                        return self.layer.forward_hip(hidden_states)
+                    return self.layer.forward_cuda(hidden_states)
+
+    def _run_decomposed(
+        self,
+        hidden_states,
+        metadata,
+        phase: str,
+        *,
+        timed: bool,
+    ):
+        torch = self.torch
+        projection_timer = (
+            CudaTimer("gdn_input_projections") if timed else nullcontext()
+        )
+        core_timer = CudaTimer(f"gdn_core_{phase}") if timed else nullcontext()
+        output_timer = (
+            CudaTimer("gdn_output_projection") if timed else nullcontext()
+        )
+        with self._set_current_vllm_config(self.vllm_config):
+            with self._forward_context(metadata, hidden_states.shape[0]):
+                with projection_timer:
+                    projected_qkvz, _ = self.layer.in_proj_qkvz(hidden_states)
+                    projected_ba, _ = self.layer.in_proj_ba(hidden_states)
+                    projected_qkvz = projected_qkvz.view(hidden_states.shape[0], -1)
+                    projected_ba = projected_ba.view(hidden_states.shape[0], -1)
+                # Match vLLM's generic ROCm path exactly. Some metadata rows do
+                # not overwrite every output lane, so an uninitialized buffer
+                # would make the decomposition both incorrect and unstable.
+                core_attn_out = torch.zeros(
+                    (
+                        hidden_states.shape[0],
+                        self.layer.num_v_heads // self.layer.tp_size,
+                        self.layer.head_v_dim,
+                    ),
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
+                z = torch.empty_like(core_attn_out)
+                with core_timer:
+                    if self.use_aiter_dispatch:
+                        torch.ops.vllm.qwen_gdn_attention_core(
+                            projected_qkvz,
+                            projected_ba,
+                            z,
+                            core_attn_out,
+                            layer_name=self.encoded_layer_name,
+                            use_aiter=True,
+                        )
+                    else:
+                        qkv_size = (
+                            self.layer.key_dim * 2 + self.layer.value_dim
+                        ) // self.layer.tp_size
+                        z_size = self.layer.value_dim // self.layer.tp_size
+                        mixed_qkv, z_flat = projected_qkvz.split(
+                            [qkv_size, z_size], dim=-1
+                        )
+                        z.copy_(
+                            z_flat.reshape(
+                                hidden_states.shape[0],
+                                -1,
+                                self.layer.head_v_dim,
+                            )
+                        )
+                        b, a = projected_ba.chunk(2, dim=-1)
+                        torch.ops.vllm.qwen_gdn_attention_core(
+                            mixed_qkv,
+                            b.contiguous(),
+                            a.contiguous(),
+                            core_attn_out,
+                            layer_name=self.encoded_layer_name,
+                            use_aiter=False,
+                        )
+                with output_timer:
+                    return self.layer._output_projection(core_attn_out, z)
+
+    def _reset_state(self) -> None:
+        self.raw_state_pages.zero_()
+
+    def _aggregate_time_samples(self, time_samples):
+        """Take the per-iteration slowest rank for TP critical-path timing."""
+
+        if self.tensor_parallel_size == 1:
+            return time_samples
+        torch = self.torch
+        operator_names = sorted(time_samples)
+        sample_counts = {len(time_samples[name]) for name in operator_names}
+        if len(sample_counts) != 1:
+            raise RuntimeError(
+                f"GDN operators have inconsistent sample counts: {sample_counts}"
+            )
+        sample_matrix = torch.tensor(
+            [time_samples[name] for name in operator_names],
+            dtype=torch.float64,
+            device="cuda",
+        )
+        torch.distributed.all_reduce(
+            sample_matrix,
+            op=torch.distributed.ReduceOp.MAX,
+        )
+        aggregated = sample_matrix.cpu().tolist()
+        return dict(zip(operator_names, aggregated))
+
+    def _validate_decomposition(
+        self,
+        hidden_states,
+        profile_input: GDNProfileInput,
+        metadata,
+    ) -> None:
+        torch = self.torch
+        self._reset_state()
+        expected = self._run_e2e(
+            hidden_states,
+            metadata,
+            timed=False,
+        )
+        # Materialize the result before resetting the recurrent state. The
+        # underlying Triton kernels are asynchronous and may reuse scratch
+        # storage on a later invocation.
+        torch.cuda.synchronize()
+        expected = expected.clone()
+        expected_state = tuple(state.clone() for state in self.layer.kv_cache)
+        torch.cuda.synchronize()
+        self._reset_state()
+        actual = self._run_decomposed(
+            hidden_states,
+            metadata,
+            profile_input.phase,
+            timed=False,
+        )
+        torch.cuda.synchronize()
+        actual = actual.clone()
+        actual_state = tuple(state.clone() for state in self.layer.kv_cache)
+        torch.cuda.synchronize()
+        if not torch.isfinite(expected).all() or not torch.isfinite(actual).all():
+            raise AssertionError("GDN decomposition produced non-finite output")
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+        for actual_tensor, expected_tensor in zip(actual_state, expected_state):
+            if not torch.isfinite(expected_tensor).all() or not torch.isfinite(
+                actual_tensor
+            ).all():
+                raise AssertionError("GDN decomposition produced non-finite state")
+            torch.testing.assert_close(
+                actual_tensor,
+                expected_tensor,
+                rtol=2e-2,
+                atol=2e-2,
+            )
+
+    @staticmethod
+    def _zero_stats(count: int) -> dict[str, float | int]:
+        return {
+            "min": 0.0,
+            "max": 0.0,
+            "mean": 0.0,
+            "median": 0.0,
+            "std": 0.0,
+            "count": int(count),
+        }
+
+    def profile(
+        self,
+        profile_input: GDNProfileInput,
+        *,
+        warmup_iterations: int = 3,
+        profile_iterations: int = 10,
+    ) -> dict[str, Any]:
+        if warmup_iterations < 0 or profile_iterations <= 0:
+            raise ValueError("warmup_iterations must be >= 0 and profile_iterations > 0")
+        torch = self.torch
+        hidden_states = torch.randn(
+            (profile_input.num_tokens, self.frontier_model_config.embedding_dim),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        # Retain the metadata object until every asynchronous kernel using its
+        # device-side pointer tables has completed. This also keeps the timed
+        # region focused on layer execution instead of metadata construction.
+        metadata = self._build_metadata(profile_input)
+        # The first invocation may compile/autotune shape-specific Triton/FLA
+        # kernels. Warm both paths before the numerical decomposition check so
+        # compilation work and temporary autotuning buffers cannot masquerade
+        # as a correctness mismatch.
+        for _ in range(max(1, warmup_iterations)):
+            self._reset_state()
+            self._run_e2e(
+                hidden_states,
+                metadata,
+                timed=False,
+            )
+            self._reset_state()
+            self._run_decomposed(
+                hidden_states,
+                metadata,
+                profile_input.phase,
+                timed=False,
+            )
+        torch.cuda.synchronize()
+        self._validate_decomposition(hidden_states, profile_input, metadata)
+        torch.cuda.synchronize()
+        self.timer_stats_store.clear_stats()
+
+        for _ in range(profile_iterations):
+            self._reset_state()
+            self._run_e2e(
+                hidden_states,
+                metadata,
+                timed=True,
+            )
+            self._reset_state()
+            self._run_decomposed(
+                hidden_states,
+                metadata,
+                profile_input.phase,
+                timed=True,
+            )
+        torch.cuda.synchronize()
+        time_samples = self.timer_stats_store.get_times()
+        time_samples = self._aggregate_time_samples(time_samples)
+        time_stats = self.timer_stats_store.get_stats_from_times(time_samples)
+        for operator in GATED_DELTA_NET_FAMILY.operators:
+            time_stats.setdefault(
+                operator.profiling_name(),
+                self._zero_stats(profile_iterations),
+            )
+
+        state_dtypes = self.layer.get_state_dtype()
+        gdn_config = self.frontier_model_config.get_gdn_config()
+        return {
+            "measurement_type": profile_method_to_measurement_type(
+                self.profile_method
+            ).value,
+            "model_architecture_profile": (
+                self.frontier_model_config.get_model_architecture_profile().profile_id
+            ),
+            "quant_signature": self.frontier_model_config.get_quant_signature(),
+            "device": self.device_name,
+            "runtime_stack_signature": self.runtime_stack_signature,
+            "gdn_runtime_backend": (
+                "vllm_rocm_aiter_triton_dispatch"
+                if self.use_aiter_dispatch
+                else "vllm_rocm_standard_dispatch"
+            ),
+            "gdn_rank_aggregation": (
+                "single_rank"
+                if self.tensor_parallel_size == 1
+                else "per_sample_rank_max"
+            ),
+            "gdn_prefill_backend": str(self.layer.gdn_prefill_backend),
+            "gdn_decode_backend": (
+                "packed_recurrent_triton"
+                if self.layer.enable_packed_recurrent_decode
+                and self.layer.gdn_decode_kernel == "triton"
+                else str(self.layer.gdn_decode_kernel)
+            ),
+            "gqa_interleaved_layout": bool(self.layer.gqa_interleaved_layout),
+            "packed_recurrent_decode": bool(
+                self.layer.enable_packed_recurrent_decode
+            ),
+            "model_dtype": str(self.frontier_model_config.dtype),
+            "conv_state_dtype": str(state_dtypes[0]).removeprefix("torch."),
+            "recurrent_state_dtype": str(state_dtypes[1]).removeprefix("torch."),
+            "weight_source": "synthetic_bf16",
+            "num_tensor_parallel_workers": self.tensor_parallel_size,
+            "hidden_size": self.frontier_model_config.embedding_dim,
+            "conv_kernel_size": gdn_config.conv_kernel_size,
+            "key_head_dim": gdn_config.key_head_dim,
+            "value_head_dim": gdn_config.value_head_dim,
+            "num_key_heads": gdn_config.num_key_heads,
+            "num_value_heads": gdn_config.num_value_heads,
+            "batch_size": profile_input.batch_size,
+            "batch_num_tokens": profile_input.num_tokens,
+            "batch_num_prefill_tokens": profile_input.num_prefill_tokens,
+            "batch_num_decode_tokens": profile_input.num_decode_tokens,
+            "max_query_len": profile_input.max_query_len,
+            "has_initial_state": profile_input.has_initial_state,
+            "query_lens": list(profile_input.query_lens),
+            "context_lens": list(profile_input.context_lens),
+            "time_stats": time_stats,
+        }
+
+    def close(self) -> None:
+        if self._owns_distributed:
+            self._destroy_model_parallel()
+            if self.torch.distributed.is_initialized():
+                self.torch.distributed.destroy_process_group()
+            self._owns_distributed = False
+
+    def __enter__(self) -> "VllmQwen35GDNWrapper":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()

--- a/frontier/profiling/linear_op/linear_op_impl.py
+++ b/frontier/profiling/linear_op/linear_op_impl.py
@@ -63,7 +63,8 @@ def _supports_share_expert(config: ModelConfig) -> bool:
 def _uses_gemma_rms_norm(config: ModelConfig) -> bool:
     return (
         getattr(config, "norm", None) == "rms_norm"
-        and getattr(config, "model_type", None) == "qwen3_next"
+        and getattr(config, "model_type", None)
+        in {"qwen3_next", "qwen3_5_moe_text"}
     )
 
 

--- a/frontier/profiling/linear_op/main.py
+++ b/frontier/profiling/linear_op/main.py
@@ -64,6 +64,10 @@ except ImportError:
     ray = None
 
 from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.common.accelerator import (
+    get_available_gpu_ids,
+    set_process_visible_device,
+)
 from frontier.profiling.linear_op.ray_setup_hook import (
     disable_ray_datasets_serializers,
 )
@@ -91,56 +95,8 @@ def _ensure_torch_available():
 
 
 def _get_available_gpus(num_gpus: int) -> List[int]:
-    """
-    Get list of available GPU IDs based on CUDA_VISIBLE_DEVICES and num_gpus.
-
-    Returns:
-        List of GPU IDs to use for profiling
-    """
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-    if cuda_visible:
-        available = [int(x.strip()) for x in cuda_visible.split(",") if x.strip()]
-    else:
-        try:
-            import subprocess
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                available = [
-                    int(x.strip()) for x in result.stdout.strip().split("\n") if x.strip()
-                ]
-            else:
-                raise RuntimeError(
-                    "Unable to discover GPUs with nvidia-smi. Set "
-                    "CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi before "
-                    "running linear-op profiling. "
-                    f"nvidia-smi stderr: {result.stderr.strip()}"
-                )
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because nvidia-smi was "
-                "not found. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running linear-op profiling."
-            ) from exc
-
-        if not available:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because it returned no "
-                "GPU indices. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running linear-op profiling."
-            )
-
-    if len(available) < num_gpus:
-        raise RuntimeError(
-            f"Requested {num_gpus} GPUs but only found {len(available)} visible GPUs "
-            f"(CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES', '')})."
-        )
-
-    return available[:num_gpus]
+    """Discover GPUs without initializing torch in the parent process."""
+    return get_available_gpu_ids(num_gpus)
 
 
 # Global variable to track CUDA initialization in worker process
@@ -787,8 +743,10 @@ def profile_model(
                     executor.shutdown(wait=True, cancel_futures=True)
         else:
             # Single-GPU sequential mode
-            os.environ["CUDA_VISIBLE_DEVICES"] = str(available_gpus[0])
             torch_module = _ensure_torch_available()
+            set_process_visible_device(
+                available_gpus[0], torch_module=torch_module
+            )
             torch_module.cuda.set_device(0)
 
             wrapper = LinearOpWrapper(

--- a/frontier/profiling/moe/main.py
+++ b/frontier/profiling/moe/main.py
@@ -57,6 +57,10 @@ except ImportError:
     ray = None
 
 from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.common.accelerator import (
+    get_available_gpu_ids,
+    set_process_visible_device,
+)
 from frontier.profiling.utils import (
     EXPORTABLE_PROFILE_METHOD_CHOICES,
     ProfileMethod,
@@ -93,7 +97,7 @@ def _get_moe_wrapper_class():
 def _worker_init(gpu_id: int) -> None:
     """Initialize worker process with specific GPU binding."""
     import torch
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    set_process_visible_device(gpu_id, torch_module=torch)
     torch.cuda.set_device(0)  # Device 0 within this process's visible devices
 
 
@@ -856,7 +860,9 @@ def profile_model(
             else:
                 # Single-GPU sequential mode
                 import torch
-                os.environ["CUDA_VISIBLE_DEVICES"] = str(available_gpus[0])
+                set_process_visible_device(
+                    available_gpus[0], torch_module=torch
+                )
                 torch.cuda.set_device(0)
 
                 wrapper_kwargs = {
@@ -916,59 +922,8 @@ def profile_model(
 
 
 def _get_available_gpus(num_gpus: int) -> List[int]:
-    """
-    Get list of available GPU IDs based on CUDA_VISIBLE_DEVICES and num_gpus.
-
-    Returns:
-        List of GPU IDs to use for profiling
-    """
-    # Check CUDA_VISIBLE_DEVICES
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-    if cuda_visible:
-        # Parse CUDA_VISIBLE_DEVICES
-        available = [int(x.strip()) for x in cuda_visible.split(",") if x.strip()]
-    else:
-        try:
-            import subprocess
-
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                available = [
-                    int(x.strip()) for x in result.stdout.strip().split("\n") if x.strip()
-                ]
-            else:
-                raise RuntimeError(
-                    "Unable to discover GPUs with nvidia-smi. Set "
-                    "CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi before "
-                    "running MoE profiling. "
-                    f"nvidia-smi stderr: {result.stderr.strip()}"
-                )
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because nvidia-smi was "
-                "not found. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running MoE profiling."
-            ) from exc
-
-        if not available:
-            raise RuntimeError(
-                "Unable to discover GPUs with nvidia-smi because it returned no "
-                "GPU indices. Set CUDA_VISIBLE_DEVICES explicitly or fix nvidia-smi "
-                "before running MoE profiling."
-            )
-
-    if len(available) < num_gpus:
-        raise RuntimeError(
-            f"Requested {num_gpus} GPUs but only found {len(available)} visible GPUs "
-            f"(CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES', '')})."
-        )
-
-    return available[:num_gpus]
+    """Discover GPUs without initializing torch in the parent process."""
+    return get_available_gpu_ids(num_gpus)
 
 
 def main():

--- a/frontier/profiling/moe/moe_impl.py
+++ b/frontier/profiling/moe/moe_impl.py
@@ -24,15 +24,38 @@ from frontier.profiling.common.parallel_utils.tensor_parallel_layers import (
     RowParallelLinear,
 )
 from frontier.profiling.common.utils import raise_if_fp8_requested
+
 try:
-    from vllm.model_executor.layers.fused_moe.fused_moe import (
-        fused_topk,
-        get_config_dtype_str,
-        try_get_optimal_moe_config,
-    )
-    from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
-        moe_align_block_size,
-    )
+    try:
+        # Current vLLM exports routing from the package root.
+        from vllm.model_executor.layers.fused_moe import fused_topk
+    except ImportError:
+        # vLLM 0.10.x kept routing in the implementation module.
+        from vllm.model_executor.layers.fused_moe.fused_moe import fused_topk
+
+    try:
+        # Current vLLM's package-level name is a module, while the callable
+        # remains in fused_moe.py.
+        from vllm.model_executor.layers.fused_moe.fused_moe import (
+            moe_align_block_size,
+        )
+    except ImportError:
+        from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+            moe_align_block_size,
+        )
+
+    try:
+        from vllm.model_executor.layers.fused_moe.fused_moe import (
+            get_config_dtype_str,
+            try_get_optimal_moe_config,
+        )
+    except ImportError:
+        from vllm.model_executor.layers.fused_moe.config import (
+            _get_config_dtype_str as get_config_dtype_str,
+        )
+        from vllm.model_executor.layers.fused_moe.fused_moe import (
+            try_get_optimal_moe_config,
+        )
 
     HAS_VLLM = True
     _VLLM_IMPORT_ERROR = None
@@ -130,12 +153,19 @@ class MoEGatingNetwork(nn.Module):
         if self.use_vllm_fused_topk and HAS_VLLM_REPLICATED_LINEAR:
             # Align gating linear kernel family with vLLM runtime contract.
             # disable_tp=True avoids requiring TP group initialization in profiling jobs.
-            self.gate = ReplicatedLinear(
-                hidden_dim,
-                num_experts,
-                bias=False,
-                disable_tp=True,
-            )
+            try:
+                self.gate = ReplicatedLinear(
+                    hidden_dim,
+                    num_experts,
+                    bias=False,
+                    disable_tp=True,
+                )
+            except (AssertionError, RuntimeError):
+                # Current vLLM still resolves the TP rank while constructing
+                # ReplicatedLinear, even with disable_tp=True. Standalone
+                # Frontier profilers intentionally do not initialize a vLLM
+                # distributed group, so use the equivalent torch GEMM module.
+                self.gate = nn.Linear(hidden_dim, num_experts, bias=False)
         else:
             # Fall back to native torch linear only when vLLM kernel alignment is disabled.
             self.gate = nn.Linear(hidden_dim, num_experts, bias=False)

--- a/frontier/profiling/moe/moe_vllm_kernel.py
+++ b/frontier/profiling/moe/moe_vllm_kernel.py
@@ -10,8 +10,9 @@ Design rationale:
 - vLLM's fused_moe_kernel uses optimized grouped GEMM with real parallelism
 - Only used when --enable_load_imbalance is specified for accurate profiling
 
-Supported vLLM versions:
-- vLLM 0.10.x: Current supported version with extended invoke_fused_moe_kernel API
+Supported vLLM APIs:
+- vLLM 0.10.x low-level fused kernel entry point
+- Current vLLM functional ``fused_experts`` entry point
 
 Note: vLLM 0.3.x support has been removed. Please use vLLM >= 0.10.0.
 """
@@ -19,27 +20,39 @@ Note: vLLM 0.3.x support has been removed. Please use vLLM >= 0.10.0.
 import torch
 import triton
 import triton.language as tl
-from typing import Dict, List, Optional, Tuple
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
 
 VLLM_AVAILABLE = False
 VLLM_VERSION = None
 VLLM_API_VERSION = None
 FP8_QUANT_AVAILABLE = False
+_functional_fused_experts = None
+_FUNCTIONAL_MXFP4_STATES: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
 
 try:
     import vllm
     VLLM_VERSION = vllm.__version__
 
-    # Import vLLM 0.10.x functions
-    from vllm.model_executor.layers.fused_moe.fused_moe import (
-        fused_moe_kernel,
-        invoke_fused_moe_kernel,
-        moe_align_block_size,
-        try_get_optimal_moe_config,
-        get_config_dtype_str,
-    )
+    try:
+        # vLLM 0.10.x low-level API.
+        from vllm.model_executor.layers.fused_moe.fused_moe import (
+            fused_moe_kernel,
+            invoke_fused_moe_kernel,
+            moe_align_block_size,
+            try_get_optimal_moe_config,
+            get_config_dtype_str,
+        )
 
-    VLLM_API_VERSION = "0.10.x"
+        VLLM_API_VERSION = "0.10.x"
+    except ImportError:
+        # Current vLLM intentionally exposes the complete fused operation
+        # rather than the two private kernel invocations Frontier used before.
+        from vllm.model_executor.layers.fused_moe import (
+            fused_experts as _functional_fused_experts,
+        )
+
+        VLLM_API_VERSION = "functional_fused_experts"
     VLLM_AVAILABLE = True
     print(f"vLLM {VLLM_VERSION} loaded successfully (API: {VLLM_API_VERSION})")
 
@@ -335,6 +348,131 @@ def _run_fused_moe_iteration(
     )
 
 
+def _run_functional_fused_experts_iteration(
+    A: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    global_num_experts: int,
+    expert_map: Optional[torch.Tensor],
+) -> None:
+    """Run the complete fused expert op exposed by current vLLM."""
+    if _functional_fused_experts is None:  # pragma: no cover - import invariant
+        raise RuntimeError("Current vLLM fused_experts API is unavailable.")
+    _functional_fused_experts(
+        hidden_states=A,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+    )
+
+
+def _get_functional_mxfp4_state(
+    *,
+    num_experts: int,
+    hidden_dim: int,
+    expert_hidden_dim: int,
+    top_k: int,
+    dtype: torch.dtype,
+) -> Dict[str, Any]:
+    """Build and cache current-vLLM's online MXFP4 AITER expert kernel."""
+    cache_key = (
+        torch.cuda.current_device(),
+        num_experts,
+        hidden_dim,
+        expert_hidden_dim,
+        top_k,
+        dtype,
+    )
+    cached = _FUNCTIONAL_MXFP4_STATES.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # The packed expert tensors are large (tens of GiB for some EP layouts).
+    # Frontier profiles one layout at a time, so retaining states for prior
+    # shapes can exhaust HBM while sweeping EP sizes.
+    if _FUNCTIONAL_MXFP4_STATES:
+        _FUNCTIONAL_MXFP4_STATES.clear()
+        torch.cuda.empty_cache()
+
+    from vllm.config.quantization import QuantizationConfigArgs
+    from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+    from vllm.model_executor.layers.quantization.online.base import (
+        OnlineQuantizationConfig,
+    )
+    from vllm.v1.worker.workspace import (
+        init_workspace_manager,
+        is_workspace_manager_initialized,
+    )
+
+    from frontier.profiling.common.vllm_compat import vllm_config_context
+
+    quantization_args = QuantizationConfigArgs(moe="mxfp4")
+    standalone_model_config = SimpleNamespace(
+        dtype=dtype,
+        hf_config=SimpleNamespace(model_type="qwen3_5_moe_text"),
+        quantization_config=quantization_args,
+    )
+    with vllm_config_context(model_config=standalone_model_config):
+        if not is_workspace_manager_initialized():
+            init_workspace_manager(torch.device("cuda"))
+        quantization_config = OnlineQuantizationConfig(quantization_args)
+        runner = FusedMoEFactory(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_dim,
+            intermediate_size=expert_hidden_dim,
+            params_dtype=dtype,
+            quant_config=quantization_config,
+            tp_size=1,
+            dp_size=1,
+            pcp_size=1,
+            prefix=(
+                f"frontier_mxfp4_e{num_experts}_h{hidden_dim}_"
+                f"i{expert_hidden_dim}_k{top_k}"
+            ),
+        )
+        layer = runner.routed_experts
+        layer.w13_weight = torch.nn.Parameter(
+            torch.empty(
+                layer.w13_weight.shape,
+                device="cuda",
+                dtype=dtype,
+            ).normal_(mean=0.0, std=0.02),
+            requires_grad=False,
+        )
+        layer.w2_weight = torch.nn.Parameter(
+            torch.empty(
+                layer.w2_weight.shape,
+                device="cuda",
+                dtype=dtype,
+            ).normal_(mean=0.0, std=0.02),
+            requires_grad=False,
+        )
+        quant_method = layer.quant_method
+        quant_method.process_weights_after_loading(layer)
+
+    backend = str(getattr(quant_method, "mxfp4_backend", "unknown"))
+    if getattr(torch.version, "hip", None) and "AITER" not in backend.upper():
+        raise RuntimeError(
+            "MXFP4 profiling on ROCm did not select an AITER backend. Set "
+            "VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 before "
+            f"starting Frontier. Selected backend: {backend}."
+        )
+
+    state = {
+        "backend": backend,
+        "layer": layer,
+        "quant_method": quant_method,
+    }
+    _FUNCTIONAL_MXFP4_STATES[cache_key] = state
+    return state
+
+
 def _collect_cuda_event_stats(step_fn, active_steps: int) -> Dict:
     times = []
     for _ in range(active_steps):
@@ -396,6 +534,7 @@ def profile_fused_moe_kernel(
     warmup_steps: int = 2,
     active_steps: int = 20,
     use_fp8: bool = False,
+    use_mxfp4: bool = False,
     per_channel_quant: bool = False,
     block_shape: Optional[List[int]] = None,
     profile_method: str = "cuda_event",
@@ -423,6 +562,7 @@ def profile_fused_moe_kernel(
         warmup_steps: Number of warmup iterations.
         active_steps: Number of active profiling iterations.
         use_fp8: Whether to use FP8 W8A8 quantization.
+        use_mxfp4: Whether to use current vLLM's online MXFP4 AITER path.
         per_channel_quant: Whether to use per-channel quantization (only for FP8).
         block_shape: Block dimensions for block-wise quantization.
         profile_method: Profiling method (``cuda_event`` or ``record_function``).
@@ -440,6 +580,13 @@ def profile_fused_moe_kernel(
         raise RuntimeError(
             "vLLM is not available. Cannot use fused_moe_kernel for load imbalance profiling. "
             "Please install vLLM or disable --enable_load_imbalance."
+        )
+
+    if use_fp8 and use_mxfp4:
+        raise ValueError("use_fp8 and use_mxfp4 are mutually exclusive.")
+    if use_mxfp4 and VLLM_API_VERSION != "functional_fused_experts":
+        raise NotImplementedError(
+            "MXFP4 profiling requires current vLLM's modular fused MoE API."
         )
 
     if profile_method not in {"cuda_event", "record_function"}:
@@ -473,26 +620,105 @@ def profile_fused_moe_kernel(
     base_dtype = torch.bfloat16 if use_fp8 else dtype
     A = torch.randn(num_tokens, hidden_dim, dtype=base_dtype, device=device)
 
-    w1 = torch.randn(
-        num_experts,
-        2 * expert_hidden_dim_per_partition,
-        hidden_dim,
-        dtype=base_dtype,
-        device=device,
-    )
-    w2 = torch.randn(
-        num_experts,
-        hidden_dim,
-        expert_hidden_dim_per_partition,
-        dtype=base_dtype,
-        device=device,
-    )
+    w1 = None
+    w2 = None
+    if not use_mxfp4:
+        w1 = torch.randn(
+            num_experts,
+            2 * expert_hidden_dim_per_partition,
+            hidden_dim,
+            dtype=base_dtype,
+            device=device,
+        )
+        w2 = torch.randn(
+            num_experts,
+            hidden_dim,
+            expert_hidden_dim_per_partition,
+            dtype=base_dtype,
+            device=device,
+        )
 
     w1_scale = None
     w2_scale = None
     A_scale = None
 
+    if VLLM_API_VERSION == "functional_fused_experts":
+        if use_fp8:
+            raise NotImplementedError(
+                "FP8 profiling with current vLLM requires its quantization "
+                "descriptor API; use BF16 or the vLLM 0.10 profiling "
+                "environment until that adapter is configured."
+            )
+
+        functional_topk_weights = topk_weights.to(
+            device=device,
+            dtype=torch.float32,
+        ).contiguous()
+        functional_topk_ids = topk_ids.to(
+            device=device,
+            dtype=torch.int32,
+        ).contiguous()
+
+        if use_mxfp4:
+            mxfp4_state = _get_functional_mxfp4_state(
+                num_experts=num_experts,
+                hidden_dim=hidden_dim,
+                expert_hidden_dim=expert_hidden_dim_per_partition,
+                top_k=top_k,
+                dtype=base_dtype,
+            )
+            mxfp4_layer = mxfp4_state["layer"]
+            mxfp4_method = mxfp4_state["quant_method"]
+
+            def _step() -> None:
+                mxfp4_method.moe_kernel.apply(
+                    A,
+                    mxfp4_layer.w13_weight,
+                    mxfp4_layer.w2_weight,
+                    functional_topk_weights,
+                    functional_topk_ids,
+                    activation=mxfp4_layer.activation,
+                    global_num_experts=align_num_experts,
+                    expert_map=expert_map,
+                    apply_router_weight_on_input=False,
+                    shared_experts=None,
+                    shared_experts_input=None,
+                )
+        else:
+            assert w1 is not None and w2 is not None
+
+            def _step() -> None:
+                _run_functional_fused_experts_iteration(
+                    A=A,
+                    w1=w1,
+                    w2=w2,
+                    topk_weights=functional_topk_weights,
+                    topk_ids=functional_topk_ids,
+                    global_num_experts=align_num_experts,
+                    expert_map=expert_map,
+                )
+
+        from frontier.profiling.common.vllm_compat import vllm_config_context
+
+        with vllm_config_context():
+            for _ in range(warmup_steps):
+                _step()
+            torch.cuda.synchronize()
+
+            if profile_method == "record_function":
+                return _collect_record_function_stats(
+                    step_fn=_step,
+                    active_steps=active_steps,
+                    output_dir=output_dir,
+                    operation_name="moe_grouped_gemm",
+                )
+            return _collect_cuda_event_stats(
+                step_fn=_step,
+                active_steps=active_steps,
+            )
+
     block_dims = _validate_block_shape(block_shape)
+    assert w1 is not None and w2 is not None
     if use_fp8:
         w1, w1_scale = quantize_weights_to_fp8(
             w1,

--- a/frontier/profiling/moe/moe_wrapper.py
+++ b/frontier/profiling/moe/moe_wrapper.py
@@ -114,9 +114,13 @@ class MoEWrapper:
         self._dtype = model_config.dtype
         precision = get_operation_precision("moe_grouped_gemm")
         use_fp8_from_manager = precision == PrecisionType.FP8
-        if use_fp8_from_manager and not self.use_vllm_kernel:
+        use_mxfp4_from_manager = precision == PrecisionType.FP4
+        if (
+            use_fp8_from_manager or use_mxfp4_from_manager
+        ) and not self.use_vllm_kernel:
             raise ValueError(
-                "FP8 moe_grouped_gemm requires vLLM fused kernel profiling (use_vllm_kernel=True)."
+                "Quantized moe_grouped_gemm requires vLLM fused kernel profiling "
+                "(use_vllm_kernel=True)."
             )
         if use_fp8_from_manager:
             if not check_vllm_available():
@@ -128,6 +132,7 @@ class MoEWrapper:
                     "vLLM FP8 quantization utilities are unavailable for moe_grouped_gemm profiling."
                 )
         self.use_fp8 = use_fp8_from_manager
+        self.use_mxfp4 = use_mxfp4_from_manager
 
         # Calculate num_experts_per_device based on EP
         # EP is a distribution parameter: it determines how experts are distributed across devices
@@ -588,7 +593,9 @@ class MoEWrapper:
                 global_num_experts=profiling_global_num_experts,
                 expert_map=profiling_expert_map,
             )
-            grouped_gemm_backend = "vllm_fused"
+            grouped_gemm_backend = (
+                "vllm_aiter_mxfp4" if self.use_mxfp4 else "vllm_fused"
+            )
         else:
             time_stats = self._profile_with_loop(
                 expert_token_counts=expert_token_counts,
@@ -641,6 +648,7 @@ class MoEWrapper:
             warmup_steps=WARMUP_STEPS,
             active_steps=ACTIVE_STEPS,
             use_fp8=self.use_fp8,
+            use_mxfp4=self.use_mxfp4,
             per_channel_quant=self.per_channel_quant,
             block_shape=self.block_shape,
             profile_method=self.profile_method,

--- a/frontier/profiling/runtime/__init__.py
+++ b/frontier/profiling/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Isolated profiling for explicitly selected runtime cost contracts."""

--- a/frontier/profiling/runtime/sglang_attention.py
+++ b/frontier/profiling/runtime/sglang_attention.py
@@ -1,0 +1,277 @@
+"""Shape/workload contracts for Qwen3.8 SGLang decode-attention primitives."""
+
+from __future__ import annotations
+
+import math
+
+
+ATTENTION_PRIMITIVES = (
+    "attn_pre_proj_qknorm",
+    "attn_rope",
+    "attn_kv_cache_write",
+    "attn_decode",
+)
+
+
+def attention_decode_spec(model, tp):
+    """Return the pinned TP-local Qwen attention layout and boundary ownership."""
+    if type(tp) is not int or tp < 1 or model.num_q_heads % tp:
+        raise ValueError("Invalid attention tensor-parallel size")
+    head_dim = model.get_head_dim()
+    if model.num_kv_heads >= tp:
+        if model.num_kv_heads % tp:
+            raise ValueError("KV heads do not divide the attention TP size")
+        kv_heads = model.num_kv_heads // tp
+    else:
+        if tp % model.num_kv_heads:
+            raise ValueError("Attention TP size does not replicate KV heads evenly")
+        kv_heads = 1
+    q_heads = model.num_q_heads // tp
+    rotary_dim = int(head_dim * model.partial_rotary_factor)
+    if (not model.use_qk_norm or not model.attn_output_gate or rotary_dim < 1
+            or rotary_dim > head_dim or rotary_dim % 2):
+        raise ValueError("Unsupported Qwen attention norm/gate/rotary configuration")
+    projected_width = 2 * q_heads * head_dim + 2 * kv_heads * head_dim
+    return {
+        "q_heads": q_heads,
+        "kv_heads": kv_heads,
+        "head_dim": head_dim,
+        "rotary_dim": rotary_dim,
+        "projected_qkv_gate_width": projected_width,
+        "local_qkv_weight_shape": (projected_width, model.embedding_dim),
+        "activation_dtype": "bfloat16",
+        "kv_cache_dtype": "bfloat16",
+        "kv_cache_layout": "NHD",
+        "page_size": 1,
+        "attention_backend": "aiter.paged_attention_ragged",
+        "qk_norm_backend": "fused_qk_gemma_rmsnorm_with_gate",
+        "rope_backend": "SGLang.RotaryEmbedding",
+        "kv_write_backend": "SGLang.store_cache",
+        "qk_norm_eps": model.rms_norm_eps,
+        "rope_theta": model.rope_theta,
+        "max_position_embeddings": model.max_position_embeddings,
+        "is_neox_style": True,
+        "output_gate": True,
+        "includes_output_projection": False,
+        "context_pattern": "uniform_logical_prefix_padding_suffix",
+        "padding_context_length": 1,
+    }
+
+
+def validate_attention_decode_spec(spec, tp):
+    required = {
+        "q_heads", "kv_heads", "head_dim", "rotary_dim", "projected_qkv_gate_width",
+        "local_qkv_weight_shape", "activation_dtype", "kv_cache_dtype", "kv_cache_layout",
+        "page_size", "attention_backend", "qk_norm_backend", "rope_backend",
+        "kv_write_backend", "qk_norm_eps", "rope_theta", "max_position_embeddings",
+        "is_neox_style", "output_gate", "includes_output_projection", "context_pattern",
+        "padding_context_length",
+    }
+    if not isinstance(spec, dict) or set(spec) != required or type(tp) is not int or tp < 1:
+        raise ValueError("Invalid attention decode shape contract")
+    integers = ("q_heads", "kv_heads", "head_dim", "rotary_dim",
+                "projected_qkv_gate_width", "page_size", "max_position_embeddings",
+                "padding_context_length")
+    if (any(type(spec[k]) is not int or spec[k] < 1 for k in integers)
+            or type(spec["qk_norm_eps"]) not in (int, float)
+            or not math.isfinite(spec["qk_norm_eps"]) or spec["qk_norm_eps"] <= 0
+            or type(spec["rope_theta"]) not in (int, float)
+            or not math.isfinite(spec["rope_theta"]) or spec["rope_theta"] <= 0
+            or spec["activation_dtype"] != "bfloat16"
+            or spec["kv_cache_dtype"] != "bfloat16"
+            or spec["kv_cache_layout"] != "NHD" or spec["page_size"] != 1
+            or spec["attention_backend"] != "aiter.paged_attention_ragged"
+            or spec["qk_norm_backend"] != "fused_qk_gemma_rmsnorm_with_gate"
+            or spec["rope_backend"] != "SGLang.RotaryEmbedding"
+            or spec["kv_write_backend"] != "SGLang.store_cache"
+            or spec["is_neox_style"] is not True or spec["output_gate"] is not True
+            or spec["includes_output_projection"] is not False
+            or spec["context_pattern"] != "uniform_logical_prefix_padding_suffix"
+            or spec["padding_context_length"] != 1):
+        raise ValueError("Malformed attention decode backend/precision contract")
+    qh, kh, dim = spec["q_heads"], spec["kv_heads"], spec["head_dim"]
+    weight = tuple(spec["local_qkv_weight_shape"])
+    if (len(weight) != 2 or any(type(v) is not int or v < 1 for v in weight)
+            or spec["rotary_dim"] > dim or spec["rotary_dim"] % 2
+            or spec["projected_qkv_gate_width"] != 2 * qh * dim + 2 * kh * dim
+            or weight[0] != spec["projected_qkv_gate_width"]):
+        raise ValueError("Inconsistent attention head/projection layout")
+
+
+def validate_attention_workload(size, logical_size, physical_context_lens, spec):
+    """Validate the bounded uniform-context decode workload used for interpolation."""
+    if (type(size) is not int or type(logical_size) is not int
+            or not 1 <= logical_size <= size
+            or not isinstance(physical_context_lens, (tuple, list))
+            or len(physical_context_lens) != size
+            or any(type(v) is not int or v < 1 for v in physical_context_lens)):
+        raise ValueError("Invalid attention logical/physical decode workload")
+    active = tuple(physical_context_lens[:logical_size])
+    padding = tuple(physical_context_lens[logical_size:])
+    if len(set(active)) != 1 or any(v != spec["padding_context_length"] for v in padding):
+        raise ValueError("Attention calibration requires uniform logical contexts and suffix padding")
+    if active[0] >= spec["max_position_embeddings"]:
+        raise ValueError("Attention context exceeds the model rotary cache")
+    return {
+        "logical_size": logical_size,
+        "padding_count": size - logical_size,
+        "active_context_length": active[0],
+        "padding_context_length": spec["padding_context_length"],
+    }
+
+
+def _reference_rope(x, positions, cache, rotary_dim, head_dim):
+    import torch
+
+    original_shape = x.shape
+    x = x.float().view(len(positions), -1, head_dim)
+    rotated, passed = x[..., :rotary_dim], x[..., rotary_dim:]
+    cos, sin = cache.index_select(0, positions).float().chunk(2, dim=-1)
+    cos, sin = cos[:, None, :], sin[:, None, :]
+    first, second = rotated.chunk(2, dim=-1)
+    rotated = torch.cat((first * cos - second * sin, second * cos + first * sin), dim=-1)
+    return torch.cat((rotated, passed), dim=-1).reshape(original_shape)
+
+
+def make_attention_primitive(name, size, logical_size, physical_context_lens,
+                             model, group, rank, random):
+    """Build one native attention-boundary invocation with an independent reference."""
+    import torch
+
+    if name not in ATTENTION_PRIMITIVES:
+        raise ValueError(f"Unknown attention primitive {name}")
+    spec = attention_decode_spec(model, group.world_size)
+    validate_attention_decode_spec(spec, group.world_size)
+    workload = validate_attention_workload(size, logical_size, physical_context_lens, spec)
+    qh, kh, dim = spec["q_heads"], spec["kv_heads"], spec["head_dim"]
+    dtype = torch.bfloat16
+
+    if name == "attn_pre_proj_qknorm":
+        from sglang.srt.layers.linear import QKVParallelLinear
+        from sglang.srt.models.utils import fused_qk_gemma_rmsnorm_with_gate
+
+        x = random((size, model.embedding_dim), .1)
+        linear = QKVParallelLinear(
+            model.embedding_dim, dim, model.num_q_heads * 2, model.num_kv_heads,
+            bias=False, quant_config=None, tp_rank=rank, tp_size=group.world_size,
+            kv_tp_rank=rank, kv_tp_size=group.world_size,
+        ).to(device="cuda", dtype=dtype)
+        linear.weight.data.copy_(random(linear.weight.shape, model.embedding_dim ** -.5))
+        q_weight = random((dim,), .05)
+        k_weight = random((dim,), .05)
+        projected = torch.nn.functional.linear(x.float(), linear.weight.float())
+        q_gate, key, value = projected.split((2 * qh * dim, kh * dim, kh * dim), dim=-1)
+        q_gate = q_gate.view(size, qh, 2 * dim)
+        query, gate = q_gate.split((dim, dim), dim=-1)
+        key = key.view(size, kh, dim)
+        query = (query * torch.rsqrt(query.square().mean(-1, keepdim=True)
+                                     + spec["qk_norm_eps"]) * (1 + q_weight.float())).to(dtype)
+        key = (key * torch.rsqrt(key.square().mean(-1, keepdim=True)
+                                 + spec["qk_norm_eps"]) * (1 + k_weight.float())).to(dtype)
+        reference = (query.reshape(size, -1), key.reshape(size, -1), value.to(dtype),
+                     gate.to(dtype).reshape(size, -1))
+
+        def fn():
+            qkv, _ = linear(x)
+            q_gate, key, value = qkv.split((2 * qh * dim, kh * dim, kh * dim), dim=-1)
+            query, key, gate = fused_qk_gemma_rmsnorm_with_gate(
+                q_gate, key, q_weight, k_weight, spec["qk_norm_eps"], dim, qh)
+            return (query.view(size, -1), key.view(size, -1), value,
+                    gate.view(size, -1))
+
+        backend = f"QKVParallelLinear.{type(linear.quant_method).__name__}+{spec['qk_norm_backend']}"
+        return fn, reference, (), backend, spec, workload
+
+    positions = torch.tensor([v - 1 for v in physical_context_lens], device="cuda", dtype=torch.int64)
+    if name == "attn_rope":
+        from sglang.srt.layers.rotary_embedding import get_rope
+
+        rope = get_rope(
+            head_size=dim, rotary_dim=dim,
+            max_position=spec["max_position_embeddings"], rope_scaling=model.rope_scaling,
+            base=spec["rope_theta"], partial_rotary_factor=model.partial_rotary_factor,
+            is_neox_style=True, dtype=dtype,
+        )
+        query = random((size, qh * dim), .1)
+        key = random((size, kh * dim), .1)
+        query_initial, key_initial = query.clone(), key.clone()
+        cache = rope.cos_sin_cache.to(device="cuda")
+        reference = (
+            _reference_rope(query_initial, positions, cache, spec["rotary_dim"], dim).to(dtype),
+            _reference_rope(key_initial, positions, cache, spec["rotary_dim"], dim).to(dtype),
+        )
+        return (lambda: rope(positions, query, key)), reference, (query, key), \
+            spec["rope_backend"], spec, workload
+
+    lengths = torch.tensor(physical_context_lens, device="cuda", dtype=torch.int32)
+    starts = torch.cumsum(lengths, 0) - lengths + 1
+    total_pages = sum(physical_context_lens) + 1
+    key = random((size, kh, dim), .1)
+    value = random((size, kh, dim), .1)
+
+    if name == "attn_kv_cache_write":
+        from sglang.kernels.ops.kvcache.kvcache import store_cache
+
+        locations = starts.clone()
+        locations[logical_size:] = 0
+        key_cache = random((total_pages, kh * dim), .1)
+        value_cache = random((total_pages, kh * dim), .1)
+        key_reference, value_reference = key_cache.clone(), value_cache.clone()
+        key_reference[locations[:logical_size].long()] = key[:logical_size].reshape(logical_size, -1)
+        value_reference[locations[:logical_size].long()] = value[:logical_size].reshape(logical_size, -1)
+
+        def fn():
+            store_cache(key.reshape(size, -1), value.reshape(size, -1), key_cache, value_cache,
+                        locations, row_bytes=kh * dim * 2, v_row_bytes=kh * dim * 2,
+                        size_limit=total_pages, reserved_skip_index=0)
+            return key_cache, value_cache
+
+        return fn, (key_reference, value_reference), (key_cache, value_cache), \
+            spec["kv_write_backend"], spec, workload
+
+    from aiter import paged_attention_ragged
+
+    query = random((size, qh, dim))
+    key_cache = random((total_pages, 1, kh, dim))
+    value_cache = random((total_pages, 1, kh, dim))
+    # torch.cumsum promotes integer inputs unless dtype is explicit. AITER's
+    # ABI reads this buffer as int32; an int64 indptr makes it interpret the
+    # high half of each element as the next sequence boundary.
+    kv_indptr = torch.cat((torch.zeros(1, device="cuda", dtype=torch.int32),
+                           torch.cumsum(lengths, 0, dtype=torch.int32)))
+    kv_indices = torch.arange(1, total_pages, device="cuda", dtype=torch.int32)
+    last_page_lens = torch.ones(size, device="cuda", dtype=torch.int32)
+    # SGLang fixes this to the model-wide maximum at backend construction;
+    # AITER uses the value for workspace addressing, not merely launch pruning.
+    partitions = (spec["max_position_embeddings"] + 255) // 256
+    workspace_bytes = size * qh * partitions * dim * 4 + 2 * size * qh * partitions * 4
+    workspace = torch.empty(workspace_bytes, device="cuda", dtype=torch.uint8)
+    output = torch.full_like(query, float("nan"))
+    one = torch.ones(1, device="cuda", dtype=torch.float32)
+    scale = dim ** -.5
+    refs = []
+    offset = 1
+    for lane, length in enumerate(physical_context_lens):
+        keys = key_cache[offset:offset + length, 0].float()
+        values = value_cache[offset:offset + length, 0].float()
+        if kh == 1:
+            keys = keys.expand(-1, qh, -1)
+            values = values.expand(-1, qh, -1)
+        elif kh != qh:
+            repeat = qh // kh
+            keys = keys.repeat_interleave(repeat, dim=1)
+            values = values.repeat_interleave(repeat, dim=1)
+        scores = torch.einsum("hd,lhd->hl", query[lane].float(), keys) * scale
+        probabilities = torch.softmax(scores, dim=-1).to(dtype)
+        refs.append(torch.einsum("hl,lhd->hd", probabilities, values.to(dtype)))
+        offset += length
+    reference = torch.stack(refs).to(dtype)
+
+    def fn():
+        return paged_attention_ragged(
+            output, workspace, query, key_cache, value_cache, scale, kv_indptr,
+            kv_indices, last_page_lens, 1, partitions, None, "auto", "NHD",
+            0.0, one, one, None, 256,
+        )
+
+    return fn, reference, (), spec["attention_backend"], spec, workload

--- a/frontier/profiling/runtime/sglang_dense.py
+++ b/frontier/profiling/runtime/sglang_dense.py
@@ -1,0 +1,144 @@
+"""Shape contracts and actual SGLang BF16 projection/activation callables.
+
+No checkpoint load or routed-expert work. Output reductions, GDN core, top-k
+and shared-output gating remain separate runtime scopes. The GDN output scope
+includes the native gated norm immediately before its GEMM.
+"""
+
+from types import SimpleNamespace
+
+
+DENSE_PRIMITIVES = ("shared_expert_gate_up", "shared_expert_activation", "shared_expert_down",
+                    "moe_router_linear", "gdn_input_projections", "gdn_output_projection")
+
+
+def validate_dense_spec(spec, tp, name=None):
+    required = {"input_width", "linear_kinds", "output_partitions", "output_widths", "local_weight_shapes",
+                "tp", "weight_dtype", "includes_reduction", "input_transform"}
+    if (not isinstance(spec, dict) or set(spec) != required or spec["tp"] != tp
+            or type(spec["input_width"]) is not int or spec["input_width"] < 1
+            or spec["weight_dtype"] != "bfloat16" or spec["includes_reduction"] is not False
+            or spec["input_transform"] not in {"none", "gdn_rmsnorm_gated"}):
+        raise ValueError("Invalid dense primitive shape contract")
+    kinds, parts, outputs, weights = (spec[k] for k in
+        ("linear_kinds", "output_partitions", "output_widths", "local_weight_shapes"))
+    if (not all(isinstance(v, (list, tuple)) for v in (kinds, parts, outputs, weights))
+            or not outputs or any(type(v) is not int or v < 1 for v in outputs)
+            or len(kinds) != len(parts) or len(kinds) != len(weights)
+            or (kinds and len(kinds) != len(outputs))):
+        raise ValueError("Malformed dense projection layout")
+    if not kinds and (len(outputs) != 1 or spec["input_width"] != 2 * outputs[0]):
+        raise ValueError("Silu/multiply requires paired input halves")
+    expected_transform = "gdn_rmsnorm_gated" if name == "gdn_output_projection" else "none"
+    if name is not None and spec["input_transform"] != expected_transform:
+        raise ValueError("Dense input transform disagrees with primitive ownership")
+    for kind, partition, output, weight in zip(kinds, parts, outputs, weights):
+        if (kind not in {"merged", "row", "replicated"} or not partition
+                or any(type(v) is not int or v < 1 for v in partition)
+                or tuple(weight) != (output, spec["input_width"])
+                or (kind == "merged" and (any(v % tp for v in partition) or sum(partition) // tp != output))
+                or (kind != "merged" and tuple(partition) != (output,))):
+            raise ValueError("Dense per-rank weights disagree with projection partitions")
+
+
+def dense_primitive_spec(name, model, tp):
+    """CPU-safe per-rank shapes; the router is replicated, not TP-sharded."""
+    if name not in DENSE_PRIMITIVES or type(tp) is not int or tp < 1:
+        raise ValueError("Unknown dense primitive or invalid TP size")
+    quant = model.quantization_config
+    if quant is not None and (quant.quantized_operations is None
+            or set(quant.quantized_operations) - {"moe_grouped_gemm"}):
+        raise ValueError("Dense primitive calibration requires unquantized dense/shared projections")
+    hidden, shared, gdn = model.embedding_dim, model.share_expert_dim, model.get_gdn_config()
+    if not gdn or not shared or shared % tp:
+        raise ValueError("Shared width and GDN heads must support this TP size")
+    gdn.get_state_layout(tensor_parallel_size=tp)
+    specs = {
+        "shared_expert_gate_up": (hidden, ("merged",), ((shared, shared),), (2 * shared // tp,)),
+        "shared_expert_activation": (2 * shared // tp, (), (), (shared // tp,)),
+        "shared_expert_down": (shared // tp, ("row",), ((hidden,),), (hidden,)),
+        "moe_router_linear": (hidden, ("replicated",), ((model.num_experts,),), (model.num_experts,)),
+        "gdn_input_projections": (hidden, ("merged", "merged"),
+            ((gdn.key_dim, gdn.key_dim, gdn.value_dim, gdn.value_dim),
+             (gdn.num_value_heads, gdn.num_value_heads)),
+            ((2 * gdn.key_dim + 2 * gdn.value_dim) // tp, 2 * gdn.num_value_heads // tp)),
+        "gdn_output_projection": (gdn.value_dim // tp, ("row",), ((hidden,),), (hidden,)),
+    }
+    width, kinds, partitions, outputs = specs[name]
+    return {"input_width": width, "linear_kinds": kinds, "output_partitions": partitions,
+            "output_widths": outputs, "local_weight_shapes": tuple((out, width) for out in outputs) if kinds else (),
+            "tp": tp, "weight_dtype": "bfloat16", "includes_reduction": False,
+            "input_transform": "gdn_rmsnorm_gated" if name == "gdn_output_projection" else "none"}
+
+
+def make_dense_primitive(name, size, model, group, rank, random):
+    """Return a callable, FP32-math reference, and the selected runtime method."""
+    import torch
+    from sglang.srt.layers.activation import SiluAndMul
+    from sglang.srt.layers.linear import MergedColumnParallelLinear, ReplicatedLinear, RowParallelLinear
+
+    spec = dense_primitive_spec(name, model, group.world_size)
+    x = random((size, spec["input_width"]))
+    if name == "shared_expert_activation":
+        activation = SiluAndMul()
+        # BaseFusedOp resolves platform dispatch on its first call. Discovery
+        # and any compilation happen outside all measured graph replays.
+        activation(x)
+        method = activation._forward_method.__name__
+        if method == "forward_native":
+            raise ValueError("Native activation fallback is not the fused runtime primitive")
+        width = spec["output_widths"][0]
+        reference = (torch.nn.functional.silu(x[:, :width].float()) * x[:, width:].float()).to(x.dtype)
+        return lambda: activation(x), reference, f"SiluAndMul.{method}"
+    norm = None
+    projection_input = x
+    if name == "gdn_output_projection":
+        from sglang.kernels.ops.attention.fla.layernorm_gated import RMSNorm
+        gdn = model.get_gdn_config()
+        local_heads = gdn.num_value_heads // group.world_size
+        core = random((size * local_heads, gdn.value_head_dim), .1)
+        gate = random(core.shape, .1)
+        norm = RMSNorm(gdn.value_head_dim, eps=model.rms_norm_eps, group_size=None,
+                       norm_before_gate=True, device="cuda", dtype=x.dtype,
+                       activation=gdn.output_gate_type)
+        norm.weight.data.copy_(random((gdn.value_head_dim,), .05) + 1.)
+        gate_reference = (torch.nn.functional.silu(gate.float()) if gdn.output_gate_type == "silu"
+                          else torch.sigmoid(gate.float()))
+        projection_input = ((core.float() * torch.rsqrt(
+            core.float().square().mean(-1, keepdim=True) + model.rms_norm_eps))
+            * norm.weight.float() * gate_reference).to(x.dtype).reshape(size, -1)
+        norm(core, gate)  # compile/discover outside graph capture and timing
+    linears, references = [], []
+    for kind, partitions, shape in zip(spec["linear_kinds"], spec["output_partitions"], spec["local_weight_shapes"]):
+        common = dict(bias=False, params_dtype=x.dtype, quant_config=None)
+        sharding = dict(tp_rank=rank, tp_size=group.world_size)
+        if kind == "merged":
+            linear = MergedColumnParallelLinear(spec["input_width"], list(partitions), **common, **sharding)
+        elif kind == "row":
+            linear = RowParallelLinear(spec["input_width"] * group.world_size, partitions[0],
+                input_is_parallel=True, reduce_results=False, **common, **sharding)
+        else:
+            linear = ReplicatedLinear(spec["input_width"], partitions[0], **common)
+        linear = linear.to(device="cuda", dtype=x.dtype)
+        if (tuple(linear.weight.shape) != shape or linear.weight.dtype != x.dtype
+                or type(linear.quant_method).__name__ != "UnquantizedLinearMethod"):
+            raise ValueError("Runtime linear shape/precision/method does not match the dense contract")
+        linear.weight.data.copy_(random(shape, spec["input_width"] ** -.5))
+        references.append(torch.nn.functional.linear(projection_input.float(), linear.weight.float()).to(x.dtype))
+        linears.append(linear)
+    backend = "+".join(f"{type(layer).__name__}.{type(layer.quant_method).__name__}" for layer in linears)
+    if name == "gdn_input_projections":
+        from sglang.srt.models.qwen3_5 import Qwen3_5GatedDeltaNet, _gdn_use_alt_stream
+        if _gdn_use_alt_stream:
+            raise ValueError("This isolated GDN input scope requires the sequential ROCm projection path")
+        # Run the native input-projection helper without constructing stateful
+        # attention/cache modules. Both projections share the same hidden input.
+        owner = SimpleNamespace(in_proj_qkvz=linears[0], in_proj_ba=linears[1], alt_stream=None,
+                                _fused_input_proj_cpu_enabled=SimpleNamespace(value=False))
+        return lambda: Qwen3_5GatedDeltaNet._forward_input_proj(owner, x), tuple(references), backend
+    if name == "gdn_output_projection":
+        def output_projection():
+            normalized = norm(core, gate).reshape(size, -1)
+            return linears[0](normalized)[0]
+        return output_projection, references[0], f"RMSNormGated+{backend}"
+    return lambda: linears[0](x)[0], references[0], backend

--- a/frontier/profiling/runtime/sglang_gdn.py
+++ b/frontier/profiling/runtime/sglang_gdn.py
@@ -1,0 +1,175 @@
+"""Shape and state contracts for SGLang's packed GDN decode core."""
+
+from __future__ import annotations
+
+
+GDN_PRIMITIVES = ("gdn_core_decode",)
+
+
+def gdn_core_spec(model, tp):
+    """Return the model-derived, per-rank packed-decode state layout."""
+    if type(tp) is not int or tp < 1:
+        raise ValueError("Invalid GDN tensor-parallel size")
+    gdn = model.get_gdn_config()
+    if gdn is None:
+        raise ValueError("GDN core profiling requires a GDN model")
+    layout = gdn.get_state_layout(tensor_parallel_size=tp)
+    return {
+        "q_heads": gdn.num_key_heads // tp,
+        "value_heads": gdn.num_value_heads // tp,
+        "key_head_dim": gdn.key_head_dim,
+        "value_head_dim": gdn.value_head_dim,
+        "mixed_qkv_width": gdn.conv_dim // tp,
+        "projected_qkvz_width": (2 * gdn.key_dim + 2 * gdn.value_dim) // tp,
+        "projected_ba_width": 2 * gdn.num_value_heads // tp,
+        "gate_width": gdn.num_value_heads // tp,
+        "conv_kernel_size": gdn.conv_kernel_size,
+        "conv_state_shape": (gdn.conv_dim // tp, layout.conv_state_shape[0]),
+        "recurrent_state_shape": layout.recurrent_state_shape,
+        "activation_dtype": "bfloat16",
+        "activation": "silu",
+        "conv_state_dtype": "bfloat16",
+        "recurrent_state_dtype": "float32",
+        "conv_bias": False,
+        "padding_cache_index": -1,
+        "includes_input_reordering": True,
+        "includes_gate_materialization": True,
+        "includes_gated_norm": False,
+    }
+
+
+def validate_gdn_core_spec(spec, tp):
+    required = {
+        "q_heads", "value_heads", "key_head_dim", "value_head_dim",
+        "mixed_qkv_width", "projected_qkvz_width", "projected_ba_width",
+        "gate_width", "conv_kernel_size",
+        "conv_state_shape", "recurrent_state_shape", "activation_dtype", "activation",
+        "conv_state_dtype", "recurrent_state_dtype", "conv_bias", "padding_cache_index",
+        "includes_input_reordering", "includes_gate_materialization", "includes_gated_norm",
+    }
+    if not isinstance(spec, dict) or set(spec) != required or type(tp) is not int or tp < 1:
+        raise ValueError("Invalid GDN core shape contract")
+    integers = ("q_heads", "value_heads", "key_head_dim", "value_head_dim",
+                "mixed_qkv_width", "projected_qkvz_width", "projected_ba_width",
+                "gate_width", "conv_kernel_size")
+    if (any(type(spec[key]) is not int or spec[key] < 1 for key in integers)
+            or spec["activation_dtype"] != "bfloat16"
+            or spec["activation"] != "silu"
+            or spec["conv_state_dtype"] != "bfloat16"
+            or spec["recurrent_state_dtype"] != "float32"
+            or spec["conv_bias"] is not False
+            or spec["padding_cache_index"] != -1
+            or spec["includes_input_reordering"] is not True
+            or spec["includes_gate_materialization"] is not True
+            or spec["includes_gated_norm"] is not False):
+        raise ValueError("Malformed GDN core state/precision contract")
+    q, hv, k, v = (spec[key] for key in
+                    ("q_heads", "value_heads", "key_head_dim", "value_head_dim"))
+    if (hv % q or spec["gate_width"] != hv
+            or spec["mixed_qkv_width"] != 2 * q * k + hv * v
+            or spec["projected_qkvz_width"] != spec["mixed_qkv_width"] + hv * v
+            or spec["projected_ba_width"] != 2 * hv
+            or tuple(spec["conv_state_shape"]) !=
+                (spec["mixed_qkv_width"], spec["conv_kernel_size"] - 1)
+            or tuple(spec["recurrent_state_shape"]) != (hv, v, k)):
+        raise ValueError("Inconsistent GDN core head/state shapes")
+
+
+def make_gdn_core_primitive(size, logical_size, model, group, random):
+    """Build one independent SGLang packed-decode invocation and FP32 reference."""
+    import torch
+    import torch.nn.functional as F
+    from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_update
+    from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
+
+    if (type(size) is not int or type(logical_size) is not int
+            or not 1 <= logical_size <= size):
+        raise ValueError("GDN decode needs positive logical <= physical size")
+    spec = gdn_core_spec(model, group.world_size)
+    validate_gdn_core_spec(spec, group.world_size)
+    if model.activation != "silu":
+        raise ValueError("Packed GDN producer currently implements SiLU convolution only")
+    qh, vh = spec["q_heads"], spec["value_heads"]
+    kd, vd = spec["key_head_dim"], spec["value_head_dim"]
+    projected_qkvz = random((size, spec["projected_qkvz_width"]), .1)
+    projected_ba = random((size, spec["projected_ba_width"]), .1)
+    conv_weight = random((spec["mixed_qkv_width"], spec["conv_kernel_size"]), .1)
+    A_log = torch.zeros(vh, device="cuda", dtype=torch.float32)
+    dt_bias = torch.zeros(vh, device="cuda", dtype=torch.float32)
+    conv_state = random((logical_size, *spec["conv_state_shape"]), .1)
+    recurrent_state = (torch.randn((logical_size, *spec["recurrent_state_shape"]),
+                                   device="cuda", dtype=torch.float32) * .01).contiguous()
+    cache_indices = torch.cat((
+        torch.arange(logical_size, device="cuda", dtype=torch.int32),
+        torch.full((size - logical_size,), spec["padding_cache_index"],
+                   device="cuda", dtype=torch.int32),
+    ))
+
+    # Independent reference for active rows. It follows the packed Triton
+    # kernel's BF16 beta rounding and FP32 recurrent-state update exactly.
+    conv_initial = conv_state.clone()
+    recurrent_initial = recurrent_state.clone()
+    q_width, v_width = qh * kd, vh * vd
+    query, key, value, z_ref = projected_qkvz.split(
+        (q_width, q_width, v_width, v_width), dim=-1)
+    b_ref, a_ref = projected_ba.split((vh, vh), dim=-1)
+    mixed_ref = torch.cat((query, key, value.reshape(size, -1)), dim=-1)
+    active_x = mixed_ref[:logical_size].float()
+    window = torch.cat((conv_initial.float(), active_x.unsqueeze(-1)), dim=-1)
+    conv_ref = F.silu((window * conv_weight.float().unsqueeze(0)).sum(-1)).to(
+        projected_qkvz.dtype)
+    q, k, v = torch.split(conv_ref, (qh * kd, qh * kd, vh * vd), dim=-1)
+    q = q.view(logical_size, qh, kd).float()
+    k = k.view(logical_size, qh, kd).float()
+    v = v.view(logical_size, vh, vd)
+    q = q / torch.sqrt(q.square().sum(-1, keepdim=True) + 1e-6)
+    k = k / torch.sqrt(k.square().sum(-1, keepdim=True) + 1e-6)
+    q = q * (kd ** -0.5)
+    head_map = torch.arange(vh, device="cuda") // (vh // qh)
+    q, k = q[:, head_map], k[:, head_map]
+    decay = torch.exp(-torch.exp(A_log)[None, :] * F.softplus(
+        a_ref[:logical_size].float() + dt_bias[None, :]))
+    beta = torch.sigmoid(b_ref[:logical_size].float()).to(projected_ba.dtype).float()
+    state_ref = recurrent_initial * decay[:, :, None, None]
+    residual = v.float() - torch.einsum("bhvk,bhk->bhv", state_ref, k)
+    residual = residual * beta[:, :, None]
+    state_ref = state_ref + residual[:, :, :, None] * k[:, :, None, :]
+    output_ref = torch.zeros((1, size, vh, vd), device="cuda", dtype=projected_qkvz.dtype)
+    output_ref[:, :logical_size] = torch.einsum(
+        "bhvk,bhk->bhv", state_ref, q).to(projected_qkvz.dtype).unsqueeze(0)
+    conv_final = conv_initial.clone()
+    conv_final[:, :, :-1] = conv_initial[:, :, 1:]
+    conv_final[:, :, -1] = mixed_ref[:logical_size]
+
+    kernel = TritonGDNKernel()
+    if not kernel.supports_packed_decode:
+        raise ValueError("Pinned SGLang runtime does not select packed GDN decode")
+
+    def fn():
+        query, key, value, z = projected_qkvz.split(
+            (q_width, q_width, v_width, v_width), dim=-1)
+        b, a = projected_ba.split((vh, vh), dim=-1)
+        b, a = b.contiguous(), a.contiguous()
+        mixed = torch.cat((query.reshape(size, -1), key.reshape(size, -1),
+                           value.reshape(size, -1)), dim=-1)
+        convolved = causal_conv1d_update(
+            mixed, conv_state, conv_weight, None, "silu",
+            conv_state_indices=cache_indices,
+        )
+        output = kernel.packed_decode(
+            convolved, a, b, A_log=A_log, dt_bias=dt_bias,
+            scale=kd ** -0.5, ssm_states=recurrent_state,
+            cache_indices=cache_indices, num_v_heads=vh, head_v_dim=vd,
+        )
+        # Z is a strided tail view of the wider QKVZ projection. Qwen's
+        # pre-norm reshape materializes it; the native trace charges that copy
+        # before the gated-norm anchor, so it belongs to the core boundary.
+        z = z.reshape(-1, vd)
+        # Basic slices are views, so state evidence adds no timed kernels.
+        return output, z, conv_state, recurrent_state[:, :2]
+
+    reference = (output_ref, z_ref.float().to(projected_qkvz.dtype).reshape(-1, vd),
+                 conv_final, state_ref[:, :2])
+    mutable = (conv_state, recurrent_state)
+    backend = "Qwen3.5.reorder+SGLang.causal_conv1d_update+TritonGDNKernel.packed_decode+Z.materialize"
+    return fn, reference, mutable, backend, spec

--- a/frontier/profiling/runtime/sglang_moe.py
+++ b/frontier/profiling/runtime/sglang_moe.py
@@ -1,0 +1,334 @@
+"""Shape contracts and native routing primitives for Qwen3.8 SGLang MoE."""
+
+from __future__ import annotations
+
+
+MOE_ROUTING_PRIMITIVES = ("moe_routing_topk",)
+MOE_ROUTED_PRIMITIVES = ("moe_sorting", "moe_experts_quant_gemm_combine")
+
+
+def moe_routing_spec(model):
+    """Return the checkpoint-pinned replicated router/top-k boundary."""
+    if (not model.is_moe or model.num_experts < 1
+            or model.num_experts_per_tok < 1
+            or model.num_experts_per_tok > model.num_experts):
+        raise ValueError("MoE routing requires a valid expert configuration")
+    return {
+        "hidden_size": model.embedding_dim,
+        "num_experts": model.num_experts,
+        "top_k": model.num_experts_per_tok,
+        "logits_dtype": "bfloat16",
+        "weights_dtype": "float32",
+        "ids_dtype": "int32",
+        "scoring": "softmax",
+        # The Qwen3.8 checkpoint omits norm_topk_prob; the active SGLang
+        # Qwen2MoeSparseMoeBlock therefore passes the false value through.
+        "renormalize": False,
+        "backend": "aiter.fused_moe.fused_topk/topk_softmax",
+        "includes_router_linear": False,
+        "includes_padding_mask": False,
+    }
+
+
+def validate_moe_routing_spec(spec):
+    required = {
+        "hidden_size", "num_experts", "top_k", "logits_dtype",
+        "weights_dtype", "ids_dtype", "scoring", "renormalize", "backend",
+        "includes_router_linear", "includes_padding_mask",
+    }
+    if not isinstance(spec, dict) or set(spec) != required:
+        raise ValueError("Invalid MoE routing shape contract")
+    if (any(type(spec[k]) is not int or spec[k] < 1
+            for k in ("hidden_size", "num_experts", "top_k"))
+            or spec["top_k"] > spec["num_experts"]
+            or spec["logits_dtype"] != "bfloat16"
+            or spec["weights_dtype"] != "float32"
+            or spec["ids_dtype"] != "int32"
+            or spec["scoring"] != "softmax"
+            or spec["renormalize"] is not False
+            or spec["backend"] != "aiter.fused_moe.fused_topk/topk_softmax"
+            or spec["includes_router_linear"] is not False
+            or spec["includes_padding_mask"] is not False):
+        raise ValueError("Malformed MoE routing backend/precision contract")
+
+
+def moe_routed_spec(model, tp):
+    """Return the TP-local routed MXFP4 shapes and AITER boundary ownership."""
+    if (type(tp) is not int or tp < 1 or not model.is_moe
+            or model.routed_mlp_hidden_dim is None
+            or model.routed_mlp_hidden_dim % tp):
+        raise ValueError("Invalid tensor-parallel routed-expert configuration")
+    local_intermediate = model.routed_mlp_hidden_dim // tp
+    if local_intermediate % 256:
+        raise ValueError("Qwen3.8 AITER MXFP4 profiling requires 256-aligned local experts")
+    return {
+        "hidden_size": model.embedding_dim,
+        "global_intermediate_size": model.routed_mlp_hidden_dim,
+        "local_intermediate_size": local_intermediate,
+        "num_experts": model.num_experts,
+        "top_k": model.num_experts_per_tok,
+        "tensor_parallel_size": tp,
+        "block_size_m": 32,
+        "activation": "silu",
+        "output_dtype": "bfloat16",
+        "activation_quant": "dynamic_mxfp4_per_1x32_e8m0",
+        "weight_quant": "mxfp4_per_1x32_e8m0",
+        "w13_packed_shape": (
+            model.num_experts, 2 * local_intermediate,
+            model.embedding_dim // 2),
+        "w2_packed_shape": (
+            model.num_experts, model.embedding_dim,
+            local_intermediate // 2),
+        "w13_scale_shape": (
+            model.num_experts, 2 * local_intermediate,
+            model.embedding_dim // 32),
+        "w2_scale_shape": (
+            model.num_experts, model.embedding_dim,
+            local_intermediate // 32),
+        "sorting_backend": "aiter.moe_sorting/opus",
+        "experts_backend": "aiter.fused_moe_2stages",
+        "assignment_reconstruction": "largest_remaining_count_then_expert_id",
+        "includes_sorting": False,
+        "includes_tp_allreduce": False,
+    }
+
+
+def validate_moe_routed_spec(spec, tp):
+    required = {
+        "hidden_size", "global_intermediate_size", "local_intermediate_size",
+        "num_experts", "top_k", "tensor_parallel_size", "block_size_m",
+        "activation", "output_dtype", "activation_quant", "weight_quant",
+        "w13_packed_shape", "w2_packed_shape", "w13_scale_shape",
+        "w2_scale_shape", "sorting_backend", "experts_backend",
+        "assignment_reconstruction", "includes_sorting", "includes_tp_allreduce",
+    }
+    if (not isinstance(spec, dict) or set(spec) != required
+            or type(tp) is not int or tp < 1):
+        raise ValueError("Invalid routed MoE shape contract")
+    integers = (
+        "hidden_size", "global_intermediate_size", "local_intermediate_size",
+        "num_experts", "top_k", "tensor_parallel_size", "block_size_m",
+    )
+    if (any(type(spec[k]) is not int or spec[k] < 1 for k in integers)
+            or spec["tensor_parallel_size"] != tp
+            or spec["global_intermediate_size"] != spec["local_intermediate_size"] * tp
+            or spec["top_k"] > spec["num_experts"]
+            or spec["block_size_m"] != 32
+            or spec["activation"] != "silu"
+            or spec["output_dtype"] != "bfloat16"
+            or spec["activation_quant"] != "dynamic_mxfp4_per_1x32_e8m0"
+            or spec["weight_quant"] != "mxfp4_per_1x32_e8m0"
+            or spec["sorting_backend"] != "aiter.moe_sorting/opus"
+            or spec["experts_backend"] != "aiter.fused_moe_2stages"
+            or spec["assignment_reconstruction"]
+                != "largest_remaining_count_then_expert_id"
+            or spec["includes_sorting"] is not False
+            or spec["includes_tp_allreduce"] is not False):
+        raise ValueError("Malformed routed MoE backend/precision contract")
+    e, h, local = spec["num_experts"], spec["hidden_size"], spec["local_intermediate_size"]
+    expected = {
+        "w13_packed_shape": (e, 2 * local, h // 2),
+        "w2_packed_shape": (e, h, local // 2),
+        "w13_scale_shape": (e, 2 * local, h // 32),
+        "w2_scale_shape": (e, h, local // 32),
+    }
+    if any(tuple(spec[name]) != shape for name, shape in expected.items()):
+        raise ValueError("Inconsistent routed MoE packed tensor shapes")
+
+
+def validate_moe_route_workload(size, physical_expert_counts, spec):
+    counts = tuple(physical_expert_counts)
+    if (type(size) is not int or size < 1 or len(counts) != spec["num_experts"]
+            or any(type(value) is not int or not 0 <= value <= size for value in counts)
+            or sum(counts) != size * spec["top_k"]):
+        raise ValueError("Invalid routed MoE physical expert counts")
+    return {
+        "physical_size": size,
+        "active_experts": sum(value > 0 for value in counts),
+        "maximum_expert_load": max(counts),
+        "sorted_token_blocks": sum(
+            (value + spec["block_size_m"] - 1) // spec["block_size_m"]
+            for value in counts if value),
+    }
+
+
+def reconstruct_topk_ids(size, physical_expert_counts, spec):
+    """Construct a deterministic valid assignment for an observed route histogram."""
+    validate_moe_route_workload(size, physical_expert_counts, spec)
+    remaining = list(physical_expert_counts)
+    rows = []
+    for _ in range(size):
+        selected = sorted(
+            (expert for expert, count in enumerate(remaining) if count),
+            key=lambda expert: (-remaining[expert], expert),
+        )[:spec["top_k"]]
+        if len(selected) != spec["top_k"]:
+            raise ValueError("Expert histogram cannot form unique per-token top-k assignments")
+        rows.append(tuple(selected))
+        for expert in selected:
+            remaining[expert] -= 1
+    if any(remaining):
+        raise ValueError("Expert histogram reconstruction left unassigned routes")
+    return tuple(rows)
+
+
+def make_moe_sorting_primitive(
+        size, physical_expert_counts, model, group, *, validate=True):
+    """Build an exact-histogram AITER Opus sorting invocation."""
+    import torch
+    from aiter.fused_moe import moe_sorting
+
+    spec = moe_routed_spec(model, group.world_size)
+    validate_moe_routed_spec(spec, group.world_size)
+    workload = validate_moe_route_workload(size, physical_expert_counts, spec)
+    assignments = reconstruct_topk_ids(size, physical_expert_counts, spec)
+    topk_ids = torch.tensor(assignments, device="cuda", dtype=torch.int32)
+    topk_weights = torch.full(
+        topk_ids.shape, 1. / spec["top_k"], device="cuda", dtype=torch.float32)
+
+    def raw():
+        return moe_sorting(
+            topk_ids, topk_weights, spec["num_experts"], spec["hidden_size"],
+            torch.bfloat16, spec["block_size_m"], accumulate=True)
+
+    expected_valid = torch.tensor(
+        [workload["sorted_token_blocks"] * spec["block_size_m"], size],
+        device="cuda", dtype=torch.int32)
+    if validate:
+        # Validate Opus' packed token-slot encoding and expert-block ownership
+        # for representative independent invocations. Only raw() is timed.
+        sorted_ids, sorted_weights, sorted_experts, valid, _ = raw()
+        torch.testing.assert_close(valid, expected_valid, atol=0, rtol=0)
+        blocks = workload["sorted_token_blocks"]
+        active = [expert for expert, count in enumerate(physical_expert_counts) if count]
+        torch.testing.assert_close(
+            sorted_experts[:blocks],
+            torch.tensor(active, device="cuda", dtype=torch.int32), atol=0, rtol=0)
+        encoded = sorted_ids[:blocks * spec["block_size_m"]].view(
+            blocks, spec["block_size_m"])
+        weights = sorted_weights[:blocks * spec["block_size_m"]].view_as(encoded)
+        token_mask = (1 << 24) - 1
+        tokens, slots = encoded & token_mask, encoded >> 24
+        seen = [0] * spec["num_experts"]
+        for block, expert in enumerate(active):
+            valid_lanes = tokens[block] < size
+            if (not bool((slots[block][valid_lanes] < spec["top_k"]).all())
+                    or not bool((weights[block][~valid_lanes] == 0).all())):
+                raise ValueError("Malformed AITER sorted route padding")
+            lane_tokens = tokens[block][valid_lanes].long()
+            lane_slots = slots[block][valid_lanes].long()
+            if not bool((topk_ids[lane_tokens, lane_slots] == expert).all()):
+                raise ValueError("AITER sorted route disagrees with input assignment")
+            torch.testing.assert_close(
+                weights[block][valid_lanes], topk_weights[lane_tokens, lane_slots],
+                atol=0, rtol=0)
+            seen[expert] = int(valid_lanes.sum().item())
+        if tuple(seen) != tuple(physical_expert_counts):
+            raise ValueError("AITER sorted route disagrees with expert histogram")
+
+    def fn():
+        return raw()[3]
+
+    return fn, expected_valid, (), spec["sorting_backend"], spec, workload
+
+
+def make_moe_experts_primitive(
+        size, physical_expert_counts, model, group, *, validate=True):
+    """Build the two-stage MXFP4 expert boundary after an untimed route sort."""
+    import torch
+    import aiter
+    from aiter.fused_moe import fused_moe_2stages, moe_sorting
+
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        raise ValueError("Native MXFP4 dtype is required for routed expert profiling")
+    spec = moe_routed_spec(model, group.world_size)
+    validate_moe_routed_spec(spec, group.world_size)
+    workload = validate_moe_route_workload(size, physical_expert_counts, spec)
+    assignments = reconstruct_topk_ids(size, physical_expert_counts, spec)
+    topk_ids = torch.tensor(assignments, device="cuda", dtype=torch.int32)
+    topk_weights = torch.full(
+        topk_ids.shape, 1. / spec["top_k"], device="cuda", dtype=torch.float32)
+    sorted_ids, sorted_weights, sorted_experts, valid, moe_out = moe_sorting(
+        topk_ids, topk_weights, spec["num_experts"], spec["hidden_size"],
+        torch.bfloat16, spec["block_size_m"], accumulate=True)
+    expected_valid = torch.tensor(
+        [workload["sorted_token_blocks"] * spec["block_size_m"], size],
+        device="cuda", dtype=torch.int32)
+    if validate:
+        torch.testing.assert_close(valid, expected_valid, atol=0, rtol=0)
+
+    # Zero-valued packed weights keep the exact tensor extents, expert address
+    # strides and memory traffic while providing an independent exact-zero
+    # oracle. Zero is invariant under the checkpoint's 16x16 weight shuffle;
+    # the marker selects the same AITER kernels as processed Quark weights.
+    w13 = torch.zeros(
+        spec["w13_packed_shape"], device="cuda", dtype=torch.uint8,
+    ).view(torch.float4_e2m1fn_x2)
+    w2 = torch.zeros(
+        spec["w2_packed_shape"], device="cuda", dtype=torch.uint8,
+    ).view(torch.float4_e2m1fn_x2)
+    w13.is_shuffled = True
+    w2.is_shuffled = True
+    w13_scale = torch.zeros(
+        spec["w13_scale_shape"], device="cuda", dtype=torch.uint8)
+    w2_scale = torch.zeros(
+        spec["w2_scale_shape"], device="cuda", dtype=torch.uint8)
+    hidden_states = (
+        torch.randn((size, spec["hidden_size"]), device="cuda", dtype=torch.bfloat16)
+        * .1).contiguous()
+    reference = torch.zeros_like(hidden_states)
+
+    def fn():
+        return fused_moe_2stages(
+            hidden_states, w13, w2, spec["top_k"], sorted_ids, sorted_weights,
+            sorted_experts, valid, moe_out, True, spec["block_size_m"],
+            activation=aiter.ActivationType.Silu,
+            quant_type=aiter.QuantType.per_1x32,
+            q_dtype_a=torch.float4_e2m1fn_x2,
+            q_dtype_w=torch.float4_e2m1fn_x2,
+            w1_scale=w13_scale,
+            w2_scale=w2_scale,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+        )
+
+    return fn, reference, (moe_out,), spec["experts_backend"], spec, workload
+
+
+def make_moe_routing_primitive(name, size, model, random):
+    """Build the native AITER top-k call and independently verify its routing."""
+    import torch
+    from sglang.srt.layers.moe.topk import _use_aiter, fused_topk
+
+    if name not in MOE_ROUTING_PRIMITIVES:
+        raise ValueError(f"Unknown MoE routing primitive {name}")
+    if not _use_aiter:
+        raise ValueError("Expected the captured SGLang AITER top-k path")
+    spec = moe_routing_spec(model)
+    validate_moe_routing_spec(spec)
+    hidden_states = random((size, spec["hidden_size"]), .1)
+    logits = random((size, spec["num_experts"]), 1.)
+    reference_scores = torch.softmax(logits.float(), dim=-1)
+    reference_weights, reference_ids = torch.topk(
+        reference_scores, spec["top_k"], dim=-1)
+
+    # AITER owns output ordering. Validate the expert set and each gathered
+    # probability once per independent invocation without adding canonicalizing
+    # sort/gather kernels to the measured graph boundary.
+    eager_weights, eager_ids = fused_topk(
+        hidden_states, logits, spec["top_k"], spec["renormalize"])
+    torch.testing.assert_close(
+        torch.sort(eager_ids, dim=-1).values,
+        torch.sort(reference_ids.to(torch.int32), dim=-1).values,
+        atol=0, rtol=0)
+    torch.testing.assert_close(
+        eager_weights, reference_scores.gather(1, eager_ids.long()),
+        atol=1e-6, rtol=1e-5)
+
+    def fn():
+        # Returning weights avoids imposing a non-native expert-id ordering on
+        # the graph. The eager checks above cover ids and id/weight pairing.
+        return fused_topk(
+            hidden_states, logits, spec["top_k"], spec["renormalize"])[0]
+
+    return fn, reference_weights, (), spec["backend"], spec

--- a/frontier/profiling/runtime/sglang_moe_routes.py
+++ b/frontier/profiling/runtime/sglang_moe_routes.py
@@ -1,0 +1,335 @@
+"""Profile exact route-conditioned Qwen3.8 MoE boundaries on one ROCm node.
+
+The input is a Frontier runtime query plan, not observed timings. Each row is
+keyed by the complete cost query (including per-expert physical token counts).
+This module does not fit across route histograms or load a model checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from dataclasses import asdict, fields
+import json
+import math
+import os
+from pathlib import Path
+
+from frontier.profiling.runtime.sglang_moe import (
+    MOE_ROUTED_PRIMITIVES, make_moe_experts_primitive, make_moe_sorting_primitive,
+)
+from frontier.profiling.runtime.sglang_primitives import MEASUREMENT_TYPE, validate_plan
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload, RuntimeIdentity
+
+
+def read_routed_queries(path, identity, components=MOE_ROUTED_PRIMITIVES):
+    payload = json.loads(Path(path).read_text())
+    if RuntimeIdentity(**payload["identity"]) != identity:
+        raise ValueError("Route query plan belongs to another runtime")
+    result = []
+    for item in payload.get("queries", ()):
+        raw = dict(item["query"])
+        raw["identity"] = RuntimeIdentity(**raw["identity"])
+        raw["workload"] = DecodeWorkload(**raw["workload"])
+        raw["physical_expert_counts"] = tuple(raw.get("physical_expert_counts", ()))
+        query = CostQuery(**raw)
+        if query.key != item.get("query_key"):
+            raise ValueError("Route query plan key disagrees with serialized query")
+        if query.component in components:
+            result.append(query)
+    if (not result
+            or len({(query.component, query.layer_id) for query in result}) != len(result)
+            or len({query.workload for query in result}) != 1):
+        raise ValueError("Route query plan requires unique routed layers for one workload")
+    return tuple(sorted(result, key=lambda query: (query.component, query.layer_id)))
+
+
+def read_sorting_queries(path, identity):
+    return read_routed_queries(path, identity, ("moe_sorting",))
+
+
+def _barrier(group):
+    import torch
+    import torch.distributed as dist
+
+    torch.cuda.synchronize()
+    dist.barrier(group=group.cpu_group)
+
+
+def profile_routed_graph(query, count, repetitions, model, group, *, trace=False):
+    import torch
+
+    size = query.workload.physical_size
+    builder = {
+        "moe_sorting": make_moe_sorting_primitive,
+        "moe_experts_quant_gemm_combine": make_moe_experts_primitive,
+    }.get(query.component)
+    if builder is None:
+        raise ValueError("Unsupported routed primitive query")
+    calls = [builder(size, query.physical_expert_counts, model, group,
+                     validate=index in {0, count - 1}) for index in range(count)]
+    if len({call[3] for call in calls}) != 1:
+        raise ValueError("One graph cannot mix routed primitive implementations")
+    originals = [[value.clone() for value in call[2]] for call in calls]
+
+    def reset(call_index):
+        for value, original in zip(calls[call_index][2], originals[call_index]):
+            value.copy_(original)
+
+    def check(call_index, output):
+        torch.testing.assert_close(
+            output, calls[call_index][1], atol=.03, rtol=.03)
+        if not bool(torch.isfinite(output).all()):
+            raise ValueError("Nonfinite routed primitive output")
+
+    for call_index in (0, count - 1):
+        reset(call_index)
+        check(call_index, calls[call_index][0]())
+    for _ in range(3):
+        for call_index, (fn, *_) in enumerate(calls):
+            reset(call_index)
+            fn()
+    _barrier(group)
+    graph, outputs = torch.cuda.CUDAGraph(), []
+    with group.graph_capture() as context:
+        with torch.cuda.graph(graph, stream=context.stream):
+            for fn, *_ in calls:
+                outputs.append(fn())
+    _barrier(group)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples = []
+    for repetition in range(repetitions + 3):
+        for call_index in range(count):
+            reset(call_index)
+        _barrier(group)
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        elapsed = start.elapsed_time(end)
+        if not math.isfinite(elapsed) or elapsed <= 0:
+            raise ValueError("Invalid routed graph timing")
+        if repetition >= 3:
+            samples.append(elapsed / count)
+        if repetition in {0, repetitions + 2}:
+            check(0, outputs[0])
+            check(count - 1, outputs[-1])
+
+    probe_calls, probe_outputs = (calls[0], calls[-1]), []
+    probe = None
+    if trace:
+        probe = torch.cuda.CUDAGraph()
+        with group.graph_capture() as context:
+            with torch.cuda.graph(probe, stream=context.stream):
+                for fn, *_ in probe_calls:
+                    probe_outputs.append(fn())
+        _barrier(group)
+    scope = f"routed:{query.component}:l{query.layer_id}:b{size}:n{count}"
+
+    def trace_replay():
+        reset(0)
+        reset(count - 1)
+        _barrier(group)
+        with torch.profiler.record_function(scope):
+            probe.replay()
+            torch.cuda.synchronize()
+        check(0, probe_outputs[0])
+        check(count - 1, probe_outputs[-1])
+        _barrier(group)
+
+    return {
+        "primitive": query.component,
+        "query_key": query.key,
+        "layer_id": query.layer_id,
+        "physical_size": size,
+        "physical_expert_counts": list(query.physical_expert_counts),
+        "invocations_per_graph": count,
+        "rank": group.rank_in_group,
+        "backend": calls[0][3],
+        "samples_ms": samples,
+        "measurement_type": MEASUREMENT_TYPE,
+        "correctness_checked": True,
+        "moe_routed_spec": calls[0][4],
+        "moe_route_workload": calls[0][5],
+        "kernel_names": [],
+        "kernel_trace_kind": "representative_graph" if trace else None,
+        "kernel_trace_invocations": 2 if trace else 0,
+        "trace_scope": scope,
+    }, trace_replay
+
+
+def attach_kernel_evidence(records, events):
+    for row in records:
+        ranges = [event for event in events
+                  if event.get("name") == row["trace_scope"]
+                  and event.get("ph") == "X"
+                  and event.get("cat") == "user_annotation"]
+        if len(ranges) != 1:
+            raise ValueError("Missing or duplicate routed replay trace range")
+        scope = ranges[0]
+        kernels = [event for event in events
+                   if event.get("cat") == "kernel" and event.get("ph") == "X"
+                   and scope["ts"] <= event["ts"]
+                   and event["ts"] + event["dur"] <= scope["ts"] + scope["dur"]]
+        if not kernels or len(kernels) % row["kernel_trace_invocations"]:
+            raise ValueError("Incomplete or unexpected routed primitive kernel evidence")
+        names = [event["name"] for event in kernels]
+        if row["primitive"] == "moe_sorting":
+            if any("aiter::opus_moe_sorting_entry" not in name for name in names):
+                raise ValueError("Unexpected routed sorting kernel evidence")
+        else:
+            allowed = (
+                "dynamic_per_group_scaled_quant_kernel", "mxfp4_moe_sort_kernel",
+                "fused_mx_quant_moe_sort_kernel", "mfma_moe1_", "mfma_moe2_",
+            )
+            if (any(not any(marker in name for marker in allowed) for name in names)
+                    or sum("mfma_moe1_" in name for name in names) != 2
+                    or sum("mfma_moe2_" in name for name in names) != 2):
+                raise ValueError("Unexpected routed expert kernel evidence")
+        row["kernel_names"] = sorted({event["name"] for event in kernels})
+        row["kernel_count"] = len(kernels)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-manifest", type=Path, required=True)
+    parser.add_argument("--query-plan", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", default="mi355x")
+    parser.add_argument("--invocations", type=int, nargs="+", default=[32, 128])
+    parser.add_argument("--repetitions", type=int, default=20)
+    parser.add_argument("--primitives", choices=MOE_ROUTED_PRIMITIVES, nargs="+",
+                        default=list(MOE_ROUTED_PRIMITIVES))
+    parser.add_argument("--layers", type=int, nargs="+")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--trace", action="store_true")
+    args = parser.parse_args()
+    validate_plan([1], args.invocations, args.repetitions, "calibration")
+
+    manifest = json.loads(args.capture_manifest.read_text())
+    if (manifest["status"] != "complete"
+            or manifest["topology"] != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1}):
+        raise ValueError("Routed profiling requires the captured eight-GPU TP-only topology")
+    for key, value in manifest["environment"].items():
+        if not key.startswith("SGLANG_"):
+            raise ValueError("Only captured SGLang runtime environment entries may be restored")
+        os.environ[key] = str(value)
+
+    import aiter
+    import sglang
+    import torch
+    import torch.distributed as dist
+    from sglang.srt.distributed.parallel_state import (
+        get_tp_group, init_distributed_environment, initialize_model_parallel,
+    )
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+    from frontier.profiling.common.model_config import ModelConfig
+    from frontier.runtime_cost.sglang import SGLangCostContract
+    from frontier.validation.runtime_cost import identity_for_capture
+    from frontier.validation.sglang_capture import _git_revision, _source_digest
+
+    rank, world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if not torch.version.hip or world != 8 or rank != local_rank:
+        raise ValueError("Run with torchrun --nproc_per_node=8 on one ROCm node")
+    torch.cuda.set_device(local_rank)
+    torch.manual_seed(1701 + rank)
+    actual = {
+        "torch": torch.__version__, "rocm": torch.version.hip,
+        "sglang_commit": _git_revision(Path(sglang.__file__).parent),
+        "aiter_commit": _git_revision(Path(aiter.__file__).parent),
+    }
+    if any(value is None or value != manifest["versions"][key]
+           for key, value in actual.items()):
+        raise ValueError(f"Profiling stack differs from the pinned capture: {actual}")
+    model = ModelConfig.from_model_name(args.model)
+    identity = identity_for_capture(manifest, model, args.device)
+    SGLangCostContract(model, identity)
+    queries = read_routed_queries(args.query_plan, identity, tuple(args.primitives))
+    if args.layers is not None:
+        requested = set(args.layers)
+        queries = tuple(query for query in queries if query.layer_id in requested)
+        if {query.layer_id for query in queries} != requested:
+            raise ValueError("Requested routed profile layer is absent from the plan")
+
+    init_fields = {field.name for field in fields(ServerArgs) if field.init}
+    server = ServerArgs(**{
+        key: value for key, value in manifest["server_args"].items()
+        if key in init_fields})
+    set_global_server_args_for_scheduler(server)
+    if os.environ.get("SGLANG_SET_CPU_AFFINITY") == "1":
+        from sglang.benchmark.one_batch import set_gpu_proc_affinity
+        set_gpu_proc_affinity(1, world, 1, rank)
+    init_distributed_environment(world_size=world, rank=rank, local_rank=local_rank, timeout=180)
+    initialize_model_parallel(tensor_model_parallel_size=world)
+    group = get_tp_group()
+    properties = torch.cuda.get_device_properties(local_rank)
+    if args.device.lower() not in properties.name.lower().replace(" ", ""):
+        raise ValueError("Requested hardware does not match the active GPU")
+    if rank == 0:
+        args.output_dir.mkdir(parents=True, exist_ok=False)
+    dist.barrier(group=group.cpu_group)
+
+    records = []
+    with torch.inference_mode():
+        for query in queries:
+            query_rows, query_replays = [], []
+            for count in args.invocations:
+                row, replay = profile_routed_graph(
+                    query, count, args.repetitions, model, group, trace=args.trace)
+                query_rows.append(row)
+                if args.trace:
+                    query_replays.append(replay)
+                if rank == 0:
+                    print(json.dumps({key: row[key] for key in (
+                        "primitive", "layer_id", "physical_size",
+                        "invocations_per_graph", "backend")}), flush=True)
+            if args.trace:
+                # Trace and release one layer at a time. Expert graphs own a
+                # streaming working set of TP-sharded weights; retaining every
+                # layer's probe graph until the end would multiply HBM use.
+                profiler = torch.profiler.profile(activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA]) if rank == 0 else nullcontext()
+                with profiler:
+                    for replay in query_replays:
+                        replay()
+                if rank == 0:
+                    trace_path = args.output_dir / (
+                        f"{query.component}-layer{query.layer_id}.trace.json")
+                    profiler.export_chrome_trace(str(trace_path))
+                    attach_kernel_evidence(
+                        query_rows,
+                        json.loads(trace_path.read_text())["traceEvents"])
+            records.extend(query_rows)
+
+    payload = {
+        "schema_version": 1,
+        "profile_kind": "exact_routed_query",
+        "identity": asdict(identity),
+        "rank": rank,
+        "world_size": world,
+        "versions": actual,
+        "rows": records,
+        "producer_source_sha256": _source_digest(Path(__file__).resolve().parents[2]),
+        "hardware": {"name": properties.name, "arch": properties.gcnArchName},
+        "extra_collective_environment": {
+            key: value for key, value in os.environ.items()
+            if key.startswith(("ROCM_QUICK_", "NCCL_"))},
+        "method": "Exact query-conditioned HIP graph replay. Per-expert counts come from the "
+                  "untimed routing plan and are deterministically reconstructed into valid unique "
+                  "top-k assignments. Independent inputs, packed zero-valued weights and output "
+                  "buffers per expert invocation preserve streaming extents with an exact-zero "
+                  "oracle; sorting has no weights. No checkpoint, cross-route fit, full-forward "
+                  "timing, or target correction.",
+    }
+    with (args.output_dir / f"rank{rank}.json").open("x") as stream:
+        json.dump(payload, stream, indent=2)
+        stream.write("\n")
+    dist.barrier(group=group.cpu_group)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/profiling/runtime/sglang_primitives.py
+++ b/frontier/profiling/runtime/sglang_primitives.py
@@ -1,0 +1,372 @@
+"""Profile SGLang's fused primitives and TP reduction without loading a checkpoint.
+
+Run with torchrun on one ROCm node. Inputs/weights are synthetic and shape
+matched; this is not full-model performance or numerical validation. Timings
+bracket an isolated multi-call graph replay, not individual kernel durations.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from dataclasses import asdict, fields
+import json
+import math
+import os
+from pathlib import Path
+
+from frontier.profiling.runtime.sglang_dense import DENSE_PRIMITIVES, dense_primitive_spec, make_dense_primitive
+from frontier.profiling.runtime.sglang_gdn import GDN_PRIMITIVES, gdn_core_spec, make_gdn_core_primitive
+from frontier.profiling.runtime.sglang_attention import (
+    ATTENTION_PRIMITIVES, attention_decode_spec, make_attention_primitive,
+)
+from frontier.profiling.runtime.sglang_moe import (
+    MOE_ROUTING_PRIMITIVES, make_moe_routing_primitive, moe_routing_spec,
+)
+
+PRIMITIVES = ("gemma_norm", "gemma_residual_norm", "shared_gate", "attention_post", "tp_allreduce",
+              *DENSE_PRIMITIVES, *GDN_PRIMITIVES, *ATTENTION_PRIMITIVES,
+              *MOE_ROUTING_PRIMITIVES)
+DEFAULT_PRIMITIVES = tuple(name for name in PRIMITIVES
+                           if name not in GDN_PRIMITIVES + ATTENTION_PRIMITIVES
+                           + MOE_ROUTING_PRIMITIVES)
+MEASUREMENT_TYPE = "HIP_GRAPH_REPLAY"
+
+
+def validate_plan(sizes, invocations, repetitions, split):
+    if split not in {"calibration", "validation"}:
+        raise ValueError("A calibration/validation split must be explicit")
+    for name, values, minimum in (("sizes", sizes, 1), ("invocations", invocations, 2)):
+        if not values or len(values) != len(set(values)) or any(type(v) is not int or v < minimum for v in values):
+            raise ValueError(f"Invalid {name}")
+    if type(repetitions) is not int or repetitions < 5:
+        raise ValueError("At least five repetitions are required")
+
+
+def make_primitive(name, size, model, group, rank, *, logical_size=None,
+                   physical_context_lens=None):
+    """Return one independent invocation; mutations are restored before replay."""
+    import torch
+    from sglang.kernels.ops.elementwise.elementwise import fused_gate_sigmoid_mul_add, fused_sigmoid_mul
+    from sglang.srt.layers.layernorm import GemmaRMSNorm, _has_rocm_triton_gemma_rms_norm, _use_aiter
+    from sglang.srt.layers.linear import RowParallelLinear
+
+    hidden, dtype = model.embedding_dim, torch.bfloat16
+    def random(shape, scale=1.):
+        return (torch.randn(shape, device="cuda", dtype=dtype) * scale).contiguous()
+    x = random((size, hidden))
+    mutable = []
+    backend = "sglang_triton_gemma"
+    attention_spec = attention_workload = moe_spec = None
+    if name in ATTENTION_PRIMITIVES:
+        fn, reference, mutable, backend, attention_spec, attention_workload = make_attention_primitive(
+            name, size, logical_size, physical_context_lens, model, group, rank, random)
+    elif name in GDN_PRIMITIVES:
+        fn, reference, mutable, backend, _ = make_gdn_core_primitive(
+            size, logical_size, model, group, random)
+    elif name in MOE_ROUTING_PRIMITIVES:
+        fn, reference, mutable, backend, moe_spec = make_moe_routing_primitive(
+            name, size, model, random)
+    elif name in DENSE_PRIMITIVES:
+        fn, reference, backend = make_dense_primitive(name, size, model, group, rank, random)
+    elif name in {"gemma_norm", "gemma_residual_norm"}:
+        if not (_use_aiter and _has_rocm_triton_gemma_rms_norm):
+            raise ValueError("Expected the AITER-enabled SGLang Triton Gemma norm path; native fallback is not a matching profile")
+        norm = GemmaRMSNorm(hidden, model.rms_norm_eps).to(device="cuda", dtype=dtype)
+        norm.weight.data.copy_(random((hidden,), .05))
+        residual = random(x.shape) if name == "gemma_residual_norm" else None
+        # ROCm's wrapper can be out-of-place; restoring inputs also guards
+        # against accidental in-place behavior after a runtime change.
+        mutable = [x] + ([residual] if residual is not None else [])
+        total = x.float() + (residual.float() if residual is not None else 0.)
+        expected = ((total * torch.rsqrt(total.square().mean(-1, keepdim=True) + model.rms_norm_eps))
+                    * (1. + norm.weight.float())).to(dtype)
+        reference = (expected, total.to(dtype)) if residual is not None else expected
+        fn = lambda: norm(x, residual)
+    elif name == "shared_gate":
+        weight, shared, final = random((hidden,), hidden ** -.5), random(x.shape), random(x.shape)
+        reference = (final.float() + torch.sigmoid(x.float() @ weight.float())[:, None] * shared.float()).to(dtype)
+        mutable = [final]
+        def fn():
+            fused_gate_sigmoid_mul_add(x, weight, shared, final)
+            return final
+        backend = "sglang_triton"
+    elif name == "attention_post":
+        heads, head_dim = model.num_q_heads // group.world_size, model.get_head_dim()
+        width = heads * head_dim
+        x = random((size, width))
+        # Qwen's Q/gate projection interleaves the Q and gate slice per head.
+        backing = random((size, heads, 2 * head_dim))
+        gate = backing[..., head_dim:]
+        linear = RowParallelLinear(model.num_q_heads * head_dim, hidden, bias=False,
+            input_is_parallel=True, reduce_results=False, params_dtype=dtype,
+            tp_rank=rank, tp_size=group.world_size).to(device="cuda", dtype=dtype)
+        linear.weight.data.copy_(random(linear.weight.shape, width ** -.5))
+        gated = (x.float() * torch.sigmoid(gate.float().reshape(size, width))).to(dtype)
+        reference = torch.nn.functional.linear(gated.float(), linear.weight.float()).to(dtype)
+        mutable = [x]
+        def fn():
+            out = fused_sigmoid_mul(x, gate, inplace=True)
+            return linear(out)[0]
+        backend = f"sglang_triton+{type(linear.quant_method).__name__}"
+    elif name == "tp_allreduce":
+        x.fill_(rank + 1)
+        reference = torch.full_like(x, group.world_size * (group.world_size + 1) / 2)
+        backend = group._resolve_outplace_all_reduce_method(x)
+        if backend not in {"ca", "qr"}:
+            raise ValueError(f"Expected a custom out-of-place reduction, got {backend}")
+        fn = lambda: group.all_reduce(x)
+        mutable = [x]
+    else:
+        raise ValueError(f"Unknown primitive {name}")
+    originals = [v.clone() for v in mutable]
+    def reset():
+        for value, original in zip(mutable, originals):
+            value.copy_(original)
+    def check(output):
+        values = output if isinstance(output, tuple) else (output,)
+        refs = reference if isinstance(reference, tuple) else (reference,)
+        if len(values) != len(refs):
+            raise ValueError("Unexpected primitive output structure")
+        for actual, expected in zip(values, refs):
+            torch.testing.assert_close(actual, expected, atol=.03, rtol=.03)
+            if not bool(torch.isfinite(actual).all()):
+                raise ValueError("Nonfinite primitive output")
+    return fn, reset, check, backend, attention_spec, attention_workload, moe_spec
+
+
+def profile_graph(name, size, count, repetitions, model, group, rank, *, logical_size=None,
+                  physical_context_lens=None, trace=False):
+    import torch
+    import torch.distributed as dist
+
+    def barrier():
+        torch.cuda.synchronize()
+        dist.barrier(group=group.cpu_group)
+    calls = [make_primitive(name, size, model, group, rank, logical_size=logical_size,
+                            physical_context_lens=physical_context_lens)
+             for _ in range(count)]
+    methods = {call[3] for call in calls}
+    if len(methods) != 1:
+        raise ValueError("One graph cannot mix primitive implementations")
+    # Check one unfused-reference comparison before capture, including in-place
+    # semantics. Every captured call owns its own mutable inputs and parameters.
+    for fn, reset, check, *_ in (calls[0], calls[-1]):
+        reset()
+        check(fn())
+    for _ in range(3):
+        for fn, reset, *_ in calls:
+            reset()
+            fn()
+    barrier()
+    graph = torch.cuda.CUDAGraph()
+    outputs = []
+    with group.graph_capture() as context:
+        with torch.cuda.graph(graph, stream=context.stream):
+            for fn, *_ in calls:
+                outputs.append(fn())
+    barrier()
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+    samples = []
+    for rep in range(repetitions + 3):
+        for _, reset, *_ in calls:
+            reset()
+        barrier()  # resets and rank synchronization are outside the timing interval
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        elapsed = start.elapsed_time(end)
+        if not math.isfinite(elapsed) or elapsed <= 0:
+            raise ValueError("Invalid graph timing")
+        if rep >= 3:
+            samples.append(elapsed / count)
+        if rep in {0, repetitions + 2}:
+            calls[0][2](outputs[0])
+            calls[-1][2](outputs[-1])
+    # ROCTracer can omit large HIP graph batches entirely. Verify the same
+    # callables in a representative two-invocation graph, not a claimed trace
+    # of every timed invocation. This probe never supplies timing estimates.
+    probe_calls, probe_outputs = (calls[0], calls[-1]), []
+    probe = None
+    if trace:
+        probe = torch.cuda.CUDAGraph()
+        with group.graph_capture() as context:
+            with torch.cuda.graph(probe, stream=context.stream):
+                for fn, *_ in probe_calls:
+                    probe_outputs.append(fn())
+        barrier()
+    def trace_replay():
+        for _, reset, *_ in probe_calls:
+            reset()
+        barrier()
+        with torch.profiler.record_function(f"primitive:{name}:b{size}:n{count}"):
+            probe.replay()
+            torch.cuda.synchronize()
+        for call, output in zip(probe_calls, probe_outputs):
+            call[2](output)
+        barrier()
+    row = {"primitive": name, "physical_size": size, "invocations_per_graph": count,
+        "rank": rank, "backend": next(iter(methods)), "samples_ms": samples,
+        "measurement_type": MEASUREMENT_TYPE, "correctness_checked": True,
+        "kernel_names": [], "kernel_trace_kind": "representative_graph" if trace else None,
+        "kernel_trace_invocations": 2 if trace else 0}
+    if name in DENSE_PRIMITIVES:
+        row["dense_spec"] = dense_primitive_spec(name, model, group.world_size)
+    if name in GDN_PRIMITIVES:
+        row["logical_size"] = logical_size
+        row["gdn_core_spec"] = gdn_core_spec(model, group.world_size)
+    if name in ATTENTION_PRIMITIVES:
+        row["logical_size"] = logical_size
+        row["physical_context_lens"] = list(physical_context_lens)
+        row["attention_decode_spec"] = calls[0][4]
+        row["attention_workload"] = calls[0][5]
+    if name in MOE_ROUTING_PRIMITIVES:
+        row["moe_routing_spec"] = calls[0][6]
+    return row, trace_replay
+
+
+def attach_kernel_evidence(records, events):
+    """Match synchronized replay ranges; never use profiler durations as costs."""
+    for row in records:
+        name, size, count = (row[k] for k in ("primitive", "physical_size", "invocations_per_graph"))
+        ranges = [e for e in events if e.get("name") == f"primitive:{name}:b{size}:n{count}"
+            and e.get("ph") == "X" and e.get("cat") == "user_annotation"]
+        if len(ranges) != 1:
+            raise ValueError("Missing or duplicate primitive replay trace range")
+        scope = ranges[0]
+        kernels = [e for e in events if e.get("cat") == "kernel" and e.get("ph") == "X"
+            and scope["ts"] <= e["ts"] and e["ts"] + e["dur"] <= scope["ts"] + scope["dur"]]
+        probe_count = row["kernel_trace_invocations"]
+        if probe_count != 2 or not kernels or len(kernels) % probe_count:
+            raise ValueError(f"Primitive graph trace has incomplete invocation coverage: {name}, b{size}, n{count}")
+        row["kernel_names"] = sorted({e["name"] for e in kernels})
+        row["kernel_count"] = len(kernels)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-manifest", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", default="mi355x")
+    parser.add_argument("--sizes", type=int, nargs="+", required=True)
+    parser.add_argument("--logical-sizes", type=int, nargs="+")
+    parser.add_argument("--active-context-lengths", type=int, nargs="+")
+    parser.add_argument("--invocations", type=int, nargs="+", default=[32, 128])
+    parser.add_argument("--repetitions", type=int, default=20)
+    parser.add_argument("--split", choices=("calibration", "validation"), required=True)
+    parser.add_argument("--primitives", choices=PRIMITIVES, nargs="+", default=list(DEFAULT_PRIMITIVES))
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--trace", action="store_true")
+    args = parser.parse_args()
+    validate_plan(args.sizes, args.invocations, args.repetitions, args.split)
+    stateful = GDN_PRIMITIVES + ATTENTION_PRIMITIVES
+    if (any(name in stateful for name in args.primitives)
+            and (args.logical_sizes is None or len(args.logical_sizes) != len(args.sizes)
+                 or any(type(v) is not int or not 1 <= v <= p
+                        for v, p in zip(args.logical_sizes, args.sizes)))):
+        raise ValueError("Stateful profiling requires one valid --logical-sizes entry per physical size")
+    if (any(name in ATTENTION_PRIMITIVES for name in args.primitives)
+            and (args.active_context_lengths is None
+                 or len(args.active_context_lengths) != len(args.sizes)
+                 or any(type(v) is not int or v < 1 for v in args.active_context_lengths))):
+        raise ValueError("Attention profiling requires one --active-context-lengths entry per size")
+    manifest = json.loads(args.capture_manifest.read_text())
+    if manifest["status"] != "complete" or manifest["topology"] != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1}:
+        raise ValueError("Primitive profiling currently requires the captured eight-GPU TP-only topology")
+    for key, value in manifest["environment"].items():
+        if not key.startswith("SGLANG_"):
+            raise ValueError("Only captured SGLang runtime environment entries may be restored")
+        os.environ[key] = str(value)
+    import torch
+    import torch.distributed as dist
+    import sglang
+    import aiter
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+    from sglang.srt.distributed.parallel_state import init_distributed_environment, initialize_model_parallel, get_tp_group
+    from frontier.profiling.common.model_config import ModelConfig
+    from frontier.runtime_cost.sglang import SGLangCostContract
+    from frontier.validation.runtime_cost import identity_for_capture
+    from frontier.validation.sglang_capture import _git_revision, _source_digest
+
+    rank, world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if not torch.version.hip or world != 8 or rank != local_rank:
+        raise ValueError("Run with torchrun --nproc_per_node=8 on one ROCm node")
+    torch.cuda.set_device(local_rank)
+    torch.manual_seed(17 + rank)
+    actual = {"torch": torch.__version__, "rocm": torch.version.hip,
+        "sglang_commit": _git_revision(Path(sglang.__file__).parent),
+        "aiter_commit": _git_revision(Path(aiter.__file__).parent)}
+    if any(value is None or value != manifest["versions"][key] for key, value in actual.items()):
+        raise ValueError(f"Profiling stack differs from the pinned capture: {actual}")
+    model = ModelConfig.from_model_name(args.model)
+    identity = identity_for_capture(manifest, model, args.device)
+    SGLangCostContract(model, identity)
+    if model.dtype != torch.bfloat16:
+        raise ValueError("Primitive profiling currently implements BF16 activations/dense weights only")
+    init_fields = {f.name for f in fields(ServerArgs) if f.init}
+    server = ServerArgs(**{k: v for k, v in manifest["server_args"].items() if k in init_fields})
+    set_global_server_args_for_scheduler(server)
+    if os.environ.get("SGLANG_SET_CPU_AFFINITY") == "1":
+        from sglang.benchmark.one_batch import set_gpu_proc_affinity
+        set_gpu_proc_affinity(1, world, 1, rank)
+    init_distributed_environment(world_size=world, rank=rank, local_rank=local_rank, timeout=180)
+    initialize_model_parallel(tensor_model_parallel_size=world)
+    group = get_tp_group()
+    properties = torch.cuda.get_device_properties(local_rank)
+    if args.device.lower() not in properties.name.lower().replace(" ", ""):
+        raise ValueError("Requested hardware does not match the active GPU")
+    if rank == 0:
+        args.output_dir.mkdir(parents=True, exist_ok=False)
+    dist.barrier(group=group.cpu_group)
+    records, trace_replays = [], []
+    with torch.inference_mode():
+        for size_index, size in enumerate(args.sizes):
+            for name in args.primitives:
+                for count in args.invocations:
+                    logical_size = args.logical_sizes[size_index] if name in stateful else None
+                    physical_context_lens = None
+                    if name in ATTENTION_PRIMITIVES:
+                        active = args.active_context_lengths[size_index]
+                        physical_context_lens = ((active,) * logical_size
+                                                 + (1,) * (size - logical_size))
+                    row, trace_replay = profile_graph(name, size, count, args.repetitions, model, group, rank,
+                        logical_size=logical_size, physical_context_lens=physical_context_lens,
+                        trace=args.trace)
+                    records.append(row)
+                    if args.trace:
+                        trace_replays.append(trace_replay)
+                    if rank == 0:
+                        print(json.dumps({k: row[k] for k in ("primitive", "physical_size", "invocations_per_graph", "backend")}), flush=True)
+        if args.trace:
+            # One profiler session avoids repeated ROCm activity-collection windows.
+            # Keep the graphs alive; all numerical/timing work above is unprofiled.
+            profiler = torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA]) if rank == 0 else nullcontext()
+            with profiler:
+                for replay in trace_replays:
+                    replay()
+            if rank == 0:
+                trace_path = args.output_dir / "kernels.trace.json"
+                profiler.export_chrome_trace(str(trace_path))
+                attach_kernel_evidence(records, json.loads(trace_path.read_text())["traceEvents"])
+    payload = {"schema_version": 1, "identity": asdict(identity), "split": args.split,
+        "rank": rank, "world_size": world, "versions": actual, "rows": records,
+        "producer_source_sha256": _source_digest(Path(__file__).resolve().parents[2]),
+        "hardware": {"name": properties.name, "arch": properties.gcnArchName},
+        "extra_collective_environment": {k: v for k, v in os.environ.items() if k.startswith(("ROCM_QUICK_", "NCCL_"))},
+        "method": "Outer event interval / independent invocations in one isolated graph replay; resets, "
+                  "barriers, reference checks and traces excluded. Synthetic shape-matched inputs/weights; "
+                  "independent weights per invocation (streaming working set), first/last outputs checked. "
+                  "Kernel identity from separate representative two-call graphs, not full timed-graph coverage. "
+                  "No checkpoint or full-forward calibration."}
+    with (args.output_dir / f"rank{rank}.json").open("x") as stream:
+        json.dump(payload, stream, indent=2)
+        stream.write("\n")
+    dist.barrier(group=group.cpu_group)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/profiling/utils/__init__.py
+++ b/frontier/profiling/utils/__init__.py
@@ -490,6 +490,7 @@ def get_collectives_inputs(
     max_collective_size: int,
     collective: str,
     total_gpus_available: int,
+    precision: str = "FP16",
 ):
     num_workers = []
 
@@ -497,7 +498,7 @@ def get_collectives_inputs(
         for _num_nodes in range(1, num_nodes + 1):
             num_workers.append(num_workers_per_node * _num_nodes)
 
-    num_workers = list(set(num_workers))
+    num_workers = sorted(set(num_workers))
     collectives_sizes = get_collectives_sizes_to_profile(max_collective_size)
 
     collectives_inputs = []
@@ -506,7 +507,11 @@ def get_collectives_inputs(
         num_workers, num_workers_per_node_combinations, collectives_sizes
     ):
         collectives_input = CollectivesInput(
-            num_workers, num_workers_per_node, collective_size, collective
+            num_workers,
+            num_workers_per_node,
+            collective_size,
+            collective,
+            precision,
         )
         if not collectives_input.is_valid(total_gpus_available, num_nodes):
             continue

--- a/frontier/profiling/utils/confirmation.py
+++ b/frontier/profiling/utils/confirmation.py
@@ -403,8 +403,27 @@ def build_moe_config_sections(
     else:
         exec_mode = f"Ray, {args.num_gpus} GPUs"
 
-    # Format precision with dtype
+    # Format the base activation precision with dtype. Quantized checkpoints can
+    # select only a subset of operations, so do not describe every MoE operation
+    # as running at this precision.
     precision_display = f"{precision_str} ({torch_dtype})"
+    quant_config = getattr(model_config, "quantization_config", None)
+    quant_method = getattr(quant_config, "quant_method", None)
+    quantized_operations = getattr(quant_config, "quantized_operations", None)
+    grouped_gemm_is_quantized = bool(quant_method) and (
+        quantized_operations is None
+        or "moe_grouped_gemm" in quantized_operations
+    )
+    grouped_gemm_precision = (
+        str(quant_method).upper()
+        if grouped_gemm_is_quantized
+        else precision_str
+    )
+    quantization_display = (
+        model_config.get_quant_signature()
+        if quant_method
+        else "Disabled"
+    )
 
     # Build operations by parallelism section
     tp_sizes = args.num_tensor_parallel_workers
@@ -412,11 +431,11 @@ def build_moe_config_sections(
     num_experts = model_config.num_experts
 
     ops_content = (
-        f"Operations (all at precision {precision_str}):\n"
-        f"    - moe_gating_linear          : replicated (TP=1)\n"
-        f"    - moe_gating_routing_topk    : replicated (TP=1)\n"
-        f"    - moe_shuffling              : replicated (TP=1)\n"
-        f"    - moe_grouped_gemm           : TP-sharded (TP=moe_tp)\n"
+        f"Operations:\n"
+        f"    - moe_gating_linear          : {precision_str}, replicated (TP=1)\n"
+        f"    - moe_gating_routing_topk    : {precision_str}, replicated (TP=1)\n"
+        f"    - moe_shuffling              : {precision_str}, replicated (TP=1)\n"
+        f"    - moe_grouped_gemm           : {grouped_gemm_precision}, TP-sharded (TP=moe_tp)\n"
         f"\n"
         f"  Per-EP Expert Distribution:"
     )
@@ -457,8 +476,9 @@ def build_moe_config_sections(
             ("Is MoE", _format_value(model_config.is_moe)),
         ]),
         ("Precision & Quantization", [
-            ("Precision (dtype)", precision_display),
-            ("FP8 Quantization", _format_value(args.use_fp8)),
+            ("Base Precision (dtype)", precision_display),
+            ("Grouped GEMM Precision", grouped_gemm_precision),
+            ("Quantization", quantization_display),
             ("Per-Channel Quant", _format_value(getattr(args, 'per_channel_quant', False))),
             ("Block Shape", _format_value(args.block_shape)),
         ]),

--- a/frontier/runtime_cost/__init__.py
+++ b/frontier/runtime_cost/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit opt-in runtime cost contracts; generic simulator defaults are unchanged."""

--- a/frontier/runtime_cost/primitives.py
+++ b/frontier/runtime_cost/primitives.py
@@ -1,0 +1,303 @@
+"""Bounded, partial SGLang primitive calibration; no full-model timing fit.
+
+The only feature is physical token count, and the identity fixes all dimensions
+and runtime settings. Validation samples never enter fitting. Independent
+weight/input buffers make graph-length sensitivity a required quality check.
+"""
+
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import asdict
+import math
+from statistics import median
+
+from frontier.profiling.runtime.sglang_primitives import MEASUREMENT_TYPE, PRIMITIVES
+from frontier.profiling.runtime.sglang_dense import DENSE_PRIMITIVES, validate_dense_spec
+from frontier.profiling.runtime.sglang_gdn import GDN_PRIMITIVES, validate_gdn_core_spec
+from frontier.profiling.runtime.sglang_attention import (
+    ATTENTION_PRIMITIVES, validate_attention_decode_spec, validate_attention_workload,
+)
+from frontier.profiling.runtime.sglang_moe import (
+    MOE_ROUTING_PRIMITIVES, validate_moe_routing_spec,
+)
+from frontier.runtime_cost.sglang import CostEstimate, RuntimeIdentity, _digest
+
+PROVENANCE_FIELDS = ("versions", "hardware", "extra_collective_environment", "method", "producer_source_sha256")
+
+
+def _provenance(payload):
+    return {key: payload[key] for key in PROVENANCE_FIELDS}
+
+
+def _positive(value):
+    return type(value) in (int, float) and math.isfinite(value) and value > 0
+
+
+def _percentile(values, fraction):
+    values = sorted(values)
+    index = (len(values) - 1) * fraction
+    lo, hi = math.floor(index), math.ceil(index)
+    return values[lo] + (values[hi] - values[lo]) * (index - lo)
+
+
+def aggregate_profiles(payloads, *, split, identity):
+    """Require complete aligned rank cohorts; aggregate max rank per repetition."""
+    payloads = deepcopy(list(payloads))
+    world = identity.tensor_parallel_size
+    if split not in {"calibration", "validation"} or len(payloads) != world:
+        raise ValueError("Complete calibration/validation rank cohort required")
+    if (any(type(p.get("rank")) is not int for p in payloads)
+            or {p["rank"] for p in payloads} != set(range(world))):
+        raise ValueError("Duplicate or missing ranks")
+    payloads.sort(key=lambda p: p["rank"])
+    groups, keys_per_rank = defaultdict(dict), []
+    for payload in payloads:
+        if (type(payload.get("schema_version")) is not int or payload["schema_version"] != 1
+                or payload.get("split") != split or payload.get("world_size") != world
+                or RuntimeIdentity(**payload["identity"]) != identity):
+            raise ValueError("Primitive profile schema/split/runtime identity mismatch")
+        if any(not payload.get(key) or payload[key] != payloads[0].get(key)
+               for key in PROVENANCE_FIELDS if key != "extra_collective_environment"):
+            raise ValueError("Incomplete or mismatched producer provenance")
+        if (not isinstance(payload.get("extra_collective_environment"), dict)
+                or payload["extra_collective_environment"] != payloads[0]["extra_collective_environment"]):
+            raise ValueError("Collective environment differs across ranks")
+        keys = set()
+        for row in payload["rows"]:
+            name, size, count = (row[k] for k in ("primitive", "physical_size", "invocations_per_graph"))
+            if (name not in PRIMITIVES or type(size) is not int or size < 1
+                    or type(count) is not int or count < 2 or row["rank"] != payload["rank"]
+                    or row["correctness_checked"] is not True or row["measurement_type"] != MEASUREMENT_TYPE
+                    or not isinstance(row["backend"], str) or not row["backend"].strip()
+                    or not isinstance(row["samples_ms"], list) or len(row["samples_ms"]) < 20
+                    or not all(_positive(v) for v in row["samples_ms"])):
+                raise ValueError("Invalid primitive profile row or fewer than 20 repetitions")
+            if name == "tp_allreduce" and row["backend"] not in {"ca", "qr"}:
+                raise ValueError("RCCL fallback is not custom-reduction calibration")
+            if name in DENSE_PRIMITIVES:
+                validate_dense_spec(row.get("dense_spec"), world, name)
+            if name in GDN_PRIMITIVES:
+                validate_gdn_core_spec(row.get("gdn_core_spec"), world)
+                if (type(row.get("logical_size")) is not int
+                        or not 1 <= row["logical_size"] <= size):
+                    raise ValueError("Invalid GDN core logical/physical workload")
+            if name in ATTENTION_PRIMITIVES:
+                validate_attention_decode_spec(row.get("attention_decode_spec"), world)
+                workload = validate_attention_workload(
+                    size, row.get("logical_size"), row.get("physical_context_lens"),
+                    row["attention_decode_spec"])
+                if row.get("attention_workload") != workload:
+                    raise ValueError("Attention workload summary disagrees with physical contexts")
+            if name in MOE_ROUTING_PRIMITIVES:
+                validate_moe_routing_spec(row.get("moe_routing_spec"))
+            if (row.get("kernel_trace_kind") != "representative_graph" or row.get("kernel_trace_invocations") != 2
+                    or (payload["rank"] == 0 and (not row["kernel_names"] or not row.get("kernel_count")
+                        or row["kernel_count"] % 2))):
+                raise ValueError("Representative rank-0 graph kernel evidence is required")
+            key = (name, size, count)
+            if key in keys:
+                raise ValueError("Duplicate primitive row")
+            keys.add(key)
+            groups[key][payload["rank"]] = row
+        keys_per_rank.append(keys)
+    if not groups or any(keys != keys_per_rank[0] for keys in keys_per_rank):
+        raise ValueError("Primitive coverage differs across ranks")
+    result = []
+    for (name, size, count), ranks in sorted(groups.items()):
+        rows = [ranks[rank] for rank in range(world)]
+        if len({len(r["samples_ms"]) for r in rows}) != 1 or len({r["backend"] for r in rows}) != 1:
+            raise ValueError("Rank timing alignment/backend mismatch")
+        if len({_digest(r.get("dense_spec")) for r in rows}) != 1:
+            raise ValueError("Dense primitive shape contract differs across ranks")
+        if len({_digest(r.get("gdn_core_spec")) for r in rows}) != 1:
+            raise ValueError("GDN core shape contract differs across ranks")
+        if len({_digest(r.get("attention_decode_spec")) for r in rows}) != 1:
+            raise ValueError("Attention decode shape contract differs across ranks")
+        if len({_digest(r.get("moe_routing_spec")) for r in rows}) != 1:
+            raise ValueError("MoE routing shape contract differs across ranks")
+        if len({r.get("logical_size") for r in rows}) != 1:
+            raise ValueError("Stateful logical workload differs across ranks")
+        if len({_digest(r.get("physical_context_lens")) for r in rows}) != 1:
+            raise ValueError("Attention physical contexts differ across ranks")
+        times = [max(values) for values in zip(*(r["samples_ms"] for r in rows))]
+        center = median(times)
+        result.append({"primitive": name, "physical_size": size, "invocations_per_graph": count,
+            "backend": rows[0]["backend"], "median_ms": center,
+            "p10_ms": _percentile(times, .1), "p90_ms": _percentile(times, .9),
+            "relative_spread": (_percentile(times, .9) - _percentile(times, .1)) / center,
+            "rank_medians_ms": [median(r["samples_ms"]) for r in rows],
+            "aligned_max_rank_samples_ms": times, "kernel_names": rows[0]["kernel_names"]})
+        if name in DENSE_PRIMITIVES:
+            result[-1]["dense_spec"] = rows[0]["dense_spec"]
+        if name in GDN_PRIMITIVES:
+            result[-1]["gdn_core_spec"] = rows[0]["gdn_core_spec"]
+            result[-1]["logical_size"] = rows[0]["logical_size"]
+        if name in ATTENTION_PRIMITIVES:
+            result[-1]["attention_decode_spec"] = rows[0]["attention_decode_spec"]
+            result[-1]["attention_workload"] = rows[0]["attention_workload"]
+            result[-1]["logical_size"] = rows[0]["logical_size"]
+            result[-1]["physical_context_lens"] = rows[0]["physical_context_lens"]
+        if name in MOE_ROUTING_PRIMITIVES:
+            result[-1]["moe_routing_spec"] = rows[0]["moe_routing_spec"]
+    return result, "sha256:" + _digest(payloads)
+
+
+def primitive_for_query(query):
+    if query.component in (DENSE_PRIMITIVES + GDN_PRIMITIVES + ATTENTION_PRIMITIVES
+                           + MOE_ROUTING_PRIMITIVES):
+        return query.component
+    if query.component == "input_layernorm":
+        return "gemma_norm" if query.residual_from_layer is None else "gemma_residual_norm"
+    return {"post_attention_layernorm": "gemma_residual_norm",
+        "shared_gate_sigmoid_mul_add": "shared_gate", "attn_post_proj_gate": "attention_post",
+        "attention_tp_allreduce": "tp_allreduce", "mlp_tp_allreduce": "tp_allreduce"}.get(query.component)
+
+
+class PrimitiveCalibration:
+    """Partial cost provider: exact identity, two endpoints, no extrapolation.
+
+This interpolates isolated graph replay cost, NOT pure kernel duration or
+full-forward performance. Graph-length/spread checks can reject a primitive.
+Held-out data is accessible only to the separate validation report method.
+"""
+
+    def __init__(self, payloads, *, identity, quality_limit=.10):
+        if not _positive(quality_limit) or quality_limit > .25:
+            raise ValueError("Quality limit must be in (0, 0.25]")
+        payloads = list(payloads)
+        self.identity, self.quality_limit = identity, quality_limit
+        self.rows, self.source = aggregate_profiles(payloads, split="calibration", identity=identity)
+        self.provenance = deepcopy(_provenance(payloads[0]))
+        self.models, self.quality = {}, {}
+        for name in sorted({r["primitive"] for r in self.rows}):
+            rows = [r for r in self.rows if r["primitive"] == name]
+            sizes = sorted({r["physical_size"] for r in rows})
+            counts = sorted({r["invocations_per_graph"] for r in rows})
+            if len(sizes) != 2 or len(counts) < 2 or len(rows) != len(sizes) * len(counts):
+                raise ValueError("Calibration needs two sizes and at least two graph lengths per primitive")
+            if len({r["backend"] for r in rows}) != 1:
+                raise ValueError("Interpolation cannot cross primitive backend selections")
+            if len({_digest(r.get("dense_spec")) for r in rows}) != 1:
+                raise ValueError("Interpolation cannot cross dense shape contracts")
+            if len({_digest(r.get("gdn_core_spec")) for r in rows}) != 1:
+                raise ValueError("Interpolation cannot cross GDN core shape contracts")
+            if len({_digest(r.get("attention_decode_spec")) for r in rows}) != 1:
+                raise ValueError("Interpolation cannot cross attention shape contracts")
+            if len({_digest(r.get("moe_routing_spec")) for r in rows}) != 1:
+                raise ValueError("Interpolation cannot cross MoE routing shape contracts")
+            padding_counts = {r["physical_size"] - r["logical_size"]
+                              for r in rows if name in GDN_PRIMITIVES + ATTENTION_PRIMITIVES}
+            if name in GDN_PRIMITIVES + ATTENTION_PRIMITIVES and len(padding_counts) != 1:
+                raise ValueError("Stateful interpolation requires a fixed padding count")
+            attention_workloads = [r["attention_workload"] for r in rows
+                                   if name in ATTENTION_PRIMITIVES]
+            if attention_workloads and (len({r["active_context_length"] for r in attention_workloads}) != 1
+                    or len({r["padding_context_length"] for r in attention_workloads}) != 1):
+                raise ValueError("Attention interpolation cannot cross context lengths")
+            selected = [r for r in rows if r["invocations_per_graph"] == counts[-1]]
+            sensitivity = max((max(r["median_ms"] for r in rows if r["physical_size"] == size)
+                - min(r["median_ms"] for r in rows if r["physical_size"] == size))
+                / next(r["median_ms"] for r in selected if r["physical_size"] == size) for size in sizes)
+            spread = max(r["relative_spread"] for r in rows)
+            self.quality[name] = {"admitted": max(sensitivity, spread) <= quality_limit,
+                "graph_length_sensitivity": sensitivity, "max_relative_spread": spread,
+                "limit": quality_limit, "calibration_sizes": sizes, "graph_lengths": counts,
+                "selected_graph_length": counts[-1]}
+            self.models[name] = {"sizes": sizes, "times": [r["median_ms"] for r in selected],
+                "backend": rows[0]["backend"], "count": counts[-1], "dense_spec": rows[0].get("dense_spec"),
+                "gdn_core_spec": rows[0].get("gdn_core_spec"),
+                "attention_decode_spec": rows[0].get("attention_decode_spec"),
+                "moe_routing_spec": rows[0].get("moe_routing_spec"),
+                "attention_workload": attention_workloads[0] if attention_workloads else None,
+                "padding_count": next(iter(padding_counts)) if padding_counts else None}
+
+    def primitive_ms(self, name, size):
+        if name not in self.models:
+            raise ValueError(f"No primitive calibration for {name}")
+        if type(size) is not int:
+            raise ValueError("Physical size must be an integer")
+        model = self.models[name]
+        lo, hi = model["sizes"]
+        if not lo <= size <= hi:
+            raise ValueError("Primitive extrapolation is not permitted")
+        a, b = model["times"]
+        return a + (b - a) * (size - lo) / (hi - lo)
+
+    def __call__(self, query):
+        if query.identity != self.identity:
+            raise ValueError("Primitive cost query belongs to another runtime")
+        name = primitive_for_query(query)
+        if name not in self.quality or not self.quality[name]["admitted"]:
+            raise ValueError(f"Missing or quality-rejected primitive calibration for {query.component}")
+        if (name in GDN_PRIMITIVES
+                and query.workload.physical_size - query.workload.logical_size
+                    != self.models[name]["padding_count"]):
+            raise ValueError("GDN core query padding differs from calibrated ownership")
+        if name in ATTENTION_PRIMITIVES:
+            model = self.models[name]
+            workload = validate_attention_workload(
+                query.workload.physical_size, query.workload.logical_size,
+                query.workload.physical_context_lens, model["attention_decode_spec"])
+            expected = model["attention_workload"]
+            if any(workload[k] != expected[k] for k in (
+                    "padding_count", "active_context_length", "padding_context_length")):
+                raise ValueError("Attention query workload differs from calibrated context ownership")
+        return CostEstimate(query.key, self.primitive_ms(name, query.workload.physical_size),
+            self.source + "/" + name, MEASUREMENT_TYPE,
+            "calibrated_collective" if query.is_collective else "isolated_compute")
+
+    def validate(self, payloads):
+        payloads = list(payloads)
+        rows, source = aggregate_profiles(payloads, split="validation", identity=self.identity)
+        if _provenance(payloads[0]) != self.provenance:
+            raise ValueError("Validation producer/hardware/environment provenance changed")
+        expected = set(self.models)
+        if {r["primitive"] for r in rows} != expected:
+            raise ValueError("Validation must cover every calibrated primitive")
+        results = []
+        for name, model in self.models.items():
+            relevant = [r for r in rows if r["primitive"] == name]
+            for size in sorted({r["physical_size"] for r in relevant}):
+                if size in model["sizes"]:
+                    raise ValueError("Validation size overlaps calibration")
+                candidates = [r for r in relevant if r["physical_size"] == size]
+                if {r["invocations_per_graph"] for r in candidates} != set(self.quality[name]["graph_lengths"]):
+                    raise ValueError("Validation graph lengths differ from calibration")
+                if any(r["backend"] != model["backend"] for r in candidates):
+                    raise ValueError("Validation primitive backend changed")
+                if any(r.get("dense_spec") != model["dense_spec"] for r in candidates):
+                    raise ValueError("Validation dense shape contract changed")
+                if any(r.get("gdn_core_spec") != model["gdn_core_spec"] for r in candidates):
+                    raise ValueError("Validation GDN core shape contract changed")
+                if any(r.get("attention_decode_spec") != model["attention_decode_spec"] for r in candidates):
+                    raise ValueError("Validation attention shape contract changed")
+                if any(r.get("moe_routing_spec") != model["moe_routing_spec"] for r in candidates):
+                    raise ValueError("Validation MoE routing shape contract changed")
+                if (name in GDN_PRIMITIVES
+                        and any(r["physical_size"] - r["logical_size"] != model["padding_count"]
+                                for r in candidates)):
+                    raise ValueError("Validation GDN core padding ownership changed")
+                if name in ATTENTION_PRIMITIVES:
+                    expected = model["attention_workload"]
+                    if any(any(r["attention_workload"][k] != expected[k] for k in (
+                            "padding_count", "active_context_length", "padding_context_length"))
+                           for r in candidates):
+                        raise ValueError("Validation attention context ownership changed")
+                observed = next(r["median_ms"] for r in candidates if r["invocations_per_graph"] == model["count"])
+                prediction = self.primitive_ms(name, size)
+                error = abs(prediction - observed) / observed
+                sensitivity = (max(r["median_ms"] for r in candidates) - min(r["median_ms"] for r in candidates)) / observed
+                spread = max(r["relative_spread"] for r in candidates)
+                results.append({"primitive": name, "physical_size": size, "predicted_ms": prediction,
+                    "observed_ms": observed, "absolute_relative_error": error,
+                    "graph_length_sensitivity": sensitivity, "max_relative_spread": spread,
+                    "passed": self.quality[name]["admitted"] and max(error, sensitivity, spread) <= self.quality_limit})
+        return {"identity": asdict(self.identity), "calibration_source": self.source,
+            "validation_source": source, "measurement_type": MEASUREMENT_TYPE,
+            "calibration_quality": deepcopy(self.quality), "validation": results,
+            "all_primitives_passed": all(r["passed"] for r in results),
+            "full_forward_parity_admitted": False,
+            "note": "Two-endpoint interpolation, trained only on calibration physical sizes. "
+                    "Isolated synthetic streaming-weight graphs; not checkpoint, full-forward, "
+                    "serving or multi-node validation. Max rank per aligned replay is a local-duration "
+                    "aggregate, not a cross-device clock-synchronized makespan."}

--- a/frontier/runtime_cost/routed_primitives.py
+++ b/frontier/runtime_cost/routed_primitives.py
@@ -1,0 +1,207 @@
+"""Strict exact-query costs for route-conditioned SGLang MoE primitives."""
+
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import asdict
+import math
+from statistics import median
+
+from frontier.profiling.runtime.sglang_moe import (
+    MOE_ROUTED_PRIMITIVES, validate_moe_route_workload, validate_moe_routed_spec,
+)
+from frontier.profiling.runtime.sglang_primitives import MEASUREMENT_TYPE
+from frontier.runtime_cost.sglang import CostEstimate, RuntimeIdentity, _digest
+
+
+PROVENANCE_FIELDS = (
+    "versions", "hardware", "extra_collective_environment", "method",
+    "producer_source_sha256",
+)
+
+
+def _positive(value):
+    return type(value) in (int, float) and math.isfinite(value) and value > 0
+
+
+def _percentile(values, fraction):
+    values = sorted(values)
+    index = (len(values) - 1) * fraction
+    lo, hi = math.floor(index), math.ceil(index)
+    return values[lo] + (values[hi] - values[lo]) * (index - lo)
+
+
+def aggregate_routed_profiles(payloads, *, identity):
+    """Aggregate aligned exact-query samples by max rank for each replay."""
+    payloads = deepcopy(list(payloads))
+    world = identity.tensor_parallel_size
+    if len(payloads) != world:
+        raise ValueError("Complete routed-profile rank cohort required")
+    if ({payload.get("rank") for payload in payloads} != set(range(world))
+            or any(type(payload.get("rank")) is not int for payload in payloads)):
+        raise ValueError("Duplicate or missing routed-profile ranks")
+    payloads.sort(key=lambda payload: payload["rank"])
+    groups, keys_per_rank = defaultdict(dict), []
+    for payload in payloads:
+        if (payload.get("schema_version") != 1
+                or payload.get("profile_kind") != "exact_routed_query"
+                or payload.get("world_size") != world
+                or RuntimeIdentity(**payload["identity"]) != identity):
+            raise ValueError("Routed profile schema/runtime identity mismatch")
+        if any(not payload.get(field) or payload[field] != payloads[0].get(field)
+               for field in PROVENANCE_FIELDS
+               if field != "extra_collective_environment"):
+            raise ValueError("Incomplete or mismatched routed-profile provenance")
+        if (not isinstance(payload.get("extra_collective_environment"), dict)
+                or payload["extra_collective_environment"]
+                    != payloads[0]["extra_collective_environment"]):
+            raise ValueError("Routed-profile collective environment differs across ranks")
+        keys = set()
+        for row in payload.get("rows", ()):
+            key = (row.get("query_key"), row.get("invocations_per_graph"))
+            spec = row.get("moe_routed_spec")
+            validate_moe_routed_spec(spec, world)
+            workload = validate_moe_route_workload(
+                row.get("physical_size"), row.get("physical_expert_counts"), spec)
+            primitive = row.get("primitive")
+            expected_backend = (spec["sorting_backend"] if primitive == "moe_sorting"
+                                else spec["experts_backend"])
+            if (primitive not in MOE_ROUTED_PRIMITIVES
+                    or not isinstance(key[0], str) or len(key[0]) != 64
+                    or any(char not in "0123456789abcdef" for char in key[0])
+                    or type(key[1]) is not int or key[1] < 2
+                    or type(row.get("layer_id")) is not int or row["layer_id"] < 0
+                    or row.get("rank") != payload["rank"]
+                    or row.get("backend") != expected_backend
+                    or row.get("measurement_type") != MEASUREMENT_TYPE
+                    or row.get("correctness_checked") is not True
+                    or row.get("moe_route_workload") != workload
+                    or row.get("kernel_trace_kind") != "representative_graph"
+                    or row.get("kernel_trace_invocations") != 2
+                    or not isinstance(row.get("samples_ms"), list)
+                    or len(row["samples_ms"]) < 20
+                    or not all(_positive(value) for value in row["samples_ms"])
+                    or (payload["rank"] == 0
+                        and (not row.get("kernel_names") or not row.get("kernel_count")
+                             or row["kernel_count"] % 2
+                             or (primitive == "moe_sorting"
+                                 and any("aiter::opus_moe_sorting_entry" not in name
+                                         for name in row["kernel_names"]))
+                             or (primitive == "moe_experts_quant_gemm_combine"
+                                 and (not any("mfma_moe1_" in name
+                                              for name in row["kernel_names"])
+                                      or not any("mfma_moe2_" in name
+                                                 for name in row["kernel_names"])))))):
+                raise ValueError("Invalid exact routed-profile row")
+            if key in keys:
+                raise ValueError("Duplicate exact routed-profile row")
+            keys.add(key)
+            groups[key][payload["rank"]] = row
+        keys_per_rank.append(keys)
+    if not groups or any(keys != keys_per_rank[0] for keys in keys_per_rank):
+        raise ValueError("Exact routed-profile coverage differs across ranks")
+
+    result = []
+    for (query_key, count), ranks in sorted(groups.items()):
+        rows = [ranks[rank] for rank in range(world)]
+        aligned = {field: {_digest(row.get(field)) for row in rows} for field in (
+            "physical_expert_counts", "moe_routed_spec", "moe_route_workload")}
+        if (any(len(values) != 1 for values in aligned.values())
+                or len({row["layer_id"] for row in rows}) != 1
+                or len({row["backend"] for row in rows}) != 1
+                or len({len(row["samples_ms"]) for row in rows}) != 1):
+            raise ValueError("Exact routed workload/backend differs across ranks")
+        samples = [max(values) for values in zip(*(
+            row["samples_ms"] for row in rows))]
+        center = median(samples)
+        if len({row["primitive"] for row in rows}) != 1:
+            raise ValueError("Exact routed primitive differs across ranks")
+        result.append({
+            "primitive": rows[0]["primitive"],
+            "query_key": query_key,
+            "layer_id": rows[0]["layer_id"],
+            "physical_size": rows[0]["physical_size"],
+            "physical_expert_counts": rows[0]["physical_expert_counts"],
+            "invocations_per_graph": count,
+            "backend": rows[0]["backend"],
+            "median_ms": center,
+            "p10_ms": _percentile(samples, .1),
+            "p90_ms": _percentile(samples, .9),
+            "relative_spread": (
+                _percentile(samples, .9) - _percentile(samples, .1)) / center,
+            "rank_medians_ms": [median(row["samples_ms"]) for row in rows],
+            "aligned_max_rank_samples_ms": samples,
+            "kernel_names": rows[0]["kernel_names"],
+            "moe_routed_spec": rows[0]["moe_routed_spec"],
+            "moe_route_workload": rows[0]["moe_route_workload"],
+        })
+    return result, "sha256:" + _digest(payloads)
+
+
+class ExactRoutedCalibration:
+    """Direct exact-query provider with replay-quality admission, not a fit."""
+
+    def __init__(self, payloads, *, identity, quality_limit=.10):
+        if not _positive(quality_limit) or quality_limit > .25:
+            raise ValueError("Quality limit must be in (0, 0.25]")
+        self.identity = identity
+        self.rows, self.source = aggregate_routed_profiles(payloads, identity=identity)
+        self.quality_limit = quality_limit
+        self.models, self.quality = {}, {}
+        by_query = defaultdict(list)
+        for row in self.rows:
+            by_query[row["query_key"]].append(row)
+        for query_key, rows in by_query.items():
+            counts = sorted(row["invocations_per_graph"] for row in rows)
+            if len(counts) < 2 or len(counts) != len(set(counts)):
+                raise ValueError("Exact routed query needs at least two graph lengths")
+            if (len({row["layer_id"] for row in rows}) != 1
+                    or len({_digest(row["physical_expert_counts"]) for row in rows}) != 1
+                    or len({_digest(row["moe_routed_spec"]) for row in rows}) != 1
+                    or len({row["backend"] for row in rows}) != 1):
+                raise ValueError("Graph lengths changed the exact routed query")
+            selected = next(
+                row for row in rows if row["invocations_per_graph"] == counts[-1])
+            sensitivity = (max(row["median_ms"] for row in rows)
+                           - min(row["median_ms"] for row in rows)) / selected["median_ms"]
+            spread = max(row["relative_spread"] for row in rows)
+            admitted = max(sensitivity, spread) <= quality_limit
+            self.quality[query_key] = {
+                "layer_id": selected["layer_id"],
+                "admitted": admitted,
+                "graph_length_sensitivity": sensitivity,
+                "max_relative_spread": spread,
+                "limit": quality_limit,
+                "graph_lengths": counts,
+                "selected_graph_length": counts[-1],
+            }
+            self.models[query_key] = selected
+
+    def __call__(self, query):
+        if query.identity != self.identity or query.component not in MOE_ROUTED_PRIMITIVES:
+            raise ValueError("Exact routed cost query belongs to another runtime/boundary")
+        if query.key not in self.models or not self.quality[query.key]["admitted"]:
+            raise ValueError("Missing or quality-rejected exact routed query")
+        row = self.models[query.key]
+        if (query.component != row["primitive"] or query.layer_id != row["layer_id"]
+                or list(query.physical_expert_counts) != row["physical_expert_counts"]
+                or query.workload.physical_size != row["physical_size"]):
+            raise ValueError("Exact routed query payload differs from profile")
+        return CostEstimate(
+            query.key, row["median_ms"], self.source + "/" + row["primitive"],
+            MEASUREMENT_TYPE, "isolated_compute")
+
+    def report(self):
+        rows = list(self.quality.values())
+        return {
+            "identity": asdict(self.identity),
+            "profile_source": self.source,
+            "measurement_type": MEASUREMENT_TYPE,
+            "queries": len(rows),
+            "all_queries_passed": bool(rows) and all(row["admitted"] for row in rows),
+            "maximum_graph_length_sensitivity": max(
+                row["graph_length_sensitivity"] for row in rows),
+            "maximum_relative_spread": max(row["max_relative_spread"] for row in rows),
+            "full_forward_parity_admitted": False,
+            "note": "Direct exact-route measurements; no interpolation across route histograms, "
+                    "checkpoint load, full-forward timing, or target correction fit.",
+        }

--- a/frontier/runtime_cost/sglang.py
+++ b/frontier/runtime_cost/sglang.py
@@ -1,0 +1,361 @@
+"""Opt-in, profile-provider-driven SGLang decoder cost composition.
+
+This adapter produces native ExecutionTime objects without loading or mutating
+the generic sklearn predictors. It is a static one-node decode contract, not a
+serving scheduler, profile fitter, or permission to extrapolate to EP/multi-node.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from copy import deepcopy
+from collections import Counter
+import hashlib
+import json
+import math
+from typing import Callable
+
+from frontier.config.precision_type import PrecisionType
+from frontier.operators.sglang_family import (
+    SGLANG_RUNTIME_CONTRACT, runtime_operator_name,
+)
+
+
+def _digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def capture_stack_signature(manifest):
+    return "sha256:" + _digest({
+        "versions": {k: v for k, v in manifest["versions"].items() if not k.startswith("frontier_")},
+        "server_args": manifest["server_args"], "environment": manifest["environment"]})
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    model_fingerprint: str
+    device: str
+    tensor_parallel_size: int
+    runtime_stack_signature: str
+    contract: str = SGLANG_RUNTIME_CONTRACT
+    expert_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    nodes: int = 1
+    data_parallel_size: int = 1
+
+    def __post_init__(self):
+        if self.contract != SGLANG_RUNTIME_CONTRACT:
+            raise ValueError("Unknown SGLang runtime cost contract")
+        if (not isinstance(self.model_fingerprint, str) or len(self.model_fingerprint) != 64
+                or any(c not in "0123456789abcdef" for c in self.model_fingerprint)):
+            raise ValueError("Invalid model fingerprint")
+        for name in ("device", "runtime_stack_signature"):
+            if not isinstance(getattr(self, name), str) or not getattr(self, name).strip():
+                raise ValueError(f"Runtime identity requires {name}")
+        for name in ("tensor_parallel_size", "expert_parallel_size", "pipeline_parallel_size",
+                     "nodes", "data_parallel_size"):
+            if type(getattr(self, name)) is not int or getattr(self, name) < 1:
+                raise ValueError(f"Invalid topology field {name}")
+        if (self.expert_parallel_size, self.pipeline_parallel_size, self.nodes, self.data_parallel_size) != (1, 1, 1, 1):
+            raise ValueError("SGLang cost composition supports one-node TP-only execution")
+        if self.tensor_parallel_size == 1:
+            raise ValueError("This collective-bearing contract requires TP > 1")
+
+    @classmethod
+    def for_model(cls, model_config, *, device, tensor_parallel_size, runtime_stack_signature):
+        # Deliberately includes checkpoint identity, dimensions, quantization and
+        # layer schedule. Equal architecture-profile labels are not sufficient.
+        if model_config.get_gdn_config() is None:
+            raise ValueError("SGLang runtime identity requires a hybrid GDN model")
+        shape = {name: getattr(model_config, name, None) for name in (
+            "name", "model_type", "num_layers", "embedding_dim", "mlp_hidden_dim",
+            "num_q_heads", "num_kv_heads", "head_dim", "num_experts", "num_experts_per_tok",
+            "share_expert_dim", "dtype", "use_qk_norm", "attn_output_gate", "rms_norm_eps",
+            "rope_theta", "rope_scaling", "partial_rotary_factor", "vocab_size",
+            "use_bias", "use_qkv_bias", "use_gated_mlp",
+        )}
+        if shape["name"] is None:
+            shape["name"] = model_config.get_name()
+        dtype = getattr(model_config, "dtype", getattr(model_config, "torch_dtype", None))
+        shape["dtype"] = PrecisionType.from_torch_dtype(str(dtype)).name
+        shape["head_dim"] = model_config.get_head_dim()
+        shape.update(architecture=model_config.get_model_architecture_profile().profile_id,
+                     quantization=model_config.get_quant_signature(),
+                     gdn=asdict(model_config.get_gdn_config()),
+                     layers=[model_config.is_gdn_layer(i) for i in range(model_config.num_layers)])
+        return cls(_digest(shape), device, tensor_parallel_size, runtime_stack_signature)
+
+
+@dataclass(frozen=True)
+class DecodeWorkload:
+    """Physical context lengths include the current query token, like SGLang seq_lens.
+
+Padding context lengths must be supplied explicitly, never guessed from logical
+requests. This object has no observed timing or output-logit fields.
+"""
+
+    logical_size: int
+    physical_context_lens: tuple[int, ...]
+    graph_mode: str = "FULL"
+
+    def __post_init__(self):
+        object.__setattr__(self, "physical_context_lens", tuple(self.physical_context_lens))
+        if (type(self.logical_size) is not int or not 0 < self.logical_size <= self.physical_size
+                or any(type(n) is not int or n < 1 for n in self.physical_context_lens)):
+            raise ValueError("Decode workload requires logical size and every physical context length")
+        if self.graph_mode != "FULL":
+            raise ValueError("Runtime cost v1 supports full-graph non-speculative decode only")
+
+    @property
+    def physical_size(self):
+        return len(self.physical_context_lens)
+
+
+@dataclass(frozen=True)
+class CostQuery:
+    identity: RuntimeIdentity
+    layer_id: int
+    layer_kind: str
+    component: str
+    workload: DecodeWorkload
+    residual_from_layer: int | None = None
+    physical_expert_counts: tuple[int, ...] = ()
+
+    def __post_init__(self):
+        if (not isinstance(self.identity, RuntimeIdentity) or not isinstance(self.workload, DecodeWorkload)
+                or type(self.layer_id) is not int or self.layer_id < 0
+                or self.layer_kind not in {"gdn", "attention"}):
+            raise ValueError("Invalid runtime cost query identity/layer/workload")
+        runtime_operator_name(self.component)
+        if ((self.component.startswith("gdn_") and self.layer_kind != "gdn")
+                or (self.component.startswith("attn_") and self.layer_kind != "attention")):
+            raise ValueError("Cost query mixer does not match layer kind")
+        residual = (self.layer_id - 1 if self.component == "input_layernorm" and self.layer_id > 0
+                    else self.layer_id if self.component == "post_attention_layernorm" else None)
+        if self.residual_from_layer != residual or isinstance(self.residual_from_layer, bool):
+            raise ValueError("Invalid fused residual ownership")
+        object.__setattr__(self, "physical_expert_counts", tuple(self.physical_expert_counts))
+        routed = self.component in {"moe_sorting", "moe_experts_quant_gemm_combine"}
+        if (bool(self.physical_expert_counts) != routed or any(type(n) is not int or n < 0
+                for n in self.physical_expert_counts) or (routed and sum(self.physical_expert_counts) == 0)):
+            raise ValueError("Routed scopes require physical expert counts; other scopes must omit them")
+
+    @property
+    def operator(self):
+        return runtime_operator_name(self.component)
+
+    @property
+    def key(self):
+        # Full workload identity is intentionally conservative: no hidden
+        # layer tying, padding erasure, context pooling or route extrapolation.
+        return _digest(asdict(self))
+
+    @property
+    def is_collective(self):
+        return self.component in {"attention_tp_allreduce", "mlp_tp_allreduce"}
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    query_key: str
+    milliseconds: float
+    source: str
+    measurement_type: str
+    basis: str
+
+    def __post_init__(self):
+        if (not isinstance(self.query_key, str) or len(self.query_key) != 64
+                or any(c not in "0123456789abcdef" for c in self.query_key)):
+            raise ValueError("Estimate requires the exact query key")
+        if (isinstance(self.milliseconds, bool) or not isinstance(self.milliseconds, (int, float))
+                or not math.isfinite(self.milliseconds) or self.milliseconds <= 0):
+            raise ValueError("Runtime costs must be finite and strictly positive")
+        if not isinstance(self.source, str) or not self.source.strip():
+            raise ValueError("Runtime cost requires profile provenance")
+        if self.measurement_type not in {"CUDA_EVENT", "KERNEL_ONLY", "HIP_GRAPH_EVENT", "HIP_GRAPH_REPLAY"}:
+            raise ValueError("Unknown runtime measurement family")
+        if self.basis not in {"isolated_compute", "calibrated_collective", "in_situ_diagnostic"}:
+            raise ValueError("Unknown cost evidence basis")
+        if self.measurement_type == "HIP_GRAPH_EVENT" and self.basis != "in_situ_diagnostic":
+            raise ValueError("HIP graph scope events are diagnostic, not isolated kernel profiles")
+
+
+@dataclass(frozen=True)
+class RuntimeCostPrediction:
+    execution: object
+    layer_executions: tuple
+    queries: tuple[CostQuery, ...]
+    estimates: tuple[CostEstimate, ...]
+    diagnostic: bool
+
+    @property
+    def decoder_ms(self):
+        return self.execution.model_time_ms
+
+    def summary(self):
+        return {"contract": SGLANG_RUNTIME_CONTRACT, "decoder_ms": self.decoder_ms,
+                "layers": len(self.layer_executions), "operators": len(self.queries),
+                "diagnostic": self.diagnostic, "routing_conditioned": True,
+                "full_forward_parity_admitted": False,
+                "boundary": "Decoder input norm through final MLP reduction; excludes embedding, "
+                            "final residual/norm, logits and host/scheduler work.",
+                "measurement_types": sorted({e.measurement_type for e in self.estimates}),
+                "sources": sorted({e.source for e in self.estimates})}
+
+
+def _native_execution(op_times, *, layers):
+    from frontier.entities.execution_time import ExecutionTime
+    return ExecutionTime(
+        num_layers_per_pipeline_stage=layers, is_moe=True, op_times=op_times,
+        attention_rope_execution_time=0., attention_kv_cache_save_execution_time=0.,
+        attention_decode_execution_time=0., attention_prefill_execution_time=0.,
+        attention_layer_pre_proj_execution_time=0., attention_layer_post_proj_execution_time=0.,
+        attn_norm_time=0., mlp_norm_time=0., add_time=0.,
+        tensor_parallel_communication_time=0., pipeline_parallel_communication_time=0.,
+        expert_parallel_communication_time=0., moe_gating_time=0., moe_shuffling_time=0.,
+        schedule_time=0., sampler_e2e_time=0., prepare_inputs_e2e_time=0.,
+        process_model_outputs_time=0., ray_comm_time=0.,
+        # Mark both physical TP domains explicitly; no legacy allreduce fallback.
+        attn_tensor_parallel_allreduce_time=0., moe_tensor_parallel_allreduce_time=0.,
+        share_expert_tensor_parallel_allreduce_time=0.,
+    )
+
+
+class SGLangCostContract:
+    """Explicitly construct this adapter to use runtime-specific cost ownership.
+
+The provider receives only workload queries, never target observations. It must
+return matching profile evidence or fail. All decoder layers are required; no
+first-layer-times-N approximation or partial-stage residual ownership is allowed.
+"""
+
+    def __init__(self, model_config, identity: RuntimeIdentity):
+        profile = model_config.get_model_architecture_profile()
+        if (profile.profile_id != "qwen3_5_moe" or not model_config.is_moe
+                or not model_config.get_gdn_config() or not model_config.attn_output_gate
+                or not model_config.use_qk_norm or not model_config.share_expert_dim
+                or set(model_config.get_moe_layer_ids()) != set(range(model_config.num_layers))):
+            raise ValueError("Runtime contract requires the gated Qwen hybrid separate-shared MoE architecture")
+        expected = RuntimeIdentity.for_model(model_config, device=identity.device,
+            tensor_parallel_size=identity.tensor_parallel_size,
+            runtime_stack_signature=identity.runtime_stack_signature)
+        if expected != identity:
+            raise ValueError("Runtime identity does not match active model dimensions/quantization")
+        self.model_config, self.identity = deepcopy(model_config), identity
+
+    def queries(self, workload: DecodeWorkload, routing_records) -> tuple[CostQuery, ...]:
+        records = tuple(routing_records)
+        expected_layers = set(range(self.model_config.num_layers))
+        if (len(records) != len(expected_layers) or {r.layer_id for r in records} != expected_layers
+                or len({r.batch_id for r in records}) != 1
+                or len({r.capture_id for r in records}) != 1):
+            raise ValueError("Cost planning requires complete unique layers from one routing batch/graph")
+        routes = {r.layer_id: r for r in records}
+        queries = []
+        for layer in range(self.model_config.num_layers):
+            route = routes[layer]
+            if (route.rank != 0 or route.logical_size != workload.logical_size
+                    or route.physical_size != workload.physical_size
+                    or route.num_experts != self.model_config.num_experts
+                    or route.top_k != self.model_config.num_experts_per_tok):
+                raise ValueError("Routing/model/physical workload identity mismatch")
+            if (route.logical_positive_weight_slots != sum(route.logical_expert_counts)
+                    or route.padding_positive_weight_slots != sum(route.padding_expert_counts)):
+                raise ValueError("Zero-weight valid selections need an explicit pruning-aware cost contract")
+            # Native workload validation and fixed-width physical counts. Rank 0
+            # may be used only after the separate all-rank routing audit passes.
+            lane = route.to_lane_workload(include_padding=True)
+            kind = "gdn" if self.model_config.is_gdn_layer(layer) else "attention"
+            mixer = ("gdn_input_projections", "gdn_core_decode", "gdn_output_projection") if kind == "gdn" else (
+                "attn_pre_proj_qknorm", "attn_rope", "attn_kv_cache_write", "attn_decode", "attn_post_proj_gate")
+            components = ("input_layernorm", *mixer, "attention_tp_allreduce", "post_attention_layernorm",
+                "shared_expert_gate_up", "shared_expert_activation", "shared_expert_down",
+                "moe_router_linear", "moe_routing_topk", "moe_sorting", "moe_experts_quant_gemm_combine",
+                "shared_gate_sigmoid_mul_add", "mlp_tp_allreduce")
+            for component in components:
+                queries.append(CostQuery(self.identity, layer, kind, component, workload,
+                    residual_from_layer=(layer - 1 if component == "input_layernorm" and layer > 0
+                                         else layer if component == "post_attention_layernorm" else None),
+                    physical_expert_counts=(tuple(lane.local_token_counts) if component in {
+                        "moe_sorting", "moe_experts_quant_gemm_combine"} else ())))
+        return tuple(queries)
+
+    def predict(self, workload: DecodeWorkload, routing_records,
+                provider: Callable[[CostQuery], CostEstimate], *, allow_diagnostic=False) -> RuntimeCostPrediction:
+        if type(allow_diagnostic) is not bool:
+            raise ValueError("allow_diagnostic must be a bool")
+        queries = self.queries(workload, routing_records)
+        estimates, per_layer = [], [dict() for _ in range(self.model_config.num_layers)]
+        for query in queries:
+            estimate = provider(query)
+            if not isinstance(estimate, CostEstimate) or estimate.query_key != query.key:
+                raise ValueError(f"Missing/mismatched estimate for {query.operator}, layer {query.layer_id}")
+            if estimate.basis == "in_situ_diagnostic":
+                if not allow_diagnostic:
+                    raise ValueError("In-situ timing requires explicit diagnostic opt-in")
+            elif estimate.basis != ("calibrated_collective" if query.is_collective else "isolated_compute"):
+                raise ValueError("Compute and independently calibrated collective evidence cannot be interchanged")
+            if estimate.measurement_type == "CUDA_EVENT":
+                raise ValueError("Eager CUDA_EVENT costs cannot price the full-graph decode contract")
+            per_layer[query.layer_id][query.operator] = estimate.milliseconds
+            estimates.append(estimate)
+        layers = tuple(_native_execution(values, layers=1) for values in per_layer)
+        # ExecutionTime's established per-layer carrier convention is preserved;
+        # average AFTER evaluating each actual layer, then aggregate exactly once.
+        average = {}
+        for values in per_layer:
+            for name, value in values.items():
+                average[name] = average.get(name, 0.) + value / len(layers)
+        execution = _native_execution(average, layers=len(layers))
+        expected = math.fsum(e.milliseconds for e in estimates)
+        if not math.isclose(execution.model_time_ms, expected, rel_tol=1e-12, abs_tol=1e-12):
+            raise ValueError("Native runtime composition lost or duplicated an operator cost")
+        return RuntimeCostPrediction(execution, layers, queries, tuple(estimates),
+            diagnostic=any(e.basis == "in_situ_diagnostic" for e in estimates))
+
+
+class ExactRuntimeCostTable:
+    """Strict profile exchange/coverage table. No automatic fitting/extrapolation.
+
+Every row includes its query and provenance. The identity and query key are
+checked before lookup. A future fitted provider must enforce its own independent
+training/holdout split and feature support; this table never hides missing rows.
+"""
+
+    def __init__(self, payload, *, identity: RuntimeIdentity):
+        if (not isinstance(payload, dict) or set(payload) != {"schema_version", "identity", "rows"}
+                or type(payload["schema_version"]) is not int or payload["schema_version"] != 1
+                or not isinstance(payload["rows"], list)
+                or RuntimeIdentity(**payload["identity"]) != identity):
+            raise ValueError("Runtime profile schema/identity mismatch")
+        self.identity, self._estimates = identity, {}
+        for row in payload["rows"]:
+            if set(row) != {"query", "estimate"}:
+                raise ValueError("Profile rows require query and estimate")
+            query = dict(row["query"])
+            query["identity"] = RuntimeIdentity(**query["identity"])
+            query["workload"] = DecodeWorkload(**query["workload"])
+            query["physical_expert_counts"] = tuple(query.get("physical_expert_counts", ()))
+            query = CostQuery(**query)
+            estimate = CostEstimate(**row["estimate"])
+            if query.identity != identity or estimate.query_key != query.key or query.key in self._estimates:
+                raise ValueError("Duplicate, mismatched or cross-runtime cost row")
+            self._estimates[query.key] = estimate
+
+    def __call__(self, query):
+        if query.identity != self.identity:
+            raise ValueError("Cost query belongs to another runtime")
+        try:
+            return self._estimates[query.key]
+        except KeyError as exc:
+            raise ValueError(f"No exact cost profile for layer {query.layer_id} / {query.operator}") from exc
+
+    def audit(self, queries):
+        queries = tuple(queries)
+        if not queries or any(q.identity != self.identity for q in queries):
+            raise ValueError("Coverage audit requires queries from the same runtime")
+        missing = [{"layer_id": q.layer_id, "operator": q.operator, "query_key": q.key}
+                   for q in queries if q.key not in self._estimates]
+        return {"complete": not missing, "queries": len(queries), "missing": missing,
+                "missing_by_operator": dict(sorted(Counter(row["operator"] for row in missing).items())),
+                "note": "Exact row coverage only, not calibration-quality or full-forward admission."}

--- a/frontier/scheduler/replica_scheduler/base_replica_scheduler.py
+++ b/frontier/scheduler/replica_scheduler/base_replica_scheduler.py
@@ -62,6 +62,7 @@ class BaseReplicaScheduler(ABC):
             replica_config=self._replica_config,
             replica=replica,
             cluster_type=self._cluster_type,
+            max_num_seqs=self._config.batch_size_cap,
         )
 
         num_blocks_mode = getattr(self._config, "num_blocks_mode", "memory_planner")

--- a/frontier/scheduler/utils/memory_planner.py
+++ b/frontier/scheduler/utils/memory_planner.py
@@ -16,10 +16,14 @@ class MemoryPlanner:
         replica_config: ReplicaConfig,
         replica: Replica,
         cluster_type: ClusterType = None,
+        max_num_seqs: int | None = None,
     ) -> None:
         self._replica_config = replica_config
         self._replica = replica
         self._cluster_type = cluster_type
+        if max_num_seqs is not None and int(max_num_seqs) <= 0:
+            raise ValueError(f"max_num_seqs must be positive, got={max_num_seqs!r}")
+        self._max_num_seqs = None if max_num_seqs is None else int(max_num_seqs)
 
         self._param_counter = ParamCounter(
             replica_config=replica_config,
@@ -90,6 +94,61 @@ class MemoryPlanner:
             * self._replica.max_request_tokens
         )
 
+    def _model_has_gdn_layers(self) -> bool:
+        getter = getattr(self._replica_config.model_config, "get_num_gdn_layers", None)
+        return callable(getter) and int(getter()) > 0
+
+    def _get_max_local_sequence_mixer_layer_count(self, *, gdn: bool) -> int:
+        if self._cluster_type == ClusterType.DECODE_FFN:
+            return 0
+        model_config = self._replica_config.model_config
+        if not self._model_has_gdn_layers():
+            return 0 if gdn else int(self._replica.num_layers)
+        layers_per_stage = int(self._replica.num_layers_per_pipeline_stage)
+        num_pipeline_stages = int(self._replica.num_pipeline_stages)
+        is_gdn_layer = model_config.is_gdn_layer
+        counts = []
+        for stage_id in range(num_pipeline_stages):
+            first_layer_id = stage_id * layers_per_stage
+            gdn_count = sum(
+                bool(is_gdn_layer(layer_id))
+                for layer_id in range(first_layer_id, first_layer_id + layers_per_stage)
+            )
+            counts.append(gdn_count if gdn else layers_per_stage - gdn_count)
+        return max(counts, default=0)
+
+    def _get_num_full_attention_layers_per_device(self) -> int:
+        return self._get_max_local_sequence_mixer_layer_count(gdn=False)
+
+    def _get_num_gdn_layers_per_device(self) -> int:
+        return self._get_max_local_sequence_mixer_layer_count(gdn=True)
+
+    def _get_gdn_state_memory_per_device_per_request(self) -> int:
+        if self._cluster_type == ClusterType.DECODE_FFN:
+            return 0
+        getter = getattr(self._replica_config.model_config, "get_gdn_config", None)
+        gdn_config = getter() if callable(getter) else None
+        if gdn_config is None:
+            return 0
+        state_layout = gdn_config.get_state_layout(
+            tensor_parallel_size=self._replica_config.attn_tensor_parallel_size,
+        )
+        return int(state_layout.total_bytes) * self._get_num_gdn_layers_per_device()
+
+    def get_gdn_state_memory_per_device_per_request_bytes(self) -> int:
+        return self._get_gdn_state_memory_per_device_per_request()
+
+    def _get_gdn_state_reservation_bytes(self) -> int:
+        state_per_request = self._get_gdn_state_memory_per_device_per_request()
+        if state_per_request == 0:
+            return 0
+        max_num_seqs = getattr(self, "_max_num_seqs", None)
+        if max_num_seqs is None:
+            raise ValueError(
+                "MemoryPlanner requires max_num_seqs to reserve fixed GDN state"
+            )
+        return state_per_request * int(max_num_seqs)
+
     def _get_kv_cache_elements_per_token_per_worker(self) -> int:
         if self._cluster_type == ClusterType.DECODE_FFN:
             return 0
@@ -116,7 +175,7 @@ class MemoryPlanner:
         )
 
     def _get_parameter_memory_per_device(self) -> int:
-        return 2 * self._param_counter.get_num_parameters_per_device()
+        return self._param_counter.get_parameter_memory_per_device_bytes()
 
     def get_parameter_memory_per_device_bytes(self) -> int:
         """Return parameter memory per device in bytes."""
@@ -127,10 +186,11 @@ class MemoryPlanner:
         if self._cluster_type == ClusterType.DECODE_FFN:
             return 0
 
-        return (
+        dense_kv_bytes = (
             self._get_kv_cache_memory_per_layer_per_request()
-            * self._replica.num_layers
+            * self._get_num_full_attention_layers_per_device()
         )
+        return dense_kv_bytes + self._get_gdn_state_memory_per_device_per_request()
 
     def get_num_blocks(
         self,
@@ -150,7 +210,9 @@ class MemoryPlanner:
         plus an optional calibrated overhead term.
         """
         page_size = self._get_kv_cache_memory_per_layer_per_block(block_size)
-        if page_size == 0:
+        num_full_attention_layers = self._get_num_full_attention_layers_per_device()
+        gdn_state_reservation_bytes = self._get_gdn_state_reservation_bytes()
+        if page_size == 0 and gdn_state_reservation_bytes == 0:
             return 0
 
         requested_memory = self._get_requested_memory_bytes(gpu_memory_utilization)
@@ -175,7 +237,10 @@ class MemoryPlanner:
             )
 
         available_kv_cache_memory = (
-            requested_memory - parameter_memory_per_device - overhead_bytes
+            requested_memory
+            - parameter_memory_per_device
+            - overhead_bytes
+            - gdn_state_reservation_bytes
         )
         if available_kv_cache_memory <= 0:
             self._raise_memory_oom(
@@ -185,6 +250,7 @@ class MemoryPlanner:
                     "requested_memory_bytes": requested_memory,
                     "parameter_memory_per_device_bytes": parameter_memory_per_device,
                     "non_kv_cache_overhead_bytes": overhead_bytes,
+                    "gdn_state_reservation_bytes": gdn_state_reservation_bytes,
                     "available_kv_cache_memory_bytes": available_kv_cache_memory,
                     "block_size": int(block_size),
                     "page_size_bytes": int(page_size),
@@ -192,8 +258,11 @@ class MemoryPlanner:
                 },
             )
 
+        if page_size == 0 or num_full_attention_layers == 0:
+            return 0
+
         num_blocks = int(
-            available_kv_cache_memory // page_size // self._replica.num_layers
+            available_kv_cache_memory // page_size // num_full_attention_layers
         )
         num_blocks = max(num_blocks, 0)
 
@@ -207,7 +276,9 @@ class MemoryPlanner:
                     "available_kv_cache_memory_bytes": available_kv_cache_memory,
                     "non_kv_cache_overhead_bytes": overhead_bytes,
                     "page_size_bytes": int(page_size),
-                    "num_layers": int(self._replica.num_layers),
+                    "num_full_attention_layers": num_full_attention_layers,
+                    "num_gdn_layers": self._get_num_gdn_layers_per_device(),
+                    "gdn_state_reservation_bytes": gdn_state_reservation_bytes,
                 },
             )
 
@@ -269,6 +340,9 @@ class MemoryPlanner:
                     "parameter_memory_per_device_bytes": parameter_memory_per_device,
                     "memory_for_kv_cache_bytes": memory_for_kv_cache,
                     "kv_cache_per_request_bytes": kv_cache_memory_per_device_per_request,
+                    "gdn_state_per_request_bytes": (
+                        self._get_gdn_state_memory_per_device_per_request()
+                    ),
                     "non_kv_cache_overhead_bytes": overhead_bytes,
                 },
             )

--- a/frontier/types/device_sku_type.py
+++ b/frontier/types/device_sku_type.py
@@ -10,3 +10,4 @@ class DeviceSKUType(BaseIntEnum):
     H800 = 6
     H20 = 7
     RTX_PRO_6000 = 8
+    MI355X = 9

--- a/frontier/types/node_sku_type.py
+++ b/frontier/types/node_sku_type.py
@@ -11,3 +11,4 @@ class NodeSKUType(BaseIntEnum):
     A800_DGX = 7
     H800_DGX = 8
     H20_DGX = 9
+    MI355X_UBB = 10

--- a/frontier/utils/param_counter.py
+++ b/frontier/utils/param_counter.py
@@ -373,6 +373,98 @@ class ParamCounter:
         )
         return num_parameters
 
+    def get_num_gdn_params_per_layer(self) -> int:
+        """Return the local Qwen GDN parameter count for one layer.
+
+        The projection and convolution outputs are column-sharded, the output
+        projection input is row-sharded, and the per-head recurrent parameters
+        follow the value-head shard. RMSNormGated owns one replicated head-width
+        vector, matching vLLM's module construction.
+        """
+
+        if self._cluster_type == ClusterType.DECODE_FFN:
+            return 0
+        getter = getattr(self._model_config, "get_gdn_config", None)
+        gdn_config = getter() if callable(getter) else None
+        if gdn_config is None:
+            return 0
+        tp_size = self._get_attn_tp_size()
+        sharded_dimensions = (
+            gdn_config.conv_dim,
+            gdn_config.key_dim,
+            gdn_config.value_dim,
+            gdn_config.num_key_heads,
+            gdn_config.num_value_heads,
+        )
+        if any(int(dimension) % tp_size != 0 for dimension in sharded_dimensions):
+            raise ValueError(
+                "GDN dimensions must be divisible by attention TP size, "
+                f"tp={tp_size}, dimensions={sharded_dimensions}"
+            )
+
+        hidden_size = int(self._model_config.embedding_dim)
+        local_conv_dim = int(gdn_config.conv_dim) // tp_size
+        local_key_dim = int(gdn_config.key_dim) // tp_size
+        local_value_dim = int(gdn_config.value_dim) // tp_size
+        local_value_heads = int(gdn_config.num_value_heads) // tp_size
+        return (
+            local_conv_dim * int(gdn_config.conv_kernel_size)
+            + hidden_size * (2 * local_key_dim + 2 * local_value_dim)
+            + hidden_size * (2 * local_value_heads)
+            + hidden_size * local_value_dim
+            + int(gdn_config.value_head_dim)
+            + 2 * local_value_heads
+        )
+
+    def get_gdn_parameter_memory_bytes_per_layer(self) -> int:
+        """Return exact BF16/FP32 bytes for one local vLLM Qwen GDN layer."""
+
+        num_parameters = self.get_num_gdn_params_per_layer()
+        if num_parameters == 0:
+            return 0
+        gdn_config = self._model_config.get_gdn_config()
+        local_value_heads = int(gdn_config.num_value_heads) // self._get_attn_tp_size()
+        # A_log is explicitly FP32; all other synthetic/checkpoint GDN weights,
+        # including dt_bias, use the BF16 model dtype in the pinned runtime.
+        return 2 * (num_parameters - local_value_heads) + 4 * local_value_heads
+
+    def _get_pipeline_stage_layer_ids(self, stage_id: int) -> range:
+        first_layer_id = int(stage_id) * self._num_layers_per_pipeline_stage
+        return range(first_layer_id, first_layer_id + self._num_layers_per_pipeline_stage)
+
+    def _get_attention_stage_totals(self) -> tuple[tuple[int, int], ...]:
+        """Return ``(parameter_elements, parameter_bytes)`` for every PP stage."""
+
+        if self._cluster_type == ClusterType.DECODE_FFN:
+            return ((0, 0),)
+        num_pipeline_stages = int(self._replica_config.num_pipeline_stages)
+        full_attention_params = self.get_num_attention_params_per_layer()
+        gdn_params = self.get_num_gdn_params_per_layer()
+        full_attention_bytes = 2 * full_attention_params
+        gdn_bytes = self.get_gdn_parameter_memory_bytes_per_layer()
+        is_gdn_layer = getattr(self._model_config, "is_gdn_layer", None)
+        totals = []
+        for stage_id in range(num_pipeline_stages):
+            element_total = 0
+            byte_total = 0
+            for layer_id in self._get_pipeline_stage_layer_ids(stage_id):
+                if callable(is_gdn_layer) and bool(is_gdn_layer(layer_id)):
+                    element_total += gdn_params
+                    byte_total += gdn_bytes
+                else:
+                    element_total += full_attention_params
+                    byte_total += full_attention_bytes
+            totals.append((element_total, byte_total))
+        return tuple(totals)
+
+    def get_num_attention_parameters_per_device(self) -> int:
+        """Return the largest resident attention/GDN shard across PP stages."""
+
+        return max(elements for elements, _ in self._get_attention_stage_totals())
+
+    def get_attention_parameter_memory_per_device_bytes(self) -> int:
+        return max(memory_bytes for _, memory_bytes in self._get_attention_stage_totals())
+
     def get_num_mlp_params_per_layer(self) -> int:
         # For DECODE_ATTN cluster, there are no MLP parameters.
         if self._cluster_type == ClusterType.DECODE_ATTN:
@@ -395,20 +487,27 @@ class ParamCounter:
 
     def get_num_parameters_per_device(self) -> int:
         if not getattr(self._model_config, "is_moe", False):
-            num_parameters_per_layer = self.get_num_parameters_per_layer()
             return (
-                num_parameters_per_layer * self._num_layers_per_pipeline_stage
+                self.get_num_attention_parameters_per_device()
+                + self.get_num_mlp_parameters_per_device()
                 + self.get_num_mtp_parameters_per_device()
             )
 
-        num_attention_parameters = (
-            self.get_num_attention_params_per_layer() * self._num_layers_per_pipeline_stage
-        )
+        num_attention_parameters = self.get_num_attention_parameters_per_device()
         num_mlp_parameters = self.get_num_mlp_parameters_per_device()
         return (
             num_attention_parameters
             + num_mlp_parameters
             + self.get_num_mtp_parameters_per_device()
+        )
+
+    def get_parameter_memory_per_device_bytes(self) -> int:
+        """Return resident parameter bytes with GDN's FP32 A_log accounted."""
+
+        return (
+            self.get_attention_parameter_memory_per_device_bytes()
+            + 2 * self.get_num_mlp_parameters_per_device()
+            + 2 * self.get_num_mtp_parameters_per_device()
         )
 
     def get_num_mlp_parameters_per_device(self) -> int:

--- a/frontier/validation/__init__.py
+++ b/frontier/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime capture and numerical validation, independent of serving schedulers."""

--- a/frontier/validation/batch_record.py
+++ b/frontier/validation/batch_record.py
@@ -1,0 +1,189 @@
+"""Versioned, tensor-free snapshots of actual model execution batches."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class BatchRecord:
+    """One rank of one iteration; context lengths exclude scheduled query tokens.
+
+    Model/topology/runtime identity belongs to the run's manifest. Timings are
+    observations only, never features passed to the execution-time predictor.
+    """
+
+    batch_id: str
+    rank: int
+    phase: str
+    request_ids: tuple[str, ...]
+    query_lens: tuple[int, ...]
+    context_lens: tuple[int, ...]
+    prefill_mask: tuple[bool, ...]
+    prompt_lens: tuple[int, ...] | None = None
+    graph_mode: str = "NONE"
+    capture_size: int = 0
+    repetition: int = 0
+    step: int = 0
+    profiled: bool = False
+    forward_gpu_ms: float | None = None
+    step_wall_ms: float | None = None
+    schema_version: int = 1
+    decode_input_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or self.schema_version != 1:
+            raise ValueError(f"Unsupported batch schema version: {self.schema_version}")
+        if not isinstance(self.batch_id, str) or not self.batch_id:
+            raise ValueError("batch_id must be a nonempty string")
+        for key in ("rank", "capture_size", "repetition", "step"):
+            value = getattr(self, key)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{key} must be a nonnegative integer")
+        size = len(self.request_ids)
+        if not size or len(set(self.request_ids)) != size:
+            raise ValueError("request_ids must be nonempty and unique within a batch")
+        if any(not isinstance(value, str) or not value for value in self.request_ids):
+            raise ValueError("request_ids must contain nonempty strings")
+        for key in ("query_lens", "context_lens", "prefill_mask"):
+            if len(getattr(self, key)) != size:
+                raise ValueError(f"{key} must have one entry per request")
+        if any(type(v) is not int or v <= 0 for v in self.query_lens):
+            raise ValueError("query_lens must contain positive integers")
+        if any(type(v) is not int or v < 0 for v in self.context_lens):
+            raise ValueError("context_lens must contain nonnegative integers")
+        if any(type(v) is not bool for v in self.prefill_mask):
+            raise ValueError("prefill_mask must contain booleans")
+        if self.prompt_lens is not None:
+            if len(self.prompt_lens) != size or any(type(v) is not int or v <= 0 for v in self.prompt_lens):
+                raise ValueError("prompt_lens must have one positive integer per request")
+            for prompt, context, query, prefill in zip(
+                self.prompt_lens, self.context_lens, self.query_lens, self.prefill_mask
+            ):
+                if (prefill and context + query > prompt) or (not prefill and context < prompt):
+                    raise ValueError("prompt_lens disagree with query/context progress")
+        expected_phase = (
+            "prefill" if all(self.prefill_mask)
+            else "mixed" if any(self.prefill_mask) else "decode"
+        )
+        if self.phase != expected_phase:
+            raise ValueError(f"phase disagrees with prefill_mask: expected {expected_phase}")
+        if any(q != 1 or c < 1 for q, c, p in zip(
+            self.query_lens, self.context_lens, self.prefill_mask
+        ) if not p):
+            raise ValueError("Non-speculative decode requires query=1 and positive context")
+        if self.graph_mode not in {"NONE", "FULL"}:
+            raise ValueError("Batch replay currently supports NONE/FULL graph modes")
+        if self.graph_mode == "FULL":
+            if self.phase != "decode" or self.capture_size < size:
+                raise ValueError("FULL graphs require pure decode and capture_size >= batch size")
+        elif self.capture_size:
+            raise ValueError("Eager batches must have capture_size=0")
+        if type(self.profiled) is not bool:
+            raise ValueError("profiled must be boolean")
+        if self.decode_input_sha256 is not None:
+            digest = self.decode_input_sha256
+            if (self.phase != "decode" or not isinstance(digest, str) or len(digest) != 64
+                    or any(c not in "0123456789abcdef" for c in digest)):
+                raise ValueError("decode_input_sha256 requires decode and a lowercase SHA-256 digest")
+        for key in ("forward_gpu_ms", "step_wall_ms"):
+            value = getattr(self, key)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, (int, float))
+                or not math.isfinite(value) or value <= 0
+            ):
+                raise ValueError(f"{key} must be finite and positive when present")
+
+    @classmethod
+    def from_dict(cls, value: dict) -> "BatchRecord":
+        fields = dict(value)
+        for key in ("request_ids", "query_lens", "context_lens", "prefill_mask"):
+            fields[key] = tuple(fields[key])
+        if fields.get("prompt_lens") is not None:
+            fields["prompt_lens"] = tuple(fields["prompt_lens"])
+        return cls(**fields)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def shape_key(self) -> tuple:
+        return (self.phase, self.query_lens, self.context_lens,
+                self.prefill_mask, self.graph_mode, self.capture_size, self.prompt_lens)
+
+    def to_frontier_batch(self, *, is_moe: bool):
+        """Hydrate an isolated prediction snapshot, with no scheduler side effects."""
+        from frontier.entities.batch import Batch, DecodeCudaGraphMetadata
+        from frontier.entities.request import Request
+
+        requests = []
+        for index, (query, context, prefill) in enumerate(zip(
+            self.query_lens, self.context_lens, self.prefill_mask
+        )):
+            prompt = self.prompt_lens[index] if self.prompt_lens else (
+                context + query if prefill else context
+            )
+            request = Request(
+                arrived_at=0.0,
+                num_prefill_tokens=prompt,
+                num_decode_tokens=max(2, context - prompt + 2),
+                num_processed_tokens=context,
+            )
+            # Snapshot hydration: no prefill-completion event should be invented.
+            request._is_prefill_complete = not prefill
+            requests.append(request)
+        batch = Batch(0, requests, list(self.query_lens), is_moe=is_moe)
+        decode_size = sum(not value for value in self.prefill_mask)
+        batch.decode_cuda_graph_metadata = DecodeCudaGraphMetadata(
+            config_mode="full_decode_only", runtime_mode=self.graph_mode,
+            capture_hit=self.graph_mode == "FULL", is_mixed_batch=self.phase == "mixed",
+            original_total_tokens=sum(self.query_lens),
+            padded_total_tokens=self.capture_size or sum(self.query_lens),
+            original_decode_batch_size=decode_size,
+            padded_decode_batch_size=self.capture_size or decode_size,
+        )
+        return batch
+
+
+def read_batches(path: str | Path) -> list[BatchRecord]:
+    records = []
+    seen = set()
+    with open(path, encoding="utf-8") as stream:
+        for lineno, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            try:
+                record = BatchRecord.from_dict(json.loads(line))
+                key = (record.batch_id, record.rank)
+                if key in seen:
+                    raise ValueError(f"Duplicate batch/rank: {key}")
+                seen.add(key)
+                records.append(record)
+            except (ValueError, TypeError, KeyError) as exc:
+                raise ValueError(f"{path}:{lineno}: {exc}") from exc
+    if not records:
+        raise ValueError(f"Empty batch ledger: {path}")
+    return records
+
+
+def validate_rank_cohorts(records: Iterable[BatchRecord], *, tensor_parallel_size: int) -> dict:
+    """Require complete, shape-identical TP cohorts before aggregating timings."""
+    if type(tensor_parallel_size) is not int or tensor_parallel_size <= 0:
+        raise ValueError("tensor_parallel_size must be a positive integer")
+    cohorts: dict[str, list[BatchRecord]] = {}
+    for record in records:
+        cohorts.setdefault(record.batch_id, []).append(record)
+    for batch_id, cohort in cohorts.items():
+        if sorted(r.rank for r in cohort) != list(range(tensor_parallel_size)):
+            raise ValueError(f"Incomplete or duplicate TP ranks for {batch_id}")
+        if any(r.shape_key() != cohort[0].shape_key() or
+               r.request_ids != cohort[0].request_ids or
+               r.decode_input_sha256 != cohort[0].decode_input_sha256 or
+               (r.profiled, r.repetition, r.step) !=
+               (cohort[0].profiled, cohort[0].repetition, cohort[0].step)
+               for r in cohort):
+            raise ValueError(f"TP ranks disagree on batch shape/identity for {batch_id}")
+    return cohorts

--- a/frontier/validation/gdn_correlation.py
+++ b/frontier/validation/gdn_correlation.py
@@ -1,0 +1,147 @@
+"""Calibrate GDN on selected batch shapes and validate disjoint held-out shapes."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import json
+import statistics
+from pathlib import Path
+
+import pandas as pd
+
+from frontier.gdn.predictor import GDNBatchFeatures, ProfiledGDNPredictor
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.gdn.sglang_trace import build_sglang_profile_row_from_samples
+from frontier.types import MeasurementType
+from frontier.validation.batch_record import read_batches
+from frontier.validation.trace import extract_batch_kernels, summarize_batch_kernels
+
+
+def correlate(capture_dir: Path, *, model: str, device: str,
+              calibration_sizes: set[int], validation_sizes: set[int]) -> tuple:
+    if not calibration_sizes or not validation_sizes or calibration_sizes & validation_sizes:
+        raise ValueError("Calibration and validation batch sizes must be nonempty and disjoint")
+    manifest = json.loads((capture_dir / "manifest.json").read_text())
+    if manifest.get("status") != "complete":
+        raise ValueError("Capture must be complete before correlation")
+    config = ModelConfig.from_model_name(model)
+    if Path(manifest["model_path"]).name != Path(model).name:
+        raise ValueError("Model does not match captured checkpoint")
+    tp = manifest["topology"]["tp"]
+    records = {(r.batch_id, r.rank): r for r in read_batches(capture_dir / "batches.jsonl")}
+    summaries, training_rows, validation = [], [], []
+    training_samples = {}
+    signature = json.dumps(manifest["versions"], sort_keys=True)
+    seen_shapes = set()
+    for path in sorted(capture_dir.glob("*-rank0.trace.json.gz")):
+        with gzip.open(path, "rt", encoding="utf-8") as stream:
+            kernels_by_batch = extract_batch_kernels(json.load(stream))
+        for batch_id, kernels in kernels_by_batch.items():
+            record = records[(batch_id, 0)]
+            size = len(record.request_ids)
+            if not record.profiled:
+                raise ValueError("Kernel traces must identify diagnostic/profiled passes")
+            summary = summarize_batch_kernels(kernels, phase=record.phase,
+                                              gdn_layers=config.get_num_gdn_layers())
+            summaries.append({"batch_id": batch_id, "rank": 0, **summary})
+            if size not in calibration_sizes | validation_sizes:
+                continue
+            seen_shapes.add((size, record.phase))
+            if size in validation_sizes:
+                validation.append((record, summary))
+                continue
+            if len(set(record.query_lens)) != 1:
+                raise ValueError("Initial GDN calibration requires uniform query lengths")
+            if record.phase == "prefill" and any(record.context_lens):
+                raise ValueError("Initial GDN calibration requires cold prefill")
+            physical_size = record.capture_size or size
+            # Decode context length is not a GDN predictor feature. Pool repeated
+            # layer samples before computing statistics rather than writing
+            # conflicting rows for the same exact predictor feature vector.
+            key = (record.phase, physical_size,
+                   record.query_lens[0] if record.phase == "prefill" else 1)
+            if key not in training_samples:
+                training_samples[key] = (record, str(path),
+                                         {name: [] for name in summary["gdn_samples_ms"]})
+            for name, values in summary["gdn_samples_ms"].items():
+                training_samples[key][2][name].extend(values)
+    expected = {(size, phase) for size in calibration_sizes | validation_sizes
+                for phase in ("prefill", "decode")}
+    if missing := expected - seen_shapes:
+        raise ValueError(f"Missing complete profiled batches: {sorted(missing)}")
+    for (phase, physical_size, _), (record, path, samples) in training_samples.items():
+        training_rows.append(build_sglang_profile_row_from_samples(
+            samples, shape={"phase": phase, "batch_size": physical_size,
+                            "input_len": record.query_lens[0] if phase == "prefill"
+                            else max(record.context_lens)},
+            trace_path=path, model_config=config, device=device,
+            tensor_parallel_size=tp, runtime_stack_signature=signature,
+        ))
+    frame = pd.json_normalize(training_rows)
+    predictor = ProfiledGDNPredictor(frame, model_config=config, device=device,
+                                    tensor_parallel_size=tp,
+                                    measurement_type=MeasurementType.KERNEL_ONLY)
+    errors = []
+    for record, summary in validation:
+        features = GDNBatchFeatures.from_batch(record.to_frontier_batch(is_moe=config.is_moe))
+        # Reject graph-padding leakage: logical held-out sizes must also produce
+        # physical feature vectors absent from the training set.
+        if any(features.exact_key() == (
+            int(row["batch_size"]), int(row["batch_num_tokens"]),
+            int(row["batch_num_prefill_tokens"]), int(row["batch_num_decode_tokens"]),
+            int(row["max_query_len"]), bool(row["has_initial_state"])
+        ) for row in training_rows):
+            raise ValueError("Held-out shape maps to an already calibrated physical graph shape")
+        predictions = predictor.predict_operator_times(features)
+        predicted = sum(predictions.values()) * config.get_num_gdn_layers()
+        observed = summary["gdn_kernel_sum_ms"]
+        errors.append({"batch_id": record.batch_id, "phase": record.phase,
+                       "batch_size": len(record.request_ids),
+                       "observed_gdn_ms": observed, "predicted_gdn_ms": predicted,
+                       "absolute_error_pct": 100 * abs(predicted / observed - 1)})
+    report = {
+        "scope": "rank-0 GDN kernel sums only; excludes attention, MoE, collectives and serving overhead",
+        "measurement_note": "Calibration and validation both use profiled kernel sums. Their error "
+                            "does not establish unprofiled decode latency accuracy. Check matching-step "
+                            "profile perturbation with frontier.validation.report before broader use.",
+        "measurement_type": "KERNEL_ONLY", "tensor_parallel_size": tp,
+        "calibration_sizes": sorted(calibration_sizes),
+        "validation_sizes": sorted(validation_sizes),
+        "by_phase": {phase: {
+            "batches": len(rows),
+            "observed_median_ms": statistics.median(r["observed_gdn_ms"] for r in rows),
+            "predicted_median_ms": statistics.median(r["predicted_gdn_ms"] for r in rows),
+            "mape_pct": statistics.mean(r["absolute_error_pct"] for r in rows),
+        } for phase in ("prefill", "decode")
+          if (rows := [r for r in errors if r["phase"] == phase])},
+    }
+    return frame, summaries, errors, report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", default="mi355x")
+    parser.add_argument("--calibration-sizes", type=int, nargs="+", required=True)
+    parser.add_argument("--validation-sizes", type=int, nargs="+", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    frame, summaries, rows, report = correlate(
+        args.capture_dir, model=args.model, device=args.device,
+        calibration_sizes=set(args.calibration_sizes), validation_sizes=set(args.validation_sizes))
+    args.output_dir.mkdir(parents=True, exist_ok=False)
+    frame.to_csv(args.output_dir / "gdn_kernel_only.csv", index=False)
+    (args.output_dir / "kernel-summary.json").write_text(json.dumps(summaries, indent=2) + "\n")
+    with (args.output_dir / "correlation.csv").open("x", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    (args.output_dir / "summary.json").write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/graph_event_report.py
+++ b/frontier/validation/graph_event_report.py
@@ -1,0 +1,313 @@
+"""Validate and summarize disjoint HIP graph scopes without native CSV relabeling."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import hashlib
+import json
+import math
+from pathlib import Path
+import statistics
+
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+from frontier.validation.operator_trace import model_layer_kinds
+from frontier.validation.report import summarize_profile_perturbation
+
+
+_PARENTS = {
+    "decoder_layer": None,
+    "input_layernorm": "decoder_layer",
+    "gdn": "decoder_layer", "full_attention": "decoder_layer",
+    "attention_reduce_and_mlp_norm": "decoder_layer",
+    "post_attention_layernorm": "attention_reduce_and_mlp_norm",
+    "mlp_including_tp_reduce": "decoder_layer",
+    **{f"gdn_{name}": "gdn" for name in ("input_projections", "attn", "norm", "out_proj")},
+    **{f"attention_{name}": "full_attention" for name in ("qkv_proj", "rotary_emb", "attn", "o_proj")},
+    **{f"moe_{name}": "mlp_including_tp_reduce" for name in ("shared_expert", "gate", "topk", "experts")},
+}
+
+
+def expected_scopes(layer_kinds, layer_ids, components):
+    if (not layer_ids or len(set(layer_ids)) != len(layer_ids)
+            or any(type(i) is not int or i < 0 or i >= len(layer_kinds) for i in layer_ids)):
+        raise ValueError("Selected graph layers must exist in the model schedule")
+    selected = set(components)
+    if not selected or len(selected) != len(components) or selected - set(_PARENTS):
+        raise ValueError("Unknown, duplicate or empty graph components")
+    for component in selected:
+        parent = _PARENTS[component]
+        while parent is not None:
+            if parent in selected:
+                raise ValueError("Nested graph scopes are not additive; select disjoint components")
+            parent = _PARENTS[parent]
+    result = set()
+    for layer in layer_ids:
+        if layer_kinds[layer] not in {"gdn", "attention"}:
+            raise ValueError("Unknown model layer kind")
+        excluded = ({"full_attention", "attention_qkv_proj", "attention_rotary_emb",
+                     "attention_attn", "attention_o_proj"} if layer_kinds[layer] == "gdn"
+                    else {"gdn", "gdn_input_projections", "gdn_attn", "gdn_norm", "gdn_out_proj"})
+        result.update((layer, component) for component in selected - excluded)
+    if not result:
+        raise ValueError("No selected timing scopes exist in the model")
+    return result
+
+
+def summarize_graph_events(records, samples, *, tensor_parallel_size, expected, quality):
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=tensor_parallel_size)
+    ledger = {(r.batch_id, r.rank): r for r in records if r.phase == "decode"}
+    if not ledger or any(not r.profiled or r.graph_mode != "FULL" or r.forward_gpu_ms is None
+                         for r in ledger.values()):
+        raise ValueError("Graph timing requires separate profiled full-decode cohorts")
+    quality_by_batch = {r["batch_id"]: r for r in quality["batches"]}
+    if any(batch_id not in quality_by_batch for batch_id, _ in ledger):
+        raise ValueError("Missing baseline perturbation check")
+    seen, captures, capture_sizes, scope_rows = defaultdict(set), {}, {}, defaultdict(list)
+    scope_totals = defaultdict(float)
+    for sample in samples:
+        if any(type(sample[k]) is not int or sample[k] < 0 for k in ("rank", "layer_id", "physical_size")):
+            raise ValueError("Graph rank/layer/physical size must be nonnegative integers")
+        key = (sample["batch_id"], sample["rank"])
+        if key not in ledger:
+            raise ValueError("Graph event has no matching decode batch/rank")
+        record = ledger[key]
+        identity = (sample["layer_id"], sample["component"])
+        if identity not in expected or identity in seen[key]:
+            raise ValueError("Unexpected or duplicate graph event scope")
+        seen[key].add(identity)
+        if (sample["measurement_type"] != "HIP_GRAPH_EVENT" or sample["parent_id"] is not None
+                or sample["physical_size"] != record.capture_size):
+            raise ValueError("Graph measurement family, disjoint scope or physical size mismatch")
+        capture_key = (record.rank, record.capture_size)
+        capture_id = sample["capture_id"]
+        if type(capture_id) is not int or capture_id < 1:
+            raise ValueError("Invalid graph capture ID")
+        if captures.setdefault(capture_key, capture_id) != capture_id:
+            raise ValueError("Multiple captured graph variants for one rank/physical size")
+        if capture_sizes.setdefault((record.rank, capture_id), record.capture_size) != record.capture_size:
+            raise ValueError("One captured graph cannot have multiple physical sizes")
+        duration = sample["inclusive_gpu_ms"]
+        if (isinstance(duration, bool) or not isinstance(duration, (int, float))
+                or not math.isfinite(duration) or duration <= 0 or duration > record.forward_gpu_ms):
+            raise ValueError("Invalid graph scope GPU duration")
+        scope_totals[key] += duration
+        input_len = max(record.context_lens) - record.step + 1
+        group = (len(record.request_ids), input_len, record.capture_size, record.rank, *identity)
+        scope_rows[group].append((record, duration, quality_by_batch[record.batch_id]["passes_latency_check"]))
+    if set(seen) != set(ledger) or any(identities != expected for identities in seen.values()):
+        raise ValueError("Incomplete graph scope coverage for a decode batch/rank")
+    if any(total > ledger[key].forward_gpu_ms + 1e-5 for key, total in scope_totals.items()):
+        raise ValueError("Disjoint scope durations exceed their same-rank forward timing")
+    summaries = []
+    for (bs, length, physical, rank, layer, component), rows in sorted(scope_rows.items()):
+        durations = [value for _, value, _ in rows]
+        repetitions = defaultdict(list)
+        for record, value, _ in rows:
+            repetitions[record.repetition].append(value)
+        medians = [statistics.median(values) for values in repetitions.values()]
+        summaries.append({"batch_size": bs, "input_len": length, "physical_size": physical,
+            "rank": rank, "layer_id": layer, "component": component,
+            "samples": len(rows), "repetitions": len(repetitions),
+            "gpu_median_of_repeat_medians_ms": statistics.median(medians),
+            "gpu_min_ms": min(durations), "gpu_max_ms": max(durations),
+            "repeat_median_cv_pct": 100 * statistics.pstdev(medians) / statistics.mean(medians),
+            "samples_failing_forward_latency_check": sum(not accepted for _, _, accepted in rows)})
+    decode_quality = [quality_by_batch[batch_id] for batch_id in cohorts if (batch_id, 0) in ledger]
+    return {"measurement_type": "HIP_GRAPH_EVENT", "decode_batches": len(decode_quality),
+        "scope_samples": sum(len(rows) for rows in scope_rows.values()),
+        "selected_scopes_per_rank": len(expected),
+        "decode_batches_failing_latency_check": sum(not r["passes_latency_check"] for r in decode_quality),
+        "all_decode_inputs_fixed": all(r.decode_input_sha256 is not None for r in ledger.values()),
+        "all_decode_batches_pass_latency_check": all(r["passes_latency_check"] for r in decode_quality),
+        "summaries": summaries,
+        "native_profile_export_admitted": False,
+        "limitations": [
+            "Disjoint event spans, not kernel sums. Endpoint costs can bias small scopes even when forward latency passes.",
+            "All samples, including rejected ones, remain in diagnostic summaries; no trimming or correction factor.",
+            "Rank/layer identities remain separate; summing per-scope rank maxima is not a measured critical path.",
+            "Fused mixer/MLP scopes and reduction boundaries do not map one-to-one to native compute operators.",
+            "Timing scopes alone contain no routing vectors; consult a separate routing audit when available. "
+            "Selected timing layers do not establish full decoder/forward coverage or EP/multi-node scaling.",
+            "Fixed token inputs do not guarantee identical activations, expert routes or numerical correctness.",
+        ]}
+
+
+def summarize_decoder_graph_events(
+        records, samples, *, tensor_parallel_size, num_layers, quality):
+    """Summarize the single span matching the runtime-cost decoder boundary."""
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=tensor_parallel_size)
+    ledger = {(record.batch_id, record.rank): record
+              for record in records if record.phase == "decode"}
+    if (not ledger or type(num_layers) is not int or num_layers < 1
+            or any(not record.profiled or record.graph_mode != "FULL"
+                   or record.forward_gpu_ms is None for record in ledger.values())):
+        raise ValueError("Decoder graph timing requires separate profiled full-decode cohorts")
+    quality_by_batch = {row["batch_id"]: row for row in quality["batches"]}
+    if any(batch_id not in quality_by_batch for batch_id, _ in ledger):
+        raise ValueError("Missing baseline perturbation check")
+
+    seen, captures, capture_sizes = set(), {}, {}
+    grouped = defaultdict(list)
+    for sample in samples:
+        key = (sample.get("batch_id"), sample.get("rank"))
+        if key not in ledger or key in seen:
+            raise ValueError("Decoder graph event has no matching batch/rank or is duplicated")
+        seen.add(key)
+        record = ledger[key]
+        if (sample.get("component") != "decoder"
+                or sample.get("measurement_type") != "HIP_GRAPH_EVENT"
+                or sample.get("first_layer_id") != 0
+                or sample.get("last_layer_id") != num_layers - 1
+                or type(sample.get("physical_size")) is not int
+                or sample["physical_size"] != record.capture_size):
+            raise ValueError("Decoder graph boundary, measurement family or size mismatch")
+        capture_id = sample.get("capture_id")
+        if type(capture_id) is not int or capture_id < 1:
+            raise ValueError("Invalid decoder graph capture ID")
+        capture_key = (record.rank, record.capture_size)
+        if captures.setdefault(capture_key, capture_id) != capture_id:
+            raise ValueError("Multiple captured decoder graph variants for one rank/size")
+        if capture_sizes.setdefault((record.rank, capture_id), record.capture_size) != record.capture_size:
+            raise ValueError("One decoder graph capture cannot have multiple physical sizes")
+        duration = sample.get("inclusive_gpu_ms")
+        if (isinstance(duration, bool) or not isinstance(duration, (int, float))
+                or not math.isfinite(duration) or duration <= 0
+                or duration > record.forward_gpu_ms):
+            raise ValueError("Invalid decoder graph event duration")
+        input_len = max(record.context_lens) - record.step + 1
+        group = (len(record.request_ids), input_len, record.capture_size, record.rank)
+        grouped[group].append((record, duration,
+            quality_by_batch[record.batch_id]["passes_latency_check"]))
+    if seen != set(ledger):
+        raise ValueError("Incomplete decoder graph event coverage")
+
+    summaries = []
+    for (batch_size, input_len, physical_size, rank), rows in sorted(grouped.items()):
+        durations = [duration for _, duration, _ in rows]
+        gaps = [record.forward_gpu_ms - duration for record, duration, _ in rows]
+        repetitions = defaultdict(list)
+        for record, duration, _ in rows:
+            repetitions[record.repetition].append(duration)
+        medians = [statistics.median(values) for values in repetitions.values()]
+        summaries.append({
+            "batch_size": batch_size,
+            "input_len": input_len,
+            "physical_size": physical_size,
+            "rank": rank,
+            "samples": len(rows),
+            "repetitions": len(repetitions),
+            "decoder_gpu_median_of_repeat_medians_ms": statistics.median(medians),
+            "decoder_gpu_min_ms": min(durations),
+            "decoder_gpu_max_ms": max(durations),
+            "forward_minus_decoder_median_ms": statistics.median(gaps),
+            "repeat_median_cv_pct": (
+                100 * statistics.pstdev(medians) / statistics.mean(medians)),
+            "samples_failing_forward_latency_check": sum(
+                not accepted for _, _, accepted in rows),
+        })
+    decode_quality = [quality_by_batch[batch_id]
+                      for batch_id in cohorts if (batch_id, 0) in ledger]
+    return {
+        "measurement_type": "HIP_GRAPH_EVENT",
+        "boundary": "first decoder layer entry through last decoder layer exit",
+        "decode_batches": len(decode_quality),
+        "decoder_scope_samples": len(samples),
+        "all_decode_inputs_fixed": all(
+            record.decode_input_sha256 is not None for record in ledger.values()),
+        "all_decode_batches_pass_latency_check": all(
+            row["passes_latency_check"] for row in decode_quality),
+        "decode_batches_failing_latency_check": sum(
+            not row["passes_latency_check"] for row in decode_quality),
+        "summaries": summaries,
+        "native_profile_export_admitted": False,
+        "limitations": [
+            "Diagnostic event span, not an isolated primitive profile or native CSV row.",
+            "The two event nodes are inside the recaptured graph and can perturb its execution.",
+            "Rejected forward-latency samples remain visible; no trimming or correction is applied.",
+            "The span excludes embedding, final residual/norm, logits, sampling and host work.",
+            "One-node TP-only validation does not establish EP or multi-node scaling.",
+        ],
+    }
+
+
+def import_graph_capture(path, *, model_config):
+    manifest = json.loads((path / "manifest.json").read_text())
+    if manifest.get("status") != "complete" or manifest.get("engine") != "sglang":
+        raise ValueError("Requires a complete SGLang capture")
+    if Path(manifest["model_path"]).name != Path(model_config.name).name:
+        raise ValueError("Model configuration does not match capture checkpoint")
+    if manifest["topology"] != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1}:
+        raise ValueError("Initial graph scope contract requires one-node TP=8/EP=1/PP=1")
+    expected = expected_scopes(model_layer_kinds(model_config),
+        manifest["options"]["graph_event_layers"], manifest["options"]["graph_event_components"])
+    records = read_batches(path / "graph-batches.jsonl")
+    baseline = [r for r in read_batches(path / "batches.jsonl") if not r.profiled]
+    quality = summarize_profile_perturbation(baseline + records, tensor_parallel_size=8)
+    samples, sources = [], []
+    for rank in range(8):
+        source = path / f"graph-events-rank{rank}.jsonl"
+        rows = [json.loads(line) for line in source.read_text().splitlines() if line.strip()]
+        if any(row["rank"] != rank for row in rows):
+            raise ValueError("Graph sample rank disagrees with source file")
+        samples.extend(rows)
+        sources.append({"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()})
+    return {"schema_version": 1, "manifest": manifest, "sources": sources,
+        "profile_perturbation": quality, **summarize_graph_events(records, samples,
+            tensor_parallel_size=8, expected=expected, quality=quality)}
+
+
+def import_decoder_graph_capture(path, *, model_config):
+    manifest = json.loads((path / "manifest.json").read_text())
+    if (manifest.get("status") != "complete" or manifest.get("engine") != "sglang"
+            or not manifest.get("options", {}).get("graph_decoder_event")):
+        raise ValueError("Requires a complete SGLang decoder graph-event capture")
+    if (Path(manifest["model_path"]).name != Path(model_config.name).name
+            or manifest["topology"] != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1}):
+        raise ValueError("Decoder graph capture model/topology mismatch")
+    records = read_batches(path / "graph-batches.jsonl")
+    baseline = [record for record in read_batches(path / "batches.jsonl")
+                if not record.profiled]
+    quality = summarize_profile_perturbation(
+        baseline + records, tensor_parallel_size=8)
+    samples, sources = [], []
+    for rank in range(8):
+        source = path / f"decoder-events-rank{rank}.jsonl"
+        rows = [json.loads(line) for line in source.read_text().splitlines()
+                if line.strip()]
+        if any(row.get("rank") != rank for row in rows):
+            raise ValueError("Decoder graph sample rank disagrees with source file")
+        samples.extend(rows)
+        sources.append({"file": source.name,
+                        "sha256": hashlib.sha256(source.read_bytes()).hexdigest()})
+    return {
+        "schema_version": 1,
+        "manifest": manifest,
+        "sources": sources,
+        "profile_perturbation": quality,
+        **summarize_decoder_graph_events(
+            records, samples, tensor_parallel_size=8,
+            num_layers=model_config.num_layers, quality=quality),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", required=True, type=Path)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--decoder", action="store_true",
+                        help="Import the whole-decoder event span instead of layer scopes")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    from frontier.profiling.common.model_config import ModelConfig
+    importer = import_decoder_graph_capture if args.decoder else import_graph_capture
+    result = importer(args.capture_dir, model_config=ModelConfig.from_model_name(args.model))
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps({k: v for k, v in result.items()
+                     if k not in {"summaries", "manifest", "sources", "profile_perturbation"}}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/hip_graph_events.py
+++ b/frontier/validation/hip_graph_events.py
@@ -1,0 +1,97 @@
+"""HIP event-record graph nodes, without Kineto or PyTorch external events.
+
+The public HIP graph API lets an event node become the current capture stream's
+dependency. Existing dependencies are preserved, so the next captured kernel
+runs after the event. Handles must outlive every executable graph using them.
+This module imports neither torch nor the HIP library until explicitly used.
+"""
+
+from __future__ import annotations
+
+import ctypes as C
+from ctypes.util import find_library
+import math
+
+
+class HipGraphEvents:
+    def __init__(self, library_path: str | None = None):
+        self.lib = C.CDLL(library_path or find_library("amdhip64") or "libamdhip64.so")
+        pointer = C.c_void_p
+        pointer_array = C.POINTER(pointer)
+        signatures = {
+            "hipStreamGetCaptureInfo_v2": [pointer, C.POINTER(C.c_int), C.POINTER(C.c_ulonglong),
+                C.POINTER(pointer), C.POINTER(pointer_array), C.POINTER(C.c_size_t)],
+            "hipStreamUpdateCaptureDependencies": [pointer, pointer_array, C.c_size_t, C.c_uint],
+            "hipGraphAddEventRecordNode": [C.POINTER(pointer), pointer, pointer_array, C.c_size_t, pointer],
+            "hipEventCreateWithFlags": [C.POINTER(pointer), C.c_uint],
+            "hipEventElapsedTime": [C.POINTER(C.c_float), pointer, pointer],
+            "hipEventDestroy": [pointer],
+        }
+        for name, signature in signatures.items():
+            function = getattr(self.lib, name)
+            function.argtypes, function.restype = signature, C.c_int
+        self.events = []
+
+    def _call(self, name, *args):
+        status = getattr(self.lib, name)(*args)
+        if status:
+            raise RuntimeError(f"{name} failed with HIP status {status}")
+
+    def capture_info(self, stream):
+        status, capture_id = C.c_int(), C.c_ulonglong()
+        graph, dependencies, count = C.c_void_p(), C.POINTER(C.c_void_p)(), C.c_size_t()
+        self._call("hipStreamGetCaptureInfo_v2", C.c_void_p(stream.cuda_stream),
+                   C.byref(status), C.byref(capture_id), C.byref(graph),
+                   C.byref(dependencies), C.byref(count))
+        if status.value == 0:
+            return None
+        if status.value != 1 or not graph.value:
+            raise ValueError("HIP stream capture is invalidated or has no graph")
+        return capture_id.value, graph, dependencies, count.value
+
+    def create_event(self):
+        handle = C.c_void_p()
+        self._call("hipEventCreateWithFlags", C.byref(handle), 0)
+        self.events.append(handle)
+        return _GraphEvent(self, handle)
+
+    def record(self, event, stream):
+        info = self.capture_info(stream)
+        if info is None:
+            raise ValueError("Graph timing nodes require an active capture")
+        capture_id, graph, dependencies, count = info
+        node = C.c_void_p()
+        self._call("hipGraphAddEventRecordNode", C.byref(node), graph, dependencies, count, event)
+        # hipStreamSetCaptureDependencies == 1. The new node already depends on
+        # ALL prior stream sinks; replacing the sink set does not discard work.
+        self._call("hipStreamUpdateCaptureDependencies", C.c_void_p(stream.cuda_stream),
+                   C.byref(node), 1, 1)
+        return capture_id
+
+    def elapsed_ms(self, start, end):
+        result = C.c_float()
+        self._call("hipEventElapsedTime", C.byref(result), start, end)
+        value = float(result.value)
+        if not math.isfinite(value) or value < 0:
+            raise ValueError("Invalid HIP graph event duration")
+        return value
+
+    def close_after_graphs_destroyed(self):
+        """Caller must synchronize and destroy all graphs referencing the events."""
+        while self.events:
+            self._call("hipEventDestroy", self.events[-1])
+            self.events.pop()
+
+
+class _GraphEvent:
+    def __init__(self, api, handle):
+        self.api, self.handle = api, handle
+        self.capture_id = None
+
+    def record(self, stream):
+        self.capture_id = self.api.record(self.handle, stream)
+
+    def elapsed_time(self, other):
+        if self.api is not other.api or self.capture_id is None or self.capture_id != other.capture_id:
+            raise ValueError("Timing endpoints must belong to the same HIP capture")
+        return self.api.elapsed_ms(self.handle, other.handle)

--- a/frontier/validation/operator_trace.py
+++ b/frontier/validation/operator_trace.py
@@ -1,0 +1,284 @@
+"""Strict decoder decomposition for SGLang Qwen3.5-family ROCm traces.
+
+These are *in-situ kernel sums*, not CUDA-event microbenchmarks. Keep fused
+runtime boundaries intact; do not relabel them as unfused Frontier operators.
+Only the single-stream, unfused-collective, separate-shared-expert path is
+supported. An unknown kernel/order fails admission instead of disappearing.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import gzip
+import hashlib
+import json
+import math
+from pathlib import Path
+
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+from frontier.validation.trace import extract_batch_kernels, interval_union_us
+from frontier.validation.report import summarize_profile_perturbation
+from frontier.operators.sglang_family import SGLANG_RUNTIME_CONTRACT
+
+
+CONTRACT = SGLANG_RUNTIME_CONTRACT
+_NORMS = {"_gemma_rmsnorm_kernel", "_gemma_fused_add_rmsnorm_kernel"}
+_REDUCTIONS = ("quickreduce::allreduce", "cross_device_reduce")
+_GEMMS = ("Cijk_Alik_", "_gemm_a16_w16_kernel_")
+_EPILOGUE = "Cijk_SB_"
+_CORE = {
+    "prefill": "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
+    "decode": "fused_recurrent_gated_delta_rule_packed_decode_kernel",
+}
+_GDN_AUX = (
+    "at::native::", "rocprim::", "_causal_conv1d_", "fused_qkv_split_gdn_",
+    "fused_gdn_gating_kernel", "l2norm_fwd_kernel", "chunk_local_cumsum_",
+    "chunk_gated_delta_rule_", "recompute_w_u_fwd_kernel", "chunk_fwd_kernel_o",
+    "fused_recurrent_gated_delta_rule_",
+)
+
+
+def _contains(name, fragments):
+    return any(fragment in name for fragment in fragments)
+
+
+class _Cursor:
+    def __init__(self, events):
+        self.events = events
+        self.index = 0
+        self.layer = -1
+        self.rows = []
+
+    def name(self):
+        return str(self.events[self.index]["name"]) if self.index < len(self.events) else "<end>"
+
+    def take(self, predicate, description):
+        if not predicate(self.name()):
+            raise ValueError(f"Layer {self.layer}, kernel {self.index}: expected {description}, "
+                             f"found {self.name()}")
+        self.index += 1
+
+    def gemm(self):
+        self.take(lambda n: _contains(n, _GEMMS), "dense GEMM")
+        while self.name().startswith(_EPILOGUE):
+            self.index += 1
+
+    def emit(self, component, start):
+        selected = self.events[start:self.index]
+        if not selected:
+            raise ValueError(f"Empty component {component}")
+        self.rows.append({
+            "layer_id": self.layer, "component": component,
+            "first_kernel": start, "end_kernel_exclusive": self.index,
+            "kernel_count": len(selected),
+            "kernel_sum_ms": sum(float(e["dur"]) for e in selected) / 1000,
+            "kernel_span_ms": (float(selected[-1]["ts"]) + float(selected[-1]["dur"])
+                               - float(selected[0]["ts"])) / 1000,
+        })
+
+    def single(self, component, predicate):
+        start = self.index
+        self.take(predicate, component)
+        self.emit(component, start)
+
+    def projection(self, component):
+        start = self.index
+        self.gemm()
+        self.emit(component, start)
+
+
+def decompose_decoder(events: list[dict], *, phase: str, layer_kinds: list[str]) -> dict:
+    """Partition every decoder kernel exactly once, preserving layer identity.
+
+    ``layer_kinds`` must come from the model config, never inferred by counting
+    the same trace being validated. Preparation/embedding/logits/sampling are
+    explicitly outside this decoder boundary and are not treated as residual
+    model overhead or used to correct a prediction.
+    """
+    if phase not in _CORE or not layer_kinds or set(layer_kinds) - {"gdn", "attention"}:
+        raise ValueError("Expected prefill/decode and an explicit hybrid layer schedule")
+    if not events:
+        raise ValueError("No kernel events")
+    streams = {(e.get("args", {}).get("device", e.get("pid")),
+                e.get("args", {}).get("stream")) for e in events}
+    if len(streams) != 1 or next(iter(streams))[1] is None:
+        raise ValueError("Operator decomposition requires one identified GPU stream")
+    previous_start = -math.inf
+    for event in events:
+        ts, dur = float(event["ts"]), float(event["dur"])
+        if (event.get("cat") != "kernel" or event.get("ph") != "X" or
+                not math.isfinite(ts) or not math.isfinite(dur) or dur <= 0):
+            raise ValueError("Invalid GPU kernel event")
+        if ts < previous_start:
+            raise ValueError("Out-of-order kernels cannot use serial decomposition")
+        previous_start = ts
+
+    cursor = _Cursor(events)
+    # The initial embedding and its all-reduce must precede the first norm.
+    embedding = [i for i, e in enumerate(events)
+                 if e["name"] == "_vocab_parallel_embedding_kernel"]
+    if len(embedding) != 1:
+        raise ValueError("Expected exactly one embedding kernel")
+    cursor.index = embedding[0] + 1
+    cursor.take(lambda n: _contains(n, _REDUCTIONS), "embedding TP all-reduce")
+    decoder_start = cursor.index
+    for layer, kind in enumerate(layer_kinds):
+        cursor.layer = layer
+        cursor.single("input_layernorm", lambda n: n in _NORMS)
+        if kind == "gdn":
+            start = cursor.index
+            cursor.gemm()
+            cursor.gemm()
+            cursor.emit("gdn_input_projections", start)
+            start = cursor.index
+            anchors = 0
+            while cursor.name() != "_layer_norm_fwd_1pass_kernel":
+                anchors += _CORE[phase] in cursor.name()
+                cursor.take(lambda n: _contains(n, _GDN_AUX), "GDN core/transform kernel")
+            if anchors != 1:
+                raise ValueError(f"Layer {layer}: expected one {phase} GDN core, found {anchors}")
+            cursor.emit(f"gdn_core_{phase}", start)
+            start = cursor.index
+            cursor.take(lambda n: n == "_layer_norm_fwd_1pass_kernel", "GDN output norm")
+            cursor.gemm()
+            cursor.emit("gdn_output_projection", start)
+        else:
+            start = cursor.index
+            cursor.gemm()
+            cursor.take(lambda n: n == "_fused_qk_gemma_rmsnorm_gate_kernel", "fused QK norm/gate")
+            cursor.emit("attn_pre_proj_qknorm", start)
+            cursor.single("attn_rope", lambda n: n == "_triton_mrope_forward_fused")
+            cursor.single("attn_kv_cache_write", lambda n: "sglang::store_kvcache<" in n)
+            start = cursor.index
+            if phase == "prefill":
+                cursor.take(lambda n: "FmhaBatchPrefillWithPagedKVCacheKernel" in n,
+                            "AITER prefill attention")
+            else:
+                cursor.take(lambda n: "paged_attention_ll4mi_QKV_mfma16_kernel" in n,
+                            "AITER decode attention")
+                cursor.take(lambda n: "paged_attention_ll4mi_reduce_kernel" in n,
+                            "AITER decode split reduction")
+            cursor.emit(f"attn_{phase}", start)
+            start = cursor.index
+            cursor.take(lambda n: n == "_fused_sigmoid_mul_kernel", "attention output gate")
+            cursor.gemm()
+            cursor.emit("attn_post_proj_gate", start)
+        cursor.single("attention_tp_allreduce", lambda n: _contains(n, _REDUCTIONS))
+        cursor.single("post_attention_layernorm", lambda n: n == "_gemma_fused_add_rmsnorm_kernel")
+        cursor.projection("shared_expert_gate_up")
+        cursor.single("shared_expert_activation", lambda n: "act_and_mul_kernel" in n)
+        cursor.projection("shared_expert_down")
+        cursor.projection("moe_router_linear")
+        cursor.single("moe_routing_topk", lambda n: "topkGatingSoftmax" in n)
+        start = cursor.index
+        while "aiter::opus_moe_sorting_entry" in cursor.name():
+            cursor.index += 1
+        cursor.emit("moe_sorting", start)
+        start = cursor.index
+        for stage in (1, 2):
+            quant_start = cursor.index
+            while _contains(cursor.name(), ("dynamic_per_group_scaled_quant_kernel",
+                                            "mxfp4_moe_sort_kernel", "fused_mx_quant_moe_sort_kernel")):
+                cursor.index += 1
+            if cursor.index == quant_start:
+                raise ValueError(f"Layer {layer}: missing stage {stage} MXFP4 activation quantization")
+            cursor.take(lambda n: n.startswith(f"mfma_moe{stage}_"), f"MXFP4 MoE GEMM {stage}")
+        cursor.emit("moe_experts_quant_gemm_combine", start)
+        cursor.single("shared_gate_sigmoid_mul_add", lambda n: n == "_fused_gate_sigmoid_mul_add_kernel")
+        cursor.single("mlp_tp_allreduce", lambda n: _contains(n, _REDUCTIONS))
+
+    decoder_end = cursor.index
+    cursor.take(lambda n: n == "_gemma_fused_add_rmsnorm_kernel", "final model norm")
+    # Additional decoder work beyond the configured schedule must not silently
+    # become 'outside decoder' work.
+    if any(e["name"] in _NORMS or "topkGatingSoftmax" in e["name"] or
+           _contains(e["name"], tuple(_CORE.values())) for e in events[cursor.index:]):
+        raise ValueError("Unexpected decoder kernels after the configured last layer")
+    selected = events[decoder_start:decoder_end]
+    totals = defaultdict(float)
+    for row in cursor.rows:
+        totals[row["component"]] += row["kernel_sum_ms"]
+    decoder_sum = sum(totals.values())
+    busy_ms = interval_union_us(selected) / 1000
+    return {
+        "contract": CONTRACT, "measurement_type": "KERNEL_ONLY",
+        "rank_aggregation": "single_rank_in_situ", "phase": phase,
+        "num_layers": len(layer_kinds), "components": cursor.rows,
+        "component_totals_ms": dict(totals),
+        "decoder_kernel_sum_ms": decoder_sum,
+        "decoder_gpu_busy_ms": busy_ms,
+        "decoder_kernel_overlap_ms": max(0, decoder_sum - busy_ms),
+        "decoder_gpu_span_ms": (float(selected[-1]["ts"]) + float(selected[-1]["dur"])
+                                - float(selected[0]["ts"])) / 1000,
+        "decoder_kernel_count": len(selected),
+        "outside_decoder_kernel_count": len(events) - len(selected),
+        "outside_decoder_kernel_sum_ms": sum(float(e["dur"]) for e in
+            events[:decoder_start] + events[decoder_end:]) / 1000,
+        "boundary_note": "Outside decoder includes prepare, embedding, final norm, logits and "
+                         "sampling; it is not a measured full-forward residual.",
+    }
+
+
+def model_layer_kinds(model_config) -> list[str]:
+    if model_config.model_type != "qwen3_5_moe_text":
+        raise ValueError("Trace contract requires the Qwen3.5-family hybrid MoE architecture")
+    return ["gdn" if model_config.is_gdn_layer(layer) else "attention"
+            for layer in range(model_config.num_layers)]
+
+
+def import_capture(capture_dir: Path, *, model_config, rank: int) -> dict:
+    manifest = json.loads((capture_dir / "manifest.json").read_text())
+    if manifest.get("status") != "complete" or manifest.get("engine") != "sglang":
+        raise ValueError("Requires a complete SGLang capture")
+    topology = manifest["topology"]
+    if (topology != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1} or rank not in range(8)):
+        raise ValueError("This trace contract requires one-node TP=8, EP=1, PP=1")
+    if Path(manifest["model_path"]).name != Path(model_config.name).name:
+        raise ValueError("Model configuration does not match capture checkpoint")
+    records = read_batches(capture_dir / "batches.jsonl")
+    validate_rank_cohorts(records, tensor_parallel_size=topology["tp"])
+    ledger = {r.batch_id: r for r in records if r.rank == rank and r.profiled}
+    rows, seen, sources = [], set(), []
+    for path in sorted(capture_dir.glob(f"*-rank{rank}.trace.json.gz")):
+        with gzip.open(path, "rt") as stream:
+            batches = extract_batch_kernels(json.load(stream))
+        sources.append({"file": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()})
+        for batch_id, kernels in batches.items():
+            if batch_id not in ledger or batch_id in seen:
+                raise ValueError(f"Unexpected or duplicate profiled batch {batch_id}")
+            record = ledger[batch_id]
+            seen.add(batch_id)
+            rows.append({"batch_id": batch_id, "rank": rank, "shape": record.to_dict(),
+                         **decompose_decoder(kernels, phase=record.phase,
+                                             layer_kinds=model_layer_kinds(model_config))})
+    if not rows or seen != set(ledger):
+        raise ValueError("Trace coverage does not match all profiled rank ledger rows")
+    return {"schema_version": 1, "contract": CONTRACT, "manifest": manifest,
+            "trace_sources": sources, "batches": rows,
+            "profile_perturbation": summarize_profile_perturbation(
+                records, tensor_parallel_size=topology["tp"]),
+            "limitations": ["Not CUDA-event timings; no native CSV export by relabeling.",
+                            "Collectives include rank skew; not isolated bandwidth measurements.",
+                            "No expert-routing load vectors; no EP or multi-node extrapolation."]}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", required=True, type=Path)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    from frontier.profiling.common.model_config import ModelConfig
+
+    result = import_capture(args.capture_dir, model_config=ModelConfig.from_model_name(args.model),
+                            rank=args.rank)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps({"batches": len(result["batches"]), "output": str(args.output)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/primitive_calibration.py
+++ b/frontier/validation/primitive_calibration.py
@@ -1,0 +1,35 @@
+"""Report held-out primitive calibration without using full-forward timings."""
+
+import argparse
+import json
+from pathlib import Path
+
+from frontier.runtime_cost.primitives import PrimitiveCalibration
+from frontier.runtime_cost.sglang import RuntimeIdentity
+
+
+def read_profiles(path):
+    return [json.loads(p.read_text()) for p in sorted(Path(path).glob("rank*.json"))]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--calibration-dir", type=Path, required=True)
+    parser.add_argument("--validation-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    payloads = read_profiles(args.calibration_dir)
+    if not payloads:
+        raise ValueError("No calibration rank profiles")
+    identity = RuntimeIdentity(**payloads[0]["identity"])
+    calibration = PrimitiveCalibration(payloads, identity=identity)
+    report = calibration.validate(read_profiles(args.validation_dir))
+    report["calibration_rows"] = calibration.rows
+    with args.output.open("x") as stream:
+        json.dump(report, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps({k: report[k] for k in ("all_primitives_passed", "calibration_quality", "validation")}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/replay.py
+++ b/frontier/validation/replay.py
@@ -1,0 +1,175 @@
+"""Replay captured batches through Frontier's native execution-time predictor.
+
+Pass normal frontier.main arguments after --. Observations are used only after
+prediction; missing profiles and dummy mode cannot yield numerical parity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+import sys
+from pathlib import Path
+
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+
+
+def replay_batches(records, predictor, *, model_config, tensor_parallel_size: int) -> list[dict]:
+    from frontier.types import ClusterType
+
+    if getattr(predictor, "_enable_dummy_mode", False):
+        raise ValueError("Dummy predictor output is not numerical correlation evidence")
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=tensor_parallel_size)
+    rows = []
+    for batch_id, cohort in cohorts.items():
+        record = cohort[0]
+        if record.profiled:
+            continue
+        if any(r.forward_gpu_ms is None for r in cohort):
+            raise ValueError(f"Missing forward GPU timing for {batch_id}")
+        batch = record.to_frontier_batch(is_moe=model_config.is_moe)
+        execution = predictor.predict_stage_execution_time(
+            batch, stage_id=0, cluster_type=ClusterType.MONOLITHIC,
+            num_layers=model_config.num_layers, layer_id=0,
+        )
+        predicted = float(execution.model_time_ms)
+        if not math.isfinite(predicted) or predicted <= 0:
+            raise ValueError(f"Invalid prediction for {batch_id}: {predicted}")
+        observed = max(r.forward_gpu_ms for r in cohort)
+        rows.append({
+            "batch_id": batch_id, "phase": record.phase,
+            "batch_size": len(record.request_ids),
+            "query_tokens": sum(record.query_lens),
+            "max_context": max(record.context_lens),
+            "graph_mode": record.graph_mode, "capture_size": record.capture_size,
+            "repetition": record.repetition, "step": record.step,
+            "observed_forward_gpu_ms": observed,
+            "predicted_model_ms": predicted,
+            "signed_error_pct": 100 * (predicted / observed - 1),
+            "absolute_error_pct": 100 * abs(predicted / observed - 1),
+        })
+    if not rows:
+        raise ValueError("No unprofiled timed batches remain for validation")
+    return rows
+
+
+def summarize_errors(rows: list[dict]) -> dict:
+    def summary(values):
+        errors = sorted(row["absolute_error_pct"] for row in values)
+        return {"batches": len(values), "mape_pct": statistics.mean(errors),
+                "median_absolute_error_pct": statistics.median(errors),
+                "p90_absolute_error_pct": errors[math.ceil(0.9 * len(errors)) - 1],
+                "max_absolute_error_pct": max(errors)}
+    if not rows:
+        raise ValueError("Cannot summarize empty predictions")
+    return {"all": summary(rows), "by_phase": {
+        phase: summary([row for row in rows if row["phase"] == phase])
+        for phase in sorted({row["phase"] for row in rows})
+    }, "scope": "locked static batches; no serving scheduler/TTFT/throughput validation",
+        "boundary_note": "Native model_time covers decoder blocks. Captured forward GPU time "
+                         "also includes embedding/final norm/logits work. Profile and account for "
+                         "those boundaries before interpreting this diagnostic as full-forward parity."}
+
+
+def profile_file_audit(config, records) -> dict:
+    """Report missing inputs before predictor initialization/training starts."""
+    replica = config.cluster_config.replica_config
+    predictor = config.cluster_config.execution_time_predictor_config
+    if predictor.enable_dummy_mode:
+        raise ValueError("Numerical replay requires dummy mode disabled")
+    attributes = []
+    for kernel_only in (False, True):
+        active = any((r.graph_mode == "FULL") == kernel_only for r in records if not r.profiled)
+        if not active:
+            continue
+        attributes += (["linear_op_kernel_only_input_file", "atten_kernel_only_input_file"]
+                       if kernel_only else ["linear_op_input_file", "atten_input_file"])
+        if replica.model_config.is_moe:
+            attributes.append("moe_kernel_only_input_file" if kernel_only else "moe_input_file")
+        if replica.model_config.get_num_gdn_layers():
+            attributes.append("gdn_kernel_only_input_file" if kernel_only else "gdn_input_file")
+    files = []
+    for attribute in attributes:
+        value = getattr(predictor, attribute)
+        path = Path(value.replace("{DEVICE}", replica.device)
+                    .replace("{MODEL}", replica.model_config.get_name())
+                    .replace("{NETWORK_DEVICE}", replica.network_device))
+        files.append({"input": attribute, "path": str(path), "exists": path.is_file()})
+    return {"complete": all(row["exists"] for row in files), "compute_profiles": files,
+            "note": "Existence only; predictor subsequently enforces schema/runtime/TP contracts. "
+                    "Communication and CPU profiles are validated by their native backends."}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ledger", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--audit-only", action="store_true")
+    args, remaining = parser.parse_known_args()
+    if not remaining or remaining[0] != "--":
+        parser.error("Pass normal Frontier configuration arguments after --")
+    records = read_batches(args.ledger)
+    manifest = json.loads(Path(args.manifest).read_text())
+    if manifest.get("status") != "complete":
+        raise ValueError("Capture manifest is not complete")
+    from frontier.config import SimulationConfig
+    original_argv = sys.argv
+    try:
+        sys.argv = [sys.argv[0], *remaining[1:]]
+        config = SimulationConfig.create_from_cli_args()
+    finally:
+        sys.argv = original_argv
+    replica = config.cluster_config.replica_config
+    topology = manifest["topology"]
+    if (config.sys_arch != "co-location" or config.cluster_config.num_replicas != 1 or
+            replica.num_pipeline_stages != 1 or replica.moe_expert_parallel_size != 1 or
+            topology != {"tp": replica.attn_tensor_parallel_size, "ep": 1, "pp": 1, "nodes": 1} or
+            replica.moe_tensor_parallel_size != replica.attn_tensor_parallel_size):
+        raise ValueError("Replay configuration must match the captured one-node TP-only topology")
+    if Path(manifest["model_path"]).name != Path(replica.model_name).name:
+        raise ValueError("Replay model name does not match captured checkpoint")
+    if replica.speculative_decoding_config.enabled:
+        raise ValueError("Captured non-speculative batches cannot use a speculative predictor")
+    if config.cluster_config.replica_scheduler_config.block_size != manifest["server_args"]["page_size"]:
+        raise ValueError("Replay block size does not match captured page size")
+    for device in manifest.get("devices", []):
+        if replica.device.lower() not in device["device_name"].lower().replace(" ", ""):
+            raise ValueError("Replay device does not match captured GPU identity")
+    validate_rank_cohorts(records, tensor_parallel_size=topology["tp"])
+    output = Path(args.output_dir)
+    output.mkdir(parents=True, exist_ok=False)
+    audit = profile_file_audit(config, records)
+    (output / "profile-audit.json").write_text(json.dumps(audit, indent=2) + "\n")
+    if args.audit_only:
+        print(json.dumps(audit, indent=2))
+        return
+    if not audit["complete"]:
+        raise ValueError(f"Missing required compute profiles; see {output / 'profile-audit.json'}")
+    from frontier.entities.cluster import Cluster
+    from frontier.execution_time_predictor import ExecutionTimePredictorRegistry
+    from frontier.types import ClusterType
+    cluster = Cluster(config.cluster_config, config.metrics_config, config.request_generator_config)
+    predictor_config = config.cluster_config.execution_time_predictor_config
+    predictor = ExecutionTimePredictorRegistry.get(
+        predictor_config.get_type(), predictor_config, replica,
+        config.cluster_config.replica_scheduler_config, config.metrics_config,
+        cluster_config=config.cluster_config, cluster_type=ClusterType.MONOLITHIC,
+        cc_backend=cluster.cc_backend,
+    )
+    rows = replay_batches(records, predictor, model_config=replica.model_config,
+                          tensor_parallel_size=topology["tp"])
+    with (output / "correlation.csv").open("x", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    summary = summarize_errors(rows)
+    (output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/report.py
+++ b/frontier/validation/report.py
@@ -1,0 +1,166 @@
+"""Summarize unprofiled TP timing samples and their repeatability diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+
+
+def summarize_output_checks(checks, *, fixed_inputs=False):
+    if not checks or any(row["output_tokens"] <= 0 for row in checks):
+        raise ValueError("Output diagnostics require nonempty token counts")
+    return {
+        "tp_output_agreement": all(row["tp_output_agreement"] for row in checks),
+        "repetitions_with_changed_outputs": sum(row["different_from_first_repeat"] > 0 for row in checks),
+        "max_changed_output_fraction": max(row["different_from_first_repeat"] / row["output_tokens"]
+                                           for row in checks),
+        "fixed_decode_inputs": fixed_inputs,
+        "note": "Finite prefill logits and cross-rank output agreement are checked. Generated output "
+                "equality is a diagnostic, not numerical-accuracy validation against a reference model. "
+                "With fixed inputs, output differences do not feed back into later decode inputs.",
+    }
+
+
+def summarize_profile_perturbation(records, *, tensor_parallel_size: int,
+                                   max_absolute_change_pct: float = 5.0) -> dict:
+    """Compare traced forwards to unprofiled repeats of the *same* step/shape.
+
+    This is a rejection diagnostic, not a bias correction. Never compare an
+    early traced decode to a later steady-state median or subtract the observed
+    perturbation from individual operators.
+    """
+    if not math.isfinite(max_absolute_change_pct) or max_absolute_change_pct < 0:
+        raise ValueError("Profile perturbation threshold must be finite and nonnegative")
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=tensor_parallel_size)
+    baseline, profiled = defaultdict(list), []
+    for cohort in cohorts.values():
+        r = cohort[0]
+        if any(item.forward_gpu_ms is None for item in cohort):
+            raise ValueError("Profile quality check requires every rank's forward GPU timing")
+        key = (r.phase, r.step, len(r.request_ids), r.query_lens, r.context_lens,
+               r.prefill_mask, r.graph_mode, r.capture_size, r.decode_input_sha256)
+        elapsed = max(item.forward_gpu_ms for item in cohort)
+        if r.profiled:
+            profiled.append((r, key, elapsed))
+        else:
+            baseline[key].append(elapsed)
+    rows = []
+    for record, key, elapsed in profiled:
+        values = baseline.get(key)
+        if not values:
+            raise ValueError(f"No matching unprofiled step/shape for {record.batch_id}")
+        median = statistics.median(values)
+        change = 100 * (elapsed / median - 1)
+        rows.append({"batch_id": record.batch_id, "phase": record.phase,
+                     "step": record.step, "baseline_repetitions": len(values),
+                     "fixed_decode_inputs": record.decode_input_sha256 is not None,
+                     "baseline_forward_gpu_median_ms": median,
+                     "baseline_forward_gpu_cv_pct": 100 * statistics.pstdev(values) / statistics.mean(values),
+                     "profiled_forward_gpu_ms": elapsed,
+                     "signed_change_pct": change,
+                     "passes_latency_check": abs(change) <= max_absolute_change_pct})
+    return {"threshold_absolute_change_pct": max_absolute_change_pct,
+            "rank_aggregation": "max per-rank forward GPU duration",
+            "batches": rows, "has_profiled_samples": bool(rows),
+            "all_pass_latency_check": bool(rows) and all(r["passes_latency_check"] for r in rows),
+            "note": "Reject materially perturbed samples for full-model calibration. Passing is "
+                    "not proof of unbiased per-operator timing. No correction factor is applied; "
+                    "routing differences and run-to-run noise can also contribute."}
+
+
+def summarize_capture(path: Path, *, skip_decode_steps: int = 4) -> dict:
+    if skip_decode_steps < 0:
+        raise ValueError("skip_decode_steps must be nonnegative")
+    manifest = json.loads((path / "manifest.json").read_text())
+    if manifest.get("status") != "complete":
+        raise ValueError("Capture must be complete before summarizing")
+    records = read_batches(path / "batches.jsonl")
+    cohorts = validate_rank_cohorts(records,
+                                   tensor_parallel_size=manifest["topology"]["tp"])
+    groups = defaultdict(lambda: defaultdict(list))
+    for cohort in cohorts.values():
+        record = cohort[0]
+        if record.profiled or (record.phase == "decode" and record.step <= skip_decode_steps):
+            continue
+        # The static runner records step 0 as prefill and step 1 as the first
+        # decode with context=input_len. Preserve each input length in a sweep.
+        input_len = (max(record.query_lens) if record.phase == "prefill"
+                     else max(record.context_lens) - record.step + 1)
+        key = (record.phase, len(record.request_ids), input_len, record.capture_size)
+        if any(r.forward_gpu_ms is None or r.step_wall_ms is None for r in cohort):
+            raise ValueError("Timing summary requires observed GPU and wall times on every rank")
+        groups[key][record.repetition].append((max(r.forward_gpu_ms for r in cohort),
+                                               max(r.step_wall_ms for r in cohort)))
+    if not groups:
+        raise ValueError("No timing samples remain after warmup-step exclusion")
+    rows = []
+    for (phase, bs, length, capture), repetitions in sorted(groups.items()):
+        gpu = [statistics.median(v[0] for v in values) for values in repetitions.values()]
+        wall = [statistics.median(v[1] for v in values) for values in repetitions.values()]
+        rows.append({"phase": phase, "batch_size": bs, "input_len": length,
+                     "capture_size": capture, "repetitions": len(repetitions),
+                     "samples": sum(len(v) for v in repetitions.values()),
+                     "forward_gpu_median_ms": statistics.median(gpu),
+                     "forward_gpu_cv_pct": 100 * statistics.pstdev(gpu) / statistics.mean(gpu),
+                     "step_wall_median_ms": statistics.median(wall),
+                     "step_wall_cv_pct": 100 * statistics.pstdev(wall) / statistics.mean(wall)})
+    checks = json.loads((path / "output-checks-rank0.json").read_text())
+    operator_quality = None
+    if (path / "operator-batches.jsonl").exists():
+        operator_quality = summarize_profile_perturbation(
+            [r for r in records if not r.profiled] + read_batches(path / "operator-batches.jsonl"),
+            tensor_parallel_size=manifest["topology"]["tp"])
+    graph_quality = None
+    graph_outputs = None
+    routing_quality = None
+    if (path / "routing-batches.jsonl").exists():
+        routing_quality = summarize_profile_perturbation(
+            [r for r in records if not r.profiled] + read_batches(path / "routing-batches.jsonl"),
+            tensor_parallel_size=manifest["topology"]["tp"])
+    if (path / "graph-batches.jsonl").exists():
+        graph_quality = summarize_profile_perturbation(
+            [r for r in records if not r.profiled] + read_batches(path / "graph-batches.jsonl"),
+            tensor_parallel_size=manifest["topology"]["tp"])
+        graph_checks = json.loads((path / "graph-output-checks-rank0.json").read_text())
+        graph_outputs = summarize_output_checks(graph_checks,
+            fixed_inputs=manifest["options"].get("freeze_decode_inputs", False))
+        baseline_digests = defaultdict(set)
+        for row in checks:
+            baseline_digests[(row["batch_size"], row["input_len"])].add(row["output_sha256"])
+        graph_outputs["repetitions_matching_any_baseline_output_digest"] = sum(
+            row["output_sha256"] in baseline_digests[(row["batch_size"], row["input_len"])]
+            for row in graph_checks)
+    return {"scope": "static TP batches; no request-serving metrics",
+            "excluded_initial_decode_steps": skip_decode_steps,
+            "timings": rows,
+            "profile_perturbation": summarize_profile_perturbation(
+                records, tensor_parallel_size=manifest["topology"]["tp"]),
+            "operator_event_perturbation": operator_quality,
+            "graph_event_perturbation": graph_quality,
+            "routing_perturbation": routing_quality,
+            "graph_output_repeatability": graph_outputs,
+            "output_repeatability": summarize_output_checks(checks,
+                fixed_inputs=manifest.get("options", {}).get("freeze_decode_inputs", False))}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, required=True)
+    parser.add_argument("--skip-decode-steps", type=int, default=4)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = summarize_capture(args.capture_dir, skip_decode_steps=args.skip_decode_steps)
+    with args.output.open("x") as stream:
+        json.dump(report, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/routed_primitive_calibration.py
+++ b/frontier/validation/routed_primitive_calibration.py
@@ -1,0 +1,45 @@
+"""Validate exact routed primitive profiles and emit an exact cost table."""
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+from frontier.profiling.runtime.sglang_moe import MOE_ROUTED_PRIMITIVES
+from frontier.profiling.runtime.sglang_moe_routes import read_routed_queries
+from frontier.runtime_cost.routed_primitives import ExactRoutedCalibration
+from frontier.runtime_cost.sglang import ExactRuntimeCostTable, RuntimeIdentity
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile-dir", type=Path, required=True)
+    parser.add_argument("--query-plan", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--table", type=Path, required=True)
+    parser.add_argument("--primitives", choices=MOE_ROUTED_PRIMITIVES, nargs="+",
+                        default=list(MOE_ROUTED_PRIMITIVES))
+    args = parser.parse_args()
+    payloads = [json.loads(path.read_text())
+                for path in sorted(args.profile_dir.glob("rank*.json"))]
+    if not payloads:
+        raise ValueError("No exact routed rank profiles")
+    identity = RuntimeIdentity(**payloads[0]["identity"])
+    calibration = ExactRoutedCalibration(payloads, identity=identity)
+    report = calibration.report()
+    if not report["all_queries_passed"]:
+        raise ValueError("One or more exact routed queries failed quality admission")
+    queries = read_routed_queries(args.query_plan, identity, tuple(args.primitives))
+    rows = [{"query": asdict(query), "estimate": asdict(calibration(query))}
+            for query in queries]
+    table = {"schema_version": 1, "identity": asdict(identity), "rows": rows}
+    ExactRuntimeCostTable(table, identity=identity)
+    for path, payload in ((args.report, report), (args.table, table)):
+        with path.open("x") as stream:
+            json.dump(payload, stream, indent=2)
+            stream.write("\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/routing.py
+++ b/frontier/validation/routing.py
@@ -1,0 +1,158 @@
+"""Observed top-k selections; logical and graph-padding assignments stay separate."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class RoutingRecord:
+    batch_id: str
+    rank: int
+    layer_id: int
+    capture_id: int
+    logical_size: int
+    physical_size: int
+    num_experts: int
+    top_k: int
+    logical_expert_counts: tuple[int, ...]
+    padding_expert_counts: tuple[int, ...]
+    logical_assignment_sha256: str
+    logical_expert_set_sha256: str
+    padding_assignment_sha256: str
+    logical_weights_sha256: str
+    padding_weights_sha256: str
+    logical_positive_weight_slots: int
+    padding_positive_weight_slots: int
+    invalid_padding_slots: int
+    schema_version: int = 1
+
+    def __post_init__(self):
+        if type(self.schema_version) is not int or self.schema_version != 1:
+            raise ValueError("Unsupported routing schema")
+        if not isinstance(self.batch_id, str) or not self.batch_id:
+            raise ValueError("Routing batch_id must be nonempty")
+        for name in ("rank", "layer_id", "capture_id", "logical_size", "physical_size",
+                     "num_experts", "top_k", "logical_positive_weight_slots",
+                     "padding_positive_weight_slots", "invalid_padding_slots"):
+            value = getattr(self, name)
+            minimum = 1 if name in {"capture_id", "logical_size", "physical_size", "num_experts", "top_k"} else 0
+            if type(value) is not int or value < minimum:
+                raise ValueError(f"Invalid integer routing field {name}")
+        if self.physical_size < self.logical_size or self.top_k > self.num_experts:
+            raise ValueError("Invalid logical/physical routing shape or top-k")
+        for name in ("logical_expert_counts", "padding_expert_counts"):
+            counts = getattr(self, name)
+            if len(counts) != self.num_experts or any(type(v) is not int or v < 0 for v in counts):
+                raise ValueError("Expert counts require one nonnegative integer per expert")
+        if (sum(self.logical_expert_counts) != self.logical_size * self.top_k
+                or max(self.logical_expert_counts) > self.logical_size):
+            raise ValueError("Logical counts disagree with distinct top-k selections")
+        if (sum(self.padding_expert_counts) + self.invalid_padding_slots
+                != (self.physical_size - self.logical_size) * self.top_k):
+            raise ValueError("Padding counts disagree with graph lanes")
+        if (self.logical_positive_weight_slots > sum(self.logical_expert_counts)
+                or self.padding_positive_weight_slots > sum(self.padding_expert_counts)):
+            raise ValueError("Positive weights exceed selected expert slots")
+        for name in ("logical_assignment_sha256", "logical_expert_set_sha256", "padding_assignment_sha256",
+                     "logical_weights_sha256", "padding_weights_sha256"):
+            value = getattr(self, name)
+            if (not isinstance(value, str) or len(value) != 64
+                    or any(c not in "0123456789abcdef" for c in value)):
+                raise ValueError("Invalid routing digest")
+
+    def to_dict(self):
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value):
+        fields = dict(value)
+        for name in ("logical_expert_counts", "padding_expert_counts"):
+            fields[name] = tuple(fields[name])
+        return cls(**fields)
+
+    def to_lane_workload(self, *, include_padding: bool):
+        """Use Frontier's canonical EP=1 descriptor, never invent EP placement."""
+        from frontier.moe_ep_workload import split_global_expert_tokens_into_lanes
+        counts = [a + (b if include_padding else 0)
+                  for a, b in zip(self.logical_expert_counts, self.padding_expert_counts)]
+        return split_global_expert_tokens_into_lanes(dict(enumerate(counts)),
+            total_expert_num=self.num_experts, moe_expert_parallel_size=1,
+            router_topk=self.top_k)[0]
+
+    def native_load_features(self, *, model_config, include_padding: bool):
+        """Canonical predictor features only; no latency fit or CSV admission."""
+        from frontier.moe_load_imbalance import MoELoadImbalanceInput
+        if (model_config.num_experts != self.num_experts
+                or model_config.num_experts_per_tok != self.top_k):
+            raise ValueError("Routing vector does not match model experts/top-k")
+        lane = self.to_lane_workload(include_padding=include_padding)
+        return MoELoadImbalanceInput(
+            num_tokens=self.physical_size if include_padding else self.logical_size,
+            num_experts_per_device=lane.local_expert_width,
+            hidden_dim=model_config.embedding_dim, expert_hidden_dim=model_config.mlp_hidden_dim,
+            router_topk=self.top_k, expert_token_counts=list(lane.local_token_counts),
+            load_distribution="runtime").to_features_dict()
+
+
+def snapshot_routing(ids, weights, *, batch_id, rank, layer_id, capture_id,
+                     logical_size, num_experts, top_k):
+    """Validate a CPU snapshot of the final top-k output passed to the experts.
+
+    Zero-weight valid IDs remain counted: weighting alone does not establish
+    whether sorting/GEMM skips them. Padding may contain sentinel -1 with zero
+    weight, but live tokens must select distinct valid experts.
+    """
+    ids, weights = np.asarray(ids), np.asarray(weights)
+    if (ids.ndim != 2 or ids.dtype.kind not in "iu" or weights.dtype.kind != "f"
+            or weights.shape != ids.shape or ids.shape[1] != top_k
+            or not 0 < logical_size <= ids.shape[0] or not 0 < top_k <= num_experts):
+        raise ValueError("Invalid top-k tensor shape, dtype or logical size")
+    if (not np.isfinite(weights).all() or (weights < 0).any()
+            or (ids >= num_experts).any() or (ids < -1).any()
+            or (ids[:logical_size] < 0).any() or (weights[ids == -1] != 0).any()):
+        raise ValueError("Invalid expert IDs or routing weights")
+    logical_sorted = np.sort(ids[:logical_size], axis=1)
+    if (np.diff(logical_sorted, axis=1) == 0).any():
+        raise ValueError("Live tokens must select distinct experts")
+    def digest(value, dtype):
+        return hashlib.sha256(np.asarray(value, dtype=dtype).tobytes(order="C")).hexdigest()
+    def counts(value):
+        return tuple(int(v) for v in np.bincount(value[value >= 0].astype(np.int64), minlength=num_experts))
+    return RoutingRecord(batch_id=batch_id, rank=rank, layer_id=layer_id, capture_id=capture_id,
+        logical_size=logical_size, physical_size=ids.shape[0], num_experts=num_experts, top_k=top_k,
+        logical_expert_counts=counts(ids[:logical_size]), padding_expert_counts=counts(ids[logical_size:]),
+        logical_assignment_sha256=digest(ids[:logical_size], "<i4"),
+        logical_expert_set_sha256=digest(logical_sorted, "<i4"),
+        padding_assignment_sha256=digest(ids[logical_size:], "<i4"),
+        logical_weights_sha256=digest(weights[:logical_size], "<f4"),
+        padding_weights_sha256=digest(weights[logical_size:], "<f4"),
+        logical_positive_weight_slots=int((weights[:logical_size] > 0).sum()),
+        padding_positive_weight_slots=int((weights[logical_size:] > 0).sum()),
+        invalid_padding_slots=int((ids[logical_size:] == -1).sum()))
+
+
+def read_routing(path: str | Path):
+    seen = set()
+    opener = gzip.open if str(path).endswith(".gz") else open
+    with opener(path, "rt") as stream:
+        for line_number, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            try:
+                record = RoutingRecord.from_dict(json.loads(line))
+                key = record.batch_id, record.rank, record.layer_id
+                if key in seen:
+                    raise ValueError("Duplicate routing batch/rank/layer")
+                seen.add(key)
+                yield record
+            except (ValueError, TypeError, KeyError) as exc:
+                raise ValueError(f"{path}:{line_number}: {exc}") from exc
+    if not seen:
+        raise ValueError(f"Empty routing ledger: {path}")

--- a/frontier/validation/routing_report.py
+++ b/frontier/validation/routing_report.py
@@ -1,0 +1,192 @@
+"""Audit per-layer expert loads, TP agreement and fixed-input routing stability."""
+
+import argparse
+from collections import defaultdict
+import gzip
+import hashlib
+import json
+from pathlib import Path
+import statistics
+
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+from frontier.validation.report import summarize_profile_perturbation
+from frontier.validation.routing import read_routing
+
+
+def graph_routing_enabled(options):
+    """Graph routing exists with either layer scopes or the decoder-wide scope."""
+    return bool(options.get("graph_event_layers") or options.get("graph_decoder_event"))
+
+
+def audit_routing(records, routes, *, layer_ids, tensor_parallel_size, model_config, feature_writer=None):
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=tensor_parallel_size)
+    ledger = {(r.batch_id, r.rank): r for r in records if r.phase == "decode"}
+    if not ledger or any(not r.profiled or r.graph_mode != "FULL" or r.decode_input_sha256 is None
+                         for r in ledger.values()):
+        raise ValueError("Routing audit requires separate fixed-input full-decode cohorts")
+    expected = set(layer_ids)
+    if not expected or len(expected) != len(layer_ids) or any(type(i) is not int or i not in range(model_config.num_layers) for i in expected):
+        raise ValueError("Invalid selected routing layers")
+    seen, captures, reference, groups = defaultdict(set), {}, {}, defaultdict(list)
+    tp_logical_mismatches, tp_padding_mismatches = [], []
+    rank0 = {}
+    count = 0
+    for row in routes:  # importer supplies rank 0 first, then other ranks
+        key = row.batch_id, row.rank
+        if key not in ledger or row.layer_id not in expected or row.layer_id in seen[key]:
+            raise ValueError("Unexpected/duplicate routing batch, rank or layer")
+        seen[key].add(row.layer_id)
+        record = ledger[key]
+        if (row.logical_size != len(record.request_ids) or row.physical_size != record.capture_size
+                or row.num_experts != model_config.num_experts or row.top_k != model_config.num_experts_per_tok):
+            raise ValueError("Routing shape/model does not match batch ledger")
+        if captures.setdefault((row.rank, row.physical_size), row.capture_id) != row.capture_id:
+            raise ValueError("Multiple routing graph variants for one physical size")
+        reference_key = row.batch_id, row.layer_id
+        logical = row.logical_assignment_sha256, row.logical_weights_sha256, row.logical_expert_counts
+        padding = row.padding_assignment_sha256, row.padding_weights_sha256, row.padding_expert_counts
+        if row.rank == 0:
+            reference[reference_key] = logical, padding
+            paired_key = record.shape_key(), record.step, record.repetition, record.decode_input_sha256, row.layer_id
+            if paired_key in rank0:
+                raise ValueError("Duplicate routing workload/step/repetition")
+            rank0[paired_key] = row
+        else:
+            if reference_key not in reference:
+                raise ValueError("Rank-0 routing reference must precede peer ranks")
+            if logical != reference[reference_key][0]:
+                tp_logical_mismatches.append((row.batch_id, row.rank, row.layer_id))
+            if padding != reference[reference_key][1]:
+                tp_padding_mismatches.append((row.batch_id, row.rank, row.layer_id))
+        counts = [a + b for a, b in zip(row.logical_expert_counts, row.padding_expert_counts)]
+        active = sum(v > 0 for v in counts)
+        max_load_ratio = max(counts) * len(counts) / sum(counts)
+        input_len = max(record.context_lens) - record.step + 1
+        group = (row.logical_size, input_len, row.physical_size, row.rank, row.layer_id)
+        groups[group].append((active, max_load_ratio, sum(row.padding_expert_counts),
+            row.padding_positive_weight_slots, row.logical_assignment_sha256,
+            record.step, record.repetition, row.logical_expert_set_sha256))
+        if feature_writer is not None and row.rank == 0:
+            feature_writer({"batch_id": row.batch_id, "rank": 0, "layer_id": row.layer_id,
+                "logical_size": row.logical_size, "physical_size": row.physical_size,
+                "logical_features": row.native_load_features(model_config=model_config, include_padding=False),
+                "physical_features": row.native_load_features(model_config=model_config, include_padding=True),
+                "note": "Observed EP=1 top-k selection features, not a measured GEMM profile or latency prediction."})
+        count += 1
+    if set(seen) != set(ledger) or any(layers != expected for layers in seen.values()):
+        raise ValueError("Incomplete routing layer coverage for a decode batch/rank")
+    summaries = []
+    for (logical, input_len, physical, rank, layer), values in sorted(groups.items()):
+        by_step = defaultdict(list)
+        for value in values:
+            by_step[value[5]].append(value)
+        varying_steps = sum(len({value[4] for value in rows}) > 1 for rows in by_step.values())
+        varying_sets = sum(len({value[7] for value in rows}) > 1 for rows in by_step.values())
+        summaries.append({"batch_size": logical, "input_len": input_len, "physical_size": physical, "rank": rank, "layer_id": layer,
+            "samples": len(values), "active_experts_median": statistics.median(v[0] for v in values),
+            "max_load_ratio_median": statistics.median(v[1] for v in values),
+            "padding_selected_slots_median": statistics.median(v[2] for v in values),
+            "padding_positive_weight_slots_median": statistics.median(v[3] for v in values),
+            "steps_with_changed_logical_assignments": varying_steps,
+            "steps_with_changed_logical_expert_sets": varying_sets, "steps": len(by_step)})
+    return {"decode_batches": sum((batch_id, 0) in ledger for batch_id in cohorts),
+        "routing_records": count, "selected_layers": sorted(expected),
+        "all_model_layers_covered": expected == set(range(model_config.num_layers)),
+        "tp_logical_mismatches": tp_logical_mismatches,
+        "tp_padding_mismatches": tp_padding_mismatches, "summaries": summaries}, rank0
+
+
+def compare_routing_passes(reference, observed):
+    rows = []
+    for key, row in observed.items():
+        if key not in reference:
+            raise ValueError("No matching fixed-input routing workload/step/repetition/layer")
+        base = reference[key]
+        l1 = sum(abs(a - b) for a, b in zip(base.logical_expert_counts, row.logical_expert_counts))
+        padding_l1 = sum(abs(a - b) for a, b in zip(base.padding_expert_counts, row.padding_expert_counts))
+        padding_total = sum(base.padding_expert_counts) + sum(row.padding_expert_counts)
+        rows.append({"batch_id": row.batch_id, "reference_batch_id": base.batch_id,
+            "batch_size": row.logical_size, "physical_size": row.physical_size, "layer_id": row.layer_id,
+            "identical_logical_assignments": base.logical_assignment_sha256 == row.logical_assignment_sha256,
+            "identical_logical_expert_sets": base.logical_expert_set_sha256 == row.logical_expert_set_sha256,
+            "identical_logical_weights": base.logical_weights_sha256 == row.logical_weights_sha256,
+            "logical_histogram_l1_fraction": l1 / (2 * row.logical_size * row.top_k),
+            "padding_histogram_l1_fraction": padding_l1 / padding_total if padding_total else 0.0})
+    if not rows:
+        raise ValueError("Empty routing comparison")
+    return {"rank": 0, "paired_layer_samples": len(rows),
+        "identical_logical_assignments": sum(r["identical_logical_assignments"] for r in rows),
+        "identical_logical_expert_sets": sum(r["identical_logical_expert_sets"] for r in rows),
+        "identical_logical_weights": sum(r["identical_logical_weights"] for r in rows),
+        "logical_histogram_l1_fraction_median": statistics.median(r["logical_histogram_l1_fraction"] for r in rows),
+        "logical_histogram_l1_fraction_max": max(r["logical_histogram_l1_fraction"] for r in rows),
+        "rows": rows}
+
+
+def import_routing_capture(path, *, model_config, feature_writer=None):
+    manifest = json.loads((path / "manifest.json").read_text())
+    if manifest.get("status") != "complete" or manifest.get("engine") != "sglang":
+        raise ValueError("Requires a complete SGLang capture")
+    if (manifest["topology"] != {"tp": 8, "ep": 1, "pp": 1, "nodes": 1}
+            or Path(manifest["model_path"]).name != Path(model_config.name).name):
+        raise ValueError("Routing contract requires the matching checkpoint and one-node TP=8/EP=1/PP=1")
+    options = manifest["options"]
+    layers = list(range(model_config.num_layers)) if options["routing_all_layers"] else options["routing_layers"]
+    baseline = [r for r in read_batches(path / "batches.jsonl") if not r.profiled]
+    reports, references, sources = {}, {}, []
+    for prefix in ("routing", "graph"):
+        if prefix == "graph" and not graph_routing_enabled(options):
+            continue
+        records = read_batches(path / f"{prefix}-batches.jsonl")
+        def routes():
+            for rank in range(8):
+                source = path / f"{prefix}-routing-rank{rank}.jsonl.gz"
+                sources.append({"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()})
+                for row in read_routing(source):
+                    if row.rank != rank:
+                        raise ValueError("Routing rank disagrees with source file")
+                    yield row
+        writer = (lambda row, prefix=prefix: feature_writer({"pass": prefix, **row})) if feature_writer else None
+        report, reference = audit_routing(records, routes(), layer_ids=layers, tensor_parallel_size=8,
+                                          model_config=model_config, feature_writer=writer)
+        reports[prefix] = {**report, "profile_perturbation": summarize_profile_perturbation(
+            baseline + records, tensor_parallel_size=8)}
+        references[prefix] = reference
+    comparison = compare_routing_passes(references["routing"], references["graph"]) if "graph" in references else None
+    return {"schema_version": 1, "manifest": manifest, "sources": sources, "passes": reports,
+        "timing_vs_routing_only": comparison,
+        "limitations": [
+            "Top-k buffer references are sampled after forward; retaining tensors may change graph pool allocation.",
+            "Positive/zero routing weights do not establish whether the backend executes or prunes a GEMM slot.",
+            "Features use native EPLaneWorkload/MoELoadImbalanceInput for observed EP=1 only; no synthetic EP extrapolation.",
+            "No ground-truth latency or profile is invented from expert counts. Unprofiled timing checks still apply.",
+        ]}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--native-features-output", type=Path)
+    args = parser.parse_args()
+    from frontier.profiling.common.model_config import ModelConfig
+    features = gzip.open(args.native_features_output, "xt") if args.native_features_output else None
+    try:
+        result = import_routing_capture(args.capture_dir,
+            model_config=ModelConfig.from_model_name(args.model),
+            feature_writer=(lambda row: features.write(json.dumps(row) + "\n")) if features else None)
+    finally:
+        if features:
+            features.close()
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps({"passes": {name: {k: v for k, v in report.items()
+        if k not in {"summaries", "profile_perturbation", "tp_logical_mismatches", "tp_padding_mismatches"}}
+        for name, report in result["passes"].items()}, "comparison": {k: v for k, v in
+        (result["timing_vs_routing_only"] or {}).items() if k != "rows"}}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/runtime_cost.py
+++ b/frontier/validation/runtime_cost.py
@@ -1,0 +1,119 @@
+"""Audit or evaluate an explicit runtime cost table for one captured decode batch.
+
+The default writes a profile coverage plan, not a prediction. Captured timings
+never enter cost queries. Predictions require an explicit complete cost table.
+"""
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+from frontier.runtime_cost.sglang import (
+    DecodeWorkload, ExactRuntimeCostTable, RuntimeIdentity, SGLangCostContract, capture_stack_signature,
+)
+from frontier.validation.batch_record import read_batches
+from frontier.validation.routing import read_routing
+from frontier.validation.routing_report import audit_routing
+
+
+def plan_captured_batch(records, routes, *, model_config, identity, padding_context_lens=()):
+    """Require all-rank agreement before using one rank's observed load vectors."""
+    records, routes = tuple(records), tuple(routes)
+    if len({r.batch_id for r in records}) != 1 or any(r.phase != "decode" for r in records):
+        raise ValueError("Runtime planning requires exactly one decode cohort")
+    audit, _ = audit_routing(records, routes, layer_ids=list(range(model_config.num_layers)),
+                            tensor_parallel_size=identity.tensor_parallel_size, model_config=model_config)
+    if audit["tp_logical_mismatches"] or audit["tp_padding_mismatches"]:
+        raise ValueError("TP routing mismatch prevents rank-0 runtime cost planning")
+    reference = next(r for r in records if r.rank == 0)
+    padding_context_lens = tuple(padding_context_lens)
+    if len(padding_context_lens) != reference.capture_size - len(reference.request_ids):
+        raise ValueError("Explicit context lengths are required for every graph-padding lane")
+    workload = DecodeWorkload(len(reference.request_ids),
+        tuple(n + 1 for n in reference.context_lens) + padding_context_lens)
+    contract = SGLangCostContract(model_config, identity)
+    rank0_routes = tuple(r for r in routes if r.rank == 0)
+    queries = contract.queries(workload, rank0_routes)
+    return contract, workload, rank0_routes, queries, audit
+
+
+def identity_for_capture(manifest, model, device):
+    """Shared admission gate for runtime query planning and profile production."""
+    topology, server = manifest["topology"], manifest["server_args"]
+    if (manifest["status"] != "complete" or manifest.get("engine") != "sglang"
+            or manifest.get("workload_mode") != "static_batch"
+            or Path(manifest["model_path"]).name != Path(model.name).name
+            or topology != {"tp": topology["tp"], "ep": 1, "pp": 1, "nodes": 1}
+            or server.get("tp_size") != topology["tp"]
+            or server.get("ep_size", 1) != 1 or server.get("pp_size", 1) != 1
+            or server.get("dp_size", 1) != 1 or server.get("enable_dp_attention", False)
+            or server.get("moe_dp_size", 1) != 1 or server.get("moe_a2a_backend", "none") != "none"
+            or server.get("enable_fused_qk_norm_rope", False)
+            or server.get("enable_fused_moe_sum_all_reduce", False)
+            or server.get("enable_two_batch_overlap", False) or server.get("enable_single_batch_overlap", False)
+            or server.get("enable_eplb", False) or server.get("ep_num_redundant_experts", 0)
+            or server.get("speculative_algorithm")):
+        raise ValueError("Capture does not match the one-node static runtime contract")
+    if not manifest["devices"] or any(device.lower() not in d["device_name"].lower().replace(" ", "")
+                                      for d in manifest["devices"]):
+        raise ValueError("Requested device does not match captured hardware")
+    # Cost producer provenance is independent of the Frontier capture observer.
+    return RuntimeIdentity.for_model(model, device=device, tensor_parallel_size=topology["tp"],
+                                        runtime_stack_signature=capture_stack_signature(manifest))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", required=True, type=Path)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--device", required=True)
+    parser.add_argument("--batch-id", required=True)
+    parser.add_argument("--pass-name", choices=("routing", "graph"), default="routing")
+    parser.add_argument("--padding-context-lens", type=int, nargs="*", default=[])
+    parser.add_argument("--profile", type=Path)
+    parser.add_argument("--predict", action="store_true")
+    parser.add_argument("--allow-diagnostic", action="store_true")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    if args.predict and args.profile is None:
+        parser.error("--predict requires --profile; missing costs are never fabricated")
+    if args.allow_diagnostic and not args.predict:
+        parser.error("--allow-diagnostic only applies to --predict")
+    from frontier.profiling.common.model_config import ModelConfig
+    model = ModelConfig.from_model_name(args.model)
+    manifest = json.loads((args.capture_dir / "manifest.json").read_text())
+    identity = identity_for_capture(manifest, model, args.device)
+    records = [r for r in read_batches(args.capture_dir / f"{args.pass_name}-batches.jsonl")
+               if r.batch_id == args.batch_id]
+    routes = []
+    for rank in range(identity.tensor_parallel_size):
+        for route in read_routing(args.capture_dir / f"{args.pass_name}-routing-rank{rank}.jsonl.gz"):
+            if route.rank != rank:
+                raise ValueError("Routing rank disagrees with source file")
+            if route.batch_id == args.batch_id:
+                routes.append(route)
+    contract, workload, rank0, queries, audit = plan_captured_batch(records, routes,
+        model_config=model, identity=identity, padding_context_lens=args.padding_context_lens)
+    payload = json.loads(args.profile.read_text()) if args.profile else {
+        "schema_version": 1, "identity": asdict(identity), "rows": []}
+    table = ExactRuntimeCostTable(payload, identity=identity)
+    result = {"schema_version": 1, "batch_id": args.batch_id, "identity": asdict(identity),
+        "routing_audit": audit, "profile_coverage": table.audit(queries),
+        "queries": [{"query": asdict(q), "query_key": q.key} for q in queries],
+        "boundary_note": "Routing-conditioned static decoder estimate; not unprofiled forward, "
+                         "serving, or distributed scaling validation. Fixed inputs do not freeze routes."}
+    if args.predict:
+        prediction = contract.predict(workload, rank0, table, allow_diagnostic=args.allow_diagnostic)
+        result["prediction"] = prediction.summary()
+        result["native_op_times_per_layer_average"] = dict(prediction.execution.op_times)
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps({"batch_id": args.batch_id, "layers": model.num_layers,
+        "queries": len(queries), "missing_profiles": len(result["profile_coverage"]["missing"]),
+        "prediction": result.get("prediction"), "output": str(args.output)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/runtime_cost_correlation.py
+++ b/frontier/validation/runtime_cost_correlation.py
@@ -1,0 +1,205 @@
+"""Correlate an exact runtime-cost prediction with a decoder HIP graph span.
+
+This is a post-prediction diagnostic. Observed timings never enter query
+construction, profile admission, cost composition, or a correction factor.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+import math
+from pathlib import Path
+
+from frontier.runtime_cost.sglang import DecodeWorkload, RuntimeIdentity
+from frontier.validation.batch_record import read_batches, validate_rank_cohorts
+from frontier.validation.graph_event_report import import_decoder_graph_capture
+from frontier.validation.routing import read_routing
+from frontier.validation.runtime_cost import (
+    identity_for_capture, plan_captured_batch,
+)
+
+
+def correlate_exact_decoder(
+        prediction_payload, records, samples, *, identity, expected_queries,
+        routing_audit, quality, all_capture_batches_pass):
+    """Validate matching prediction/observation identities and report error."""
+    records, samples, expected_queries = tuple(records), tuple(samples), tuple(expected_queries)
+    try:
+        serialized_identity = RuntimeIdentity(**prediction_payload.get("identity", {}))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise ValueError("Runtime prediction schema/identity mismatch") from error
+    if (not isinstance(prediction_payload, dict)
+            or type(prediction_payload.get("schema_version")) is not int
+            or prediction_payload["schema_version"] != 1
+            or not isinstance(identity, RuntimeIdentity)
+            or serialized_identity != identity):
+        raise ValueError("Runtime prediction schema/identity mismatch")
+    batch_id = prediction_payload.get("batch_id")
+    if not isinstance(batch_id, str) or not batch_id:
+        raise ValueError("Runtime prediction requires a captured batch ID")
+    coverage = prediction_payload.get("profile_coverage", {})
+    prediction = prediction_payload.get("prediction")
+    if (not isinstance(coverage, dict)
+            or coverage.get("complete") is not True
+            or coverage.get("missing") != []
+            or not isinstance(prediction, dict)
+            or prediction.get("routing_conditioned") is not True
+            or prediction.get("full_forward_parity_admitted") is not False
+            or prediction.get("diagnostic") is not False):
+        raise ValueError("Correlation requires a complete isolated-profile prediction")
+    predicted_ms = prediction.get("decoder_ms")
+    if (isinstance(predicted_ms, bool) or not isinstance(predicted_ms, (int, float))
+            or not math.isfinite(predicted_ms) or predicted_ms <= 0):
+        raise ValueError("Prediction requires a finite positive decoder duration")
+
+    serialized = prediction_payload.get("queries")
+    expected_keys = [query.key for query in expected_queries]
+    expected_serialized = [
+        {"query": asdict(query), "query_key": query.key}
+        for query in expected_queries]
+    if (not isinstance(serialized, list) or not expected_keys
+            or any(not isinstance(item, dict) for item in serialized)
+            or len(expected_keys) != len(set(expected_keys))
+            or json.dumps(serialized, sort_keys=True, separators=(",", ":"))
+            != json.dumps(expected_serialized, sort_keys=True, separators=(",", ":"))
+            or type(coverage.get("queries")) is not int
+            or coverage["queries"] != len(expected_keys)):
+        raise ValueError("Prediction queries do not match the exact captured routing plan")
+    if (not isinstance(routing_audit, dict)
+            or routing_audit.get("all_model_layers_covered") is not True
+            or isinstance(routing_audit.get("routing_records"), bool)
+            or not isinstance(routing_audit.get("routing_records"), int)
+            or routing_audit["routing_records"] < 1
+            or routing_audit.get("tp_logical_mismatches")
+            or routing_audit.get("tp_padding_mismatches")):
+        raise ValueError("Exact decoder correlation requires all-rank routing agreement")
+
+    layer_ids = {query.layer_id for query in expected_queries}
+    if layer_ids != set(range(len(layer_ids))):
+        raise ValueError("Exact runtime plan must cover a contiguous decoder layer schedule")
+
+    cohorts = validate_rank_cohorts(records, tensor_parallel_size=identity.tensor_parallel_size)
+    if (set(cohorts) != {batch_id} or len(records) != identity.tensor_parallel_size
+            or any(record.phase != "decode" or not record.profiled
+                   or record.graph_mode != "FULL" or record.forward_gpu_ms is None
+                   or record.decode_input_sha256 is None
+                   for record in records)):
+        raise ValueError("Correlation requires one fixed-input profiled decode TP cohort")
+    by_rank = {record.rank: record for record in records}
+    sample_by_rank = {}
+    for sample in samples:
+        if not isinstance(sample, dict):
+            raise ValueError("Malformed decoder event span")
+        rank = sample.get("rank")
+        if (type(rank) is not int or rank not in by_rank or rank in sample_by_rank
+                or sample.get("batch_id") != batch_id
+                or sample.get("component") != "decoder"
+                or sample.get("measurement_type") != "HIP_GRAPH_EVENT"
+                or sample.get("first_layer_id") != 0
+                or sample.get("last_layer_id") != len(layer_ids) - 1
+                or sample.get("physical_size") != by_rank[rank].capture_size):
+            raise ValueError("Missing, duplicate or mismatched decoder event span")
+        duration = sample.get("inclusive_gpu_ms")
+        if (isinstance(duration, bool) or not isinstance(duration, (int, float))
+                or not math.isfinite(duration) or duration <= 0
+                or duration > by_rank[rank].forward_gpu_ms):
+            raise ValueError("Invalid decoder event duration")
+        sample_by_rank[rank] = sample
+    if set(sample_by_rank) != set(by_rank):
+        raise ValueError("Decoder event span does not cover every TP rank")
+
+    quality_rows = quality.get("batches", ()) if isinstance(quality, dict) else ()
+    if (not isinstance(quality_rows, (list, tuple))
+            or any(not isinstance(row, dict) for row in quality_rows)):
+        raise ValueError("Malformed decoder-event perturbation report")
+    matching_quality = [row for row in quality_rows if row.get("batch_id") == batch_id]
+    if (len(matching_quality) != 1
+            or matching_quality[0].get("passes_latency_check") is not True):
+        raise ValueError("Exact decoder event failed or lacks the perturbation gate")
+    quality_row = matching_quality[0]
+    signed_change_pct = quality_row.get("signed_change_pct")
+    if (isinstance(signed_change_pct, bool)
+            or not isinstance(signed_change_pct, (int, float))
+            or not math.isfinite(signed_change_pct)):
+        raise ValueError("Invalid decoder-event perturbation measurement")
+    if type(all_capture_batches_pass) is not bool or not all_capture_batches_pass:
+        raise ValueError("Every captured decoder batch must pass the perturbation gate")
+    observed_ms = max(row["inclusive_gpu_ms"] for row in sample_by_rank.values())
+    forward_ms = max(record.forward_gpu_ms for record in records)
+    signed_error = predicted_ms - observed_ms
+    return {
+        "schema_version": 1,
+        "batch_id": batch_id,
+        "identity": prediction_payload["identity"],
+        "boundary": "first decoder layer entry through last decoder layer exit",
+        "queries": len(expected_keys),
+        "routing_records": routing_audit["routing_records"],
+        "predicted_decoder_ms": predicted_ms,
+        "observed_decoder_max_rank_ms": observed_ms,
+        "signed_error_ms": signed_error,
+        "absolute_relative_error": abs(signed_error) / observed_ms,
+        "profiled_forward_max_rank_ms": forward_ms,
+        "forward_minus_decoder_ms": forward_ms - observed_ms,
+        "observer_signed_change_pct": signed_change_pct,
+        "observer_latency_check_passed": True,
+        "all_capture_decode_batches_passed": all_capture_batches_pass,
+        "full_forward_parity_admitted": False,
+        "correction_applied": False,
+        "note": "Post-prediction exact-route decoder diagnostic; observation is not a profile, fit target, or full-forward parity claim.",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, required=True)
+    parser.add_argument("--prediction", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from frontier.profiling.common.model_config import ModelConfig
+
+    payload = json.loads(args.prediction.read_text())
+    model = ModelConfig.from_model_name(args.model)
+    manifest = json.loads((args.capture_dir / "manifest.json").read_text())
+    serialized_identity = RuntimeIdentity(**payload["identity"])
+    identity = identity_for_capture(manifest, model, serialized_identity.device)
+    if identity != serialized_identity:
+        raise ValueError("Prediction and decoder capture have different runtime identities")
+    batch_id = payload["batch_id"]
+    records = [record for record in read_batches(args.capture_dir / "graph-batches.jsonl")
+               if record.batch_id == batch_id]
+    routes = []
+    for rank in range(identity.tensor_parallel_size):
+        routes.extend(route for route in read_routing(
+            args.capture_dir / f"graph-routing-rank{rank}.jsonl.gz")
+            if route.batch_id == batch_id)
+    first_query = payload["queries"][0]["query"]
+    workload = DecodeWorkload(**first_query["workload"])
+    padding_context_lens = workload.physical_context_lens[workload.logical_size:]
+    _, planned_workload, _, queries, routing_audit = plan_captured_batch(
+        records, routes, model_config=model, identity=identity,
+        padding_context_lens=padding_context_lens)
+    if planned_workload != workload:
+        raise ValueError("Prediction workload differs from the observed decoder batch")
+    decoder_report = import_decoder_graph_capture(args.capture_dir, model_config=model)
+    samples = []
+    for rank in range(identity.tensor_parallel_size):
+        source = args.capture_dir / f"decoder-events-rank{rank}.jsonl"
+        samples.extend(row for row in (
+            json.loads(line) for line in source.read_text().splitlines() if line.strip())
+            if row.get("batch_id") == batch_id)
+    result = correlate_exact_decoder(
+        payload, records, samples, identity=identity, expected_queries=queries,
+        routing_audit=routing_audit, quality=decoder_report["profile_perturbation"],
+        all_capture_batches_pass=decoder_report["all_decode_batches_pass_latency_check"])
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/runtime_mapping.py
+++ b/frontier/validation/runtime_mapping.py
@@ -1,0 +1,162 @@
+"""Explicit SGLang-to-Frontier boundary audit; never split fused measurements.
+
+This is a semantic map against the native registries, not a replacement cost
+model. Unsupported fusions and measurement families stay visible and fail CSV
+admission instead of silently changing simulator numerics.
+"""
+
+from dataclasses import dataclass
+import argparse
+import json
+from pathlib import Path
+
+from frontier.operators.binding import bind_operator_query
+from frontier.operators.sglang_family import runtime_operator_name
+from frontier.validation.operator_trace import CONTRACT, model_layer_kinds
+
+
+@dataclass(frozen=True)
+class Boundary:
+    targets: tuple[str, ...]
+    relationship: str = "matching_boundary"
+    note: str = "Matching work boundary still requires compatible backend, dtype, shape and timing profiles."
+
+
+def _rules(phase, layer_id):
+    core = f"gdn_core_{phase}"
+    common = {
+        "input_layernorm": Boundary(("input_layernorm",) if layer_id == 0
+            else ("input_layernorm", "add_ffn_residual"),
+            "matching_boundary" if layer_id == 0 else "fused_cross_layer",
+            "Layer 0 has no residual input; later input norms fuse the preceding layer's FFN residual add."),
+        "post_attention_layernorm": Boundary(("post_attention_layernorm", "add_attn_residual"),
+            "fused", "Current-layer attention residual addition is fused with normalization."),
+        "gdn_input_projections": Boundary(("gdn_input_projections",)),
+        core: Boundary((core,)),
+        "gdn_output_projection": Boundary(("gdn_output_projection",)),
+        "attn_pre_proj_qknorm": Boundary(("attn_pre_proj",)),
+        "attn_rope": Boundary(("attn_rope",)),
+        "attn_kv_cache_write": Boundary(("attn_kv_cache_save",)),
+        f"attn_{phase}": Boundary((f"attn_{phase}",)),
+        "attn_post_proj_gate": Boundary(("attn_post_proj",), "native_gap",
+            "Runtime fuses output gating into this measured group; the generic native post projection omits gating."),
+        "attention_tp_allreduce": Boundary(("attn_tensor_parallel_allreduce",), "collective_in_situ",
+            "One TP collective; observed duration includes rank-arrival skew, not just transfer cost."),
+        "shared_expert_gate_up": Boundary(("share_expert_up_proj",)),
+        "shared_expert_activation": Boundary(("share_expert_act",)),
+        "shared_expert_down": Boundary(("share_expert_down_proj",)),
+        "moe_router_linear": Boundary(("moe_gating_linear",)),
+        "moe_routing_topk": Boundary(("moe_gating_routing_topk",)),
+        "moe_sorting": Boundary(("moe_shuffling",), "backend_boundary_check",
+            "AITER sorting must be checked against the native producer's shuffling/dispatch boundary."),
+        "moe_experts_quant_gemm_combine": Boundary(("moe_grouped_gemm",), "backend_boundary_check",
+            "Two MXFP4 quantization/GEMM stages plus combine are inseparable in this runtime group."),
+        "shared_gate_sigmoid_mul_add": Boundary((), "native_gap",
+            "Fused shared gate dot product, sigmoid, multiply and add have no canonical native operator."),
+        "mlp_tp_allreduce": Boundary(("moe_tensor_parallel_allreduce", "share_expert_tensor_parallel_allreduce"),
+            "fused_collective", "SGLang reduces the combined routed+shared output ONCE on TP=8. Do not "
+            "assign that duration twice to native routed and shared reductions."),
+    }
+    common.update({
+        "gdn": Boundary(("gdn_input_projections", core, "gdn_output_projection"), "composite",
+            "Whole GDN event span; cannot divide into three native operator timings."),
+        "full_attention": Boundary(("attn_pre_proj", "attn_rope", "attn_kv_cache_save",
+            f"attn_{phase}", "attn_post_proj"), "native_gap",
+            "Whole mixer span includes the output gate, which is missing from the generic native projection path."),
+        "attention_reduce_and_mlp_norm": Boundary(("attn_tensor_parallel_allreduce",
+            "post_attention_layernorm", "add_attn_residual"), "composite",
+            "Collective plus fused residual/norm; no decomposition into invented communication and compute costs."),
+        "mlp_including_tp_reduce": Boundary(("share_expert_up_proj", "share_expert_act",
+            "share_expert_down_proj", "moe_gating_linear", "moe_gating_routing_topk", "moe_shuffling",
+            "moe_grouped_gemm", "moe_tensor_parallel_allreduce", "share_expert_tensor_parallel_allreduce"),
+            "native_gap", "Includes shared gating/addition and one combined reduction; native compute "
+            "and communication boundaries are not equivalent to this total."),
+        "moe_shared_expert": Boundary(("share_expert_up_proj", "share_expert_act", "share_expert_down_proj"),
+            "composite", "Whole shared MLP, excluding its separate gate and combined TP reduction."),
+        "moe_gate": common["moe_router_linear"], "moe_topk": common["moe_routing_topk"],
+        "moe_experts": Boundary(("moe_shuffling", "moe_grouped_gemm"), "composite",
+            "Dispatcher, sorting and MXFP4 quantization/GEMMs/combine; do not label the whole scope grouped GEMM."),
+        "gdn_attn": Boundary((core,), "partial",
+            "The inner attention module omits GDN transformations performed by the surrounding mixer."),
+        "gdn_norm": Boundary(("gdn_output_projection",), "partial", "Native output scope also includes projection."),
+        "gdn_out_proj": Boundary(("gdn_output_projection",), "partial", "Native output scope also includes gated norm."),
+        "attention_qkv_proj": Boundary(("attn_pre_proj",), "partial", "Module projection excludes subsequent QK norm."),
+        "attention_rotary_emb": common["attn_rope"],
+        "attention_attn": Boundary(("attn_kv_cache_save", f"attn_{phase}"), "composite",
+            "Radix attention boundary includes cache write and attention kernels."),
+        "attention_o_proj": Boundary(("attn_post_proj",)),
+    })
+    return common
+
+
+def map_runtime_components(components, *, phase, layer_id, measurement_type, model_config):
+    schedule = model_layer_kinds(model_config)
+    if phase not in {"prefill", "decode"} or type(layer_id) is not int or not 0 <= layer_id < len(schedule):
+        raise ValueError("Runtime map requires a valid model layer and prefill/decode phase")
+    if measurement_type not in {"CUDA_EVENT", "KERNEL_ONLY", "HIP_GRAPH_EVENT"}:
+        raise ValueError("Unknown measurement family")
+    components = list(components)
+    if not components or len(set(components)) != len(components):
+        raise ValueError("Runtime components must be nonempty and unique")
+    rules = _rules(phase, layer_id)
+    profile = model_config.get_model_architecture_profile()
+    architecture_ops = set(profile.linear_attention.sharded_ops + profile.linear_attention.replicated_ops)
+    mappings = []
+    for component in components:
+        if component not in rules:
+            raise ValueError(f"No admitted runtime boundary for {component}")
+        if ((component.startswith("gdn") and schedule[layer_id] != "gdn")
+                or ((component.startswith("attn_") or component in {"full_attention", "attention_qkv_proj",
+                    "attention_rotary_emb", "attention_attn", "attention_o_proj"}) and schedule[layer_id] != "attention")):
+            raise ValueError("Runtime mixer boundary disagrees with model layer schedule")
+        rule = rules[component]
+        targets = []
+        for name in rule.targets:
+            if name in architecture_ops:
+                owner = "dense_attention"
+            else:
+                binding = bind_operator_query(name)
+                if phase not in {p.value for p in binding.operator.phases}:
+                    raise ValueError("Native operator is not enabled for this phase")
+                owner = binding.family_id
+            targets.append({"operator": name, "family": owner,
+                "layer_offset": -1 if component == "input_layernorm" and name == "add_ffn_residual" else 0})
+        try:
+            runtime_target = runtime_operator_name(component) if phase == "decode" else None
+        except ValueError:
+            runtime_target = None
+        mappings.append({"runtime_component": component, "native_targets": targets,
+            "relationship": rule.relationship, "note": rule.note,
+            "opt_in_runtime_operator": runtime_target,
+            "native_csv_export_admitted": False})
+    return {"contract": CONTRACT, "model_architecture_profile": profile.profile_id,
+        "phase": phase, "layer_id": layer_id, "layer_kind": schedule[layer_id],
+        "measurement_type": measurement_type,
+        "native_measurement_family_supported": measurement_type != "HIP_GRAPH_EVENT",
+        "mappings": mappings,
+        "note": "Generic-native semantic mapping only; no calibration or numeric replacement. "
+                "opt_in_runtime_operator identifies the separate explicit SGLang cost adapter, not CSV admission. Fused/partial groups "
+                "must not be split, duplicated or relabeled. Embedding/final norm/logits remain "
+                "outside native decoder model_time; the final FFN residual is fused in the final norm."}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--layer", required=True, type=int)
+    parser.add_argument("--phase", choices=("prefill", "decode"), required=True)
+    parser.add_argument("--measurement-type", required=True)
+    parser.add_argument("--components", nargs="+", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    from frontier.profiling.common.model_config import ModelConfig
+    result = map_runtime_components(args.components, phase=args.phase, layer_id=args.layer,
+        measurement_type=args.measurement_type, model_config=ModelConfig.from_model_name(args.model))
+    with args.output.open("x") as stream:
+        json.dump(result, stream, indent=2)
+        stream.write("\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/sglang_capture.py
+++ b/frontier/validation/sglang_capture.py
@@ -1,0 +1,559 @@
+"""Capture reproducible static batches using SGLang's real checkpoint runner.
+
+No SGLang source changes are required. This opt-in benchmark uses its one_batch
+allocation/forward helpers; it does not simulate a serving scheduler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+from contextlib import ExitStack
+import gzip
+import hashlib
+import importlib.metadata
+import itertools
+import json
+import os
+import platform
+import subprocess
+import time
+from pathlib import Path
+
+from frontier.validation.batch_record import BatchRecord, read_batches, validate_rank_cohorts
+
+
+def _host_list(value, name: str) -> list[int]:
+    if value is None:
+        raise ValueError(f"SGLang did not provide {name} on the CPU")
+    if hasattr(value, "device") and value.device.type != "cpu":
+        raise ValueError(f"{name} must be CPU-resident; capture must not copy GPU tensors")
+    return [int(v) for v in (value.tolist() if hasattr(value, "tolist") else value)]
+
+
+def snapshot_forward_batch(batch) -> dict:
+    """Read the pinned runtime's CPU metadata without synchronizing a device."""
+    size = int(batch.batch_size)
+    if batch.forward_mode.is_decode():
+        query = [1] * size
+        context = [v - 1 for v in _host_list(batch.seq_lens_cpu, "seq_lens_cpu")]
+        phase = "decode"
+    elif batch.forward_mode.is_extend() and not batch.forward_mode.is_mixed():
+        query = _host_list(batch.extend_seq_lens_cpu, "extend_seq_lens_cpu")
+        context = _host_list(batch.extend_prefix_lens_cpu, "extend_prefix_lens_cpu")
+        phase = "prefill"
+    else:
+        raise ValueError(f"Static capture does not support forward mode {batch.forward_mode}")
+    if len(query) != size or len(context) != size:
+        raise ValueError("SGLang CPU lengths disagree with batch_size")
+    return dict(phase=phase, query_lens=tuple(query), context_lens=tuple(context),
+                prefill_mask=(phase == "prefill",) * size)
+
+
+class ForwardObserver:
+    """Measure only model forward on the GPU; sample/prepare remain step work."""
+
+    def __init__(self, runner):
+        import torch
+
+        self.runner = runner
+        self.original = runner.forward
+        self.start = torch.cuda.Event(enable_timing=True)
+        self.end = torch.cuda.Event(enable_timing=True)
+        self.snapshot = None
+        self.enabled = False
+        runner.forward = self.forward
+
+    def forward(self, forward_batch, *args, **kwargs):
+        if not self.enabled:
+            return self.original(forward_batch, *args, **kwargs)
+        self.snapshot = snapshot_forward_batch(forward_batch)
+        self.start.record()
+        output = self.original(forward_batch, *args, **kwargs)
+        self.end.record()
+        graph = bool(output.can_run_graph)
+        graph_runner = self.runner.decode_cuda_graph_runner
+        self.snapshot.update(
+            graph_mode="FULL" if graph else "NONE",
+            capture_size=int(graph_runner.bs) if graph else 0,
+        )
+        return output
+
+
+def _git_revision(path: str | Path) -> str | None:
+    directory = Path(path).resolve()
+    directory = next((p for p in (directory, *directory.parents) if (p / ".git").exists()), directory)
+    result = subprocess.run(["git", "-c", f"safe.directory={directory}",
+                             "-C", str(directory), "rev-parse", "HEAD"],
+                            capture_output=True, text=True, check=False)
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _source_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*.py")):
+        digest.update(str(path.relative_to(root)).encode())
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def decode_trajectory(token_ids, batch_size: int, output_len: int):
+    """Return decode input rows and a content digest, never write token IDs.
+
+    A normal first repetition provides one fixed trajectory per workload.
+    The final generated row is excluded because no forward consumes it.
+    Tensor allocation/copies happen outside all measured steps.
+    """
+    if (batch_size < 1 or output_len < 2 or len(token_ids) != batch_size * output_len
+            or any(type(v) is not int or v < 0 for v in token_ids)):
+        raise ValueError("Decode trajectory requires complete nonnegative integer token rows")
+    rows = tuple(tuple(token_ids[i:i + batch_size])
+                 for i in range(0, batch_size * (output_len - 1), batch_size))
+    digest = hashlib.sha256(json.dumps(rows, separators=(",", ":")).encode()).hexdigest()
+    return rows, digest
+
+
+def _worker(rank, server_args, port_args, options):
+    import numpy as np
+    import torch
+    import torch.distributed as dist
+    from sglang.benchmark import one_batch as bench
+
+    bench.initialize_moe_config(server_args)
+    bench.initialize_fp8_gemm_config(server_args)
+    bench.initialize_fp4_gemm_config(server_args)
+    if bench.get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):
+        bench.set_gpu_proc_affinity(1, server_args.tp_size, 1, rank)
+    bench.configure_logger(server_args, prefix=f" TP{rank}")
+    runner, _tokenizer = bench.load_model(server_args, port_args, rank, rank)
+    actual = runner.torch_runner
+    observer = ForwardObserver(actual)
+    output_dir = Path(options["output_dir"])
+    output_checks = []
+    graph_runner = actual.decode_cuda_graph_runner
+    properties = torch.cuda.get_device_properties(rank)
+    runtime = {
+        "rank": rank, "device_name": properties.name,
+        "total_memory_bytes": properties.total_memory,
+        "gcn_arch_name": getattr(properties, "gcnArchName", None),
+        "allocated_bytes_after_init": torch.cuda.memory_allocated(rank),
+        "reserved_bytes_after_init": torch.cuda.memory_reserved(rank),
+        "max_total_num_tokens": actual.max_total_num_tokens,
+        "request_pool_size": getattr(actual.req_to_token_pool, "size", None),
+        "capture_sizes": list(getattr(graph_runner, "capture_bs", [])),
+    }
+    with (output_dir / f"runtime-rank{rank}.json").open("x") as stream:
+        json.dump(runtime, stream, indent=2)
+
+    graph_observer = None
+    graph_samples = []
+    decoder_graph_observer = None
+    decoder_graph_samples = []
+    frozen_inputs, frozen_digests = {}, {}
+    routing_observer, routing_stream = None, None
+
+    def run_case(bs, length, repetition, *, measured, profiled=False, operator_events=False,
+                 graph_events=False, routing=False):
+        # Each shape/repetition sees identical prompts on all TP ranks. Cache
+        # pools are reset outside timing and no prefix-cache lookup is used.
+        np.random.seed(options["seed"])
+        torch.manual_seed(options["seed"])
+        reqs = bench.prepare_synthetic_inputs_for_latency_test(bs, length)
+        runner.clear()
+        observer.enabled = measured
+        batch = None
+        next_ids = None
+        records = []
+        routing_snapshots = []
+        digest = hashlib.sha256()
+        token_ids = []
+        steps = (options["output_len"] if graph_events or routing else 1 if operator_events else
+                 options["trace_steps"] + 1 if profiled else options["output_len"])
+        for step in range(steps):
+            suffix = ("-graph-events" if graph_events else "-routing" if routing else "-operator-events" if operator_events
+                      else "-trace" if profiled else "")
+            identifier = f"b{bs}-l{length}-r{repetition}-s{step}" + suffix
+            decode_ids = (frozen_inputs[(bs, length)][step - 1]
+                          if step > 0 and (bs, length) in frozen_inputs else next_ids)
+            runner.synchronize()
+            # Synchronization is inside the trace marker so its GPU interval is
+            # unambiguous even when HIP graph launches omit correlation IDs.
+            with torch.profiler.record_function(f"frontier.batch:{identifier}"):
+                tic = time.perf_counter()
+                if step == 0:
+                    next_ids, logits, batch = runner.extend(reqs)
+                else:
+                    next_ids, logits = runner.decode(decode_ids, batch)
+                runner.synchronize()
+                wall_ms = (time.perf_counter() - tic) * 1000
+            if measured:
+                records.append(BatchRecord(
+                    batch_id=identifier, rank=rank,
+                    request_ids=tuple(str(req.rid) for req in reqs),
+                    prompt_lens=tuple(len(req.origin_input_ids) for req in reqs),
+                    repetition=repetition, step=step, profiled=profiled,
+                    decode_input_sha256=frozen_digests.get((bs, length)) if step > 0 else None,
+                    forward_gpu_ms=observer.start.elapsed_time(observer.end),
+                    step_wall_ms=wall_ms, **observer.snapshot,
+                ))
+                if graph_events and step > 0:
+                    if records[-1].graph_mode != "FULL":
+                        raise ValueError("Graph-event validation must execute a full decode graph")
+                    if graph_observer is not None:
+                        graph_samples.extend({"batch_id": identifier, "rank": rank, **sample}
+                            for sample in graph_observer.collect_graph(records[-1].capture_size))
+                    if decoder_graph_observer is not None:
+                        decoder_graph_samples.append({"batch_id": identifier, "rank": rank,
+                            **decoder_graph_observer.collect_graph(records[-1].capture_size)})
+                if routing and step > 0:
+                    record = records[-1]
+                    if record.graph_mode != "FULL":
+                        raise ValueError("Routing observation requires a full decode graph")
+                    routing_snapshots.append(routing_observer.snapshot_graph(
+                        physical_size=record.capture_size, logical_size=bs, batch_id=identifier, rank=rank))
+            # Only digests are retained; the ledger contains no prompt/output text.
+            tokens = next_ids.detach().cpu().numpy()
+            digest.update(tokens.tobytes())
+            token_ids.extend(int(v) for v in tokens)
+            if step == 0 and not bool(torch.isfinite(logits).all()):
+                raise RuntimeError("Checkpoint forward returned nonfinite logits")
+        observer.enabled = False
+        runner.cleanup(batch)
+        # Only the necessary device-to-host snapshots happen between steps.
+        # CPU validation, hashing, histograms and compression wait until the
+        # entire repetition ends, avoiding long serialization gaps in decode.
+        for snapshot in routing_snapshots:
+            for sample in routing_observer.summarize_snapshot(snapshot):
+                routing_stream.write(json.dumps(sample.to_dict(), separators=(",", ":")) + "\n")
+        return records, digest.hexdigest(), token_ids
+
+    operator_records = []
+    operator_samples = []
+    with (output_dir / f"batches-rank{rank}.jsonl").open("x") as ledger:
+        for bs, length in itertools.product(options["batch_size"], options["input_len"]):
+            capacity = min(runner.max_batch_size(length, options["output_len"]),
+                           getattr(actual.req_to_token_pool, "size", bs))
+            if bs > capacity:
+                raise ValueError(f"Requested batch {bs} exceeds runtime capacity {capacity}")
+            for warmup in range(options["warmups"]):
+                run_case(bs, length, warmup, measured=False)
+            reference_tokens = None
+            for repetition in range(options["repetitions"]):
+                records, digest, tokens = run_case(bs, length, repetition, measured=True)
+                if options["freeze_decode_inputs"] and (bs, length) not in frozen_inputs:
+                    trajectory, input_digest = decode_trajectory(tokens, bs, options["output_len"])
+                    frozen_inputs[(bs, length)] = torch.tensor(
+                        trajectory, dtype=torch.int64, device=f"cuda:{rank}")
+                    frozen_digests[(bs, length)] = input_digest
+                    # The first repetition generated the very trajectory that
+                    # subsequent repetitions consume; include it in the cohort.
+                    records = [dataclasses.replace(r, decode_input_sha256=input_digest)
+                               if r.phase == "decode" else r for r in records]
+                if reference_tokens is None:
+                    reference_tokens = tokens
+                differing = sum(a != b for a, b in zip(tokens, reference_tokens))
+                if server_args.tp_size > 1:
+                    digests = [None] * server_args.tp_size
+                    dist.all_gather_object(digests, digest)
+                    if len(set(digests)) != 1:
+                        raise RuntimeError("TP ranks generated different output digests")
+                output_checks.append({"batch_size": bs, "input_len": length,
+                    "repetition": repetition, "output_sha256": digest,
+                    "decode_input_sha256": frozen_digests.get((bs, length)),
+                    "output_tokens": len(tokens), "different_from_first_repeat": differing,
+                    "tp_output_agreement": True})
+                for record in records:
+                    ledger.write(json.dumps(record.to_dict()) + "\n")
+                ledger.flush()
+                if rank == 0:
+                    decode = [r.forward_gpu_ms for r in records if r.phase == "decode"]
+                    print(f"capture b={bs} l={length} repeat={repetition}: "
+                          f"prefill={records[0].forward_gpu_ms:.3f}ms "
+                          f"decode={np.median(decode):.3f}ms "
+                          f"changed_tokens={differing}/{len(tokens)}", flush=True)
+            if options["trace"]:
+                # Profiling is a separate pass, excluded from all timing summaries.
+                profiler = None
+                if rank in options["trace_ranks"]:
+                    profiler = torch.profiler.profile(activities=[
+                        torch.profiler.ProfilerActivity.CPU,
+                        torch.profiler.ProfilerActivity.CUDA,
+                    ])
+                    profiler.start()
+                records, _, _ = run_case(bs, length, 0, measured=True, profiled=True)
+                if profiler is not None:
+                    profiler.stop()
+                    profiler.export_chrome_trace(str(
+                        output_dir / f"b{bs}-l{length}-rank{rank}.trace.json.gz"
+                    ))
+                for record in records:
+                    ledger.write(json.dumps(record.to_dict()) + "\n")
+                ledger.flush()
+            if options["operator_event_layers"]:
+                from frontier.validation.sglang_operator_events import OperatorEventObserver
+
+                # Install after the baseline and trace passes. Graphs remain
+                # untouched; only eager prefill executes these Python scopes.
+                with OperatorEventObserver(actual.model, options["operator_event_layers"]) as scopes:
+                    for repetition in range(options["operator_event_repetitions"]):
+                        records, _, _ = run_case(bs, length, repetition, measured=True,
+                                                 profiled=True, operator_events=True)
+                        if records[0].graph_mode != "NONE":
+                            raise ValueError("Operator-event capture requires eager prefill")
+                        samples = scopes.collect()
+                        if not samples:
+                            raise ValueError("Operator-event scopes did not execute")
+                        operator_records.extend(records)
+                        operator_samples.extend({"batch_id": records[0].batch_id, "rank": rank, **s}
+                                                for s in samples)
+    if options["operator_event_layers"]:
+        with (output_dir / f"operator-batches-rank{rank}.jsonl").open("x") as stream:
+            for record in operator_records:
+                stream.write(json.dumps(record.to_dict()) + "\n")
+        with (output_dir / f"operator-events-rank{rank}.jsonl").open("x") as stream:
+            for sample in operator_samples:
+                stream.write(json.dumps(sample) + "\n")
+    capture_routing = bool(options["routing_layers"] or options["routing_all_layers"])
+    # Routing-only and timing+routing are separate passes. The untouched
+    # original graphs remain the unprofiled timing baseline.
+    graph_events_enabled = bool(options["graph_event_layers"] or options["graph_decoder_event"])
+    for pass_name in (["routing"] if capture_routing else []) + (["graph"] if graph_events_enabled else []):
+        from frontier.validation.sglang_graph_events import (
+            GraphDecoderEventObserver, GraphOperatorEventObserver,
+        )
+
+        # Only replace the decode runner after every ordinary baseline/trace
+        # pass has finished. No production server or persistent runtime source
+        # is changed. Keep event handles alive until this worker exits.
+        with ExitStack() as stack:
+            if pass_name == "graph":
+                if options["graph_event_layers"]:
+                    graph_observer = stack.enter_context(GraphOperatorEventObserver(actual.model,
+                        options["graph_event_layers"], components=options["graph_event_components"]))
+                if options["graph_decoder_event"]:
+                    decoder_graph_observer = stack.enter_context(
+                        GraphDecoderEventObserver(actual.model))
+            if capture_routing:
+                from frontier.validation.sglang_routing import RoutingGraphObserver
+                routing_observer = stack.enter_context(RoutingGraphObserver(actual.model,
+                    None if options["routing_all_layers"] else options["routing_layers"]))
+            actual.init_cuda_graphs()
+        if pass_name == "graph":
+            if graph_observer is not None:
+                graph_observer.validate_captures()
+            if decoder_graph_observer is not None:
+                decoder_graph_observer.validate_captures()
+        if capture_routing:
+            routing_observer.validate_captures()
+            routing_stream = gzip.open(output_dir / f"{pass_name}-routing-rank{rank}.jsonl.gz", "xt")
+            if rank == 0:
+                print(f"routing capture: {len(routing_observer.layers)} layers, pass={pass_name}", flush=True)
+        graph_records, graph_checks = [], []
+        for bs, length in itertools.product(options["batch_size"], options["input_len"]):
+            for warmup in range(options["warmups"]):
+                run_case(bs, length, warmup, measured=False, graph_events=pass_name == "graph", routing=capture_routing)
+            reference_tokens = None
+            for repetition in range(options["graph_event_repetitions"] if pass_name == "graph"
+                                    else options["routing_repetitions"]):
+                records, digest, tokens = run_case(bs, length, repetition, measured=True,
+                    profiled=True, graph_events=pass_name == "graph", routing=capture_routing)
+                if reference_tokens is None:
+                    reference_tokens = tokens
+                differing = sum(a != b for a, b in zip(tokens, reference_tokens))
+                if server_args.tp_size > 1:
+                    digests = [None] * server_args.tp_size
+                    dist.all_gather_object(digests, digest)
+                    if len(set(digests)) != 1:
+                        raise RuntimeError("Instrumented TP ranks generated different outputs")
+                graph_records.extend(records)
+                graph_checks.append({"batch_size": bs, "input_len": length, "repetition": repetition,
+                    "output_sha256": digest, "output_tokens": len(tokens),
+                    "decode_input_sha256": frozen_digests.get((bs, length)),
+                    "different_from_first_repeat": differing, "tp_output_agreement": True})
+                if rank == 0:
+                    print(f"{pass_name} b={bs} l={length} repeat={repetition}: "
+                          f"decode={np.median([r.forward_gpu_ms for r in records[1:]]):.3f}ms",
+                          flush=True)
+        if routing_stream is not None:
+            routing_stream.close()
+            routing_stream = None
+        for name, rows in ((f"{pass_name}-batches", [r.to_dict() for r in graph_records]),
+                           *([("graph-events", graph_samples)]
+                             if pass_name == "graph" and graph_observer is not None else []),
+                           *([("decoder-events", decoder_graph_samples)]
+                             if pass_name == "graph" and decoder_graph_observer is not None else [])):
+            with (output_dir / f"{name}-rank{rank}.jsonl").open("x") as stream:
+                for row in rows:
+                    stream.write(json.dumps(row) + "\n")
+        with (output_dir / f"{pass_name}-output-checks-rank{rank}.json").open("x") as stream:
+            json.dump(graph_checks, stream, indent=2)
+    with (output_dir / f"output-checks-rank{rank}.json").open("x") as stream:
+        json.dump(output_checks, stream, indent=2)
+    if server_args.tp_size > 1:
+        bench.destroy_model_parallel()
+        bench.destroy_distributed_environment()
+
+
+def main():
+    from sglang.benchmark import one_batch as bench
+    import torch
+    import torch.multiprocessing as mp
+    import sglang
+    import aiter
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    bench.ServerArgs.add_cli_args(parser)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--batch-size", type=int, nargs="+", default=[16, 24, 32])
+    parser.add_argument("--input-len", type=int, nargs="+", default=[1024])
+    parser.add_argument("--output-len", type=int, default=32)
+    parser.add_argument("--capture-warmups", type=int, default=2)
+    parser.add_argument("--repetitions", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--freeze-decode-inputs", action="store_true",
+                        help="Replay the first baseline's tokens as fixed decode inputs for each shape")
+    parser.add_argument("--trace", action="store_true")
+    parser.add_argument("--trace-ranks", type=int, nargs="+", default=[0])
+    parser.add_argument("--trace-steps", type=int, default=3)
+    parser.add_argument("--operator-event-layers", type=int, nargs="+", default=[])
+    parser.add_argument("--operator-event-repetitions", type=int, default=3)
+    parser.add_argument("--graph-event-layers", type=int, nargs="+", default=[])
+    parser.add_argument("--graph-decoder-event", action="store_true",
+                        help="Add one HIP event pair around the full decoder layer sequence")
+    parser.add_argument("--graph-event-repetitions", type=int, default=3)
+    routing_group = parser.add_mutually_exclusive_group()
+    routing_group.add_argument("--routing-layers", type=int, nargs="+", default=[])
+    routing_group.add_argument("--routing-all-layers", action="store_true")
+    parser.add_argument("--routing-repetitions", type=int, default=3)
+    from frontier.validation.sglang_graph_events import DEFAULT_COMPONENTS
+    parser.add_argument("--graph-event-components", nargs="+", default=list(DEFAULT_COMPONENTS))
+    args = parser.parse_args()
+    if (min(args.batch_size + args.input_len) <= 0 or args.output_len < 2
+            or args.capture_warmups < 1 or args.repetitions < 1 or args.trace_steps < 1):
+        parser.error("Positive shapes, warmups/repetitions/trace-steps and output-len >=2 required")
+    if len(set(args.batch_size)) != len(args.batch_size) or len(set(args.input_len)) != len(args.input_len):
+        parser.error("Duplicate shapes would produce duplicate batch IDs")
+    if args.freeze_decode_inputs and args.trace and args.trace_steps >= args.output_len:
+        parser.error("Fixed-input trace steps must fit the baseline decode trajectory")
+    if (args.routing_repetitions < 1 or any(v < 0 for v in args.routing_layers)
+            or len(set(args.routing_layers)) != len(args.routing_layers)):
+        parser.error("Routing requires unique nonnegative layers and positive repetitions")
+    if (args.routing_layers or args.routing_all_layers) and not args.freeze_decode_inputs:
+        parser.error("Routing comparison requires --freeze-decode-inputs")
+    for prefix in ("operator", "graph"):
+        layers = getattr(args, f"{prefix}_event_layers")
+        if (getattr(args, f"{prefix}_event_repetitions") < 1 or any(v < 0 for v in layers)
+                or len(set(layers)) != len(layers)):
+            parser.error("Events require unique nonnegative layer IDs and positive repetitions")
+    server_args = bench.ServerArgs.from_cli_args(args)
+    if (args.routing_layers or args.routing_all_layers) and (
+            getattr(server_args, "enable_eplb", False)
+            or getattr(server_args, "ep_num_redundant_experts", 0)
+            or getattr(server_args, "enable_return_routed_experts", False)):
+        parser.error("Routing observation requires no expert remapping or other routed-expert capturer")
+    if (server_args.nnodes != 1 or server_args.pp_size != 1 or
+            server_args.ep_size != 1 or server_args.dp_size != 1 or
+            server_args.speculative_algorithm is not None):
+        parser.error("Initial capture supports one node, TP only, and no speculation")
+    if any(r < 0 or r >= server_args.tp_size for r in args.trace_ranks):
+        parser.error("trace-ranks must belong to the TP group")
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=False)
+    options = {key: getattr(args, key) for key in (
+        "batch_size", "input_len", "output_len", "repetitions", "seed", "freeze_decode_inputs",
+        "trace", "trace_ranks", "trace_steps",
+        "operator_event_layers", "operator_event_repetitions",
+        "graph_event_layers", "graph_decoder_event", "graph_event_repetitions",
+        "graph_event_components",
+        "routing_layers", "routing_all_layers", "routing_repetitions",
+    )}
+    options["warmups"] = args.capture_warmups
+    options["output_dir"] = str(output_dir)
+    manifest = {
+        "schema_version": 1, "status": "running", "engine": "sglang",
+        "workload_mode": "static_batch", "hostname": platform.node(),
+        "model_path": server_args.model_path, "options": options,
+        "topology": {"tp": server_args.tp_size, "ep": 1, "pp": 1, "nodes": 1},
+        "versions": {"python": platform.python_version(), "torch": torch.__version__,
+                     "rocm": torch.version.hip, "sglang": _version("sglang"),
+                     "sglang_commit": _git_revision(Path(sglang.__file__).parent),
+                     "frontier_commit": _git_revision(Path(__file__).parent),
+                     "frontier_source_sha256": _source_digest(Path(__file__).parents[1]),
+                     "aiter": _version("aiter") or getattr(aiter, "__version__", None),
+                     "aiter_commit": _git_revision(Path(aiter.__file__).parent)},
+        "server_args": dataclasses.asdict(server_args),
+        "environment": {k: v for k, v in os.environ.items() if
+                        k.startswith(("SGLANG_", "HIP_VISIBLE", "ROCR_VISIBLE", "CUDA_VISIBLE"))
+                        and not any(s in k for s in ("TOKEN", "SECRET", "KEY", "PASSWORD"))},
+        "timing_contract": {
+            "forward_gpu_ms": "current-stream GPU events around ModelRunner.forward; excludes sampling",
+            "step_wall_ms": "synchronized prepare+forward+sample; excludes ledger serialization",
+            "rank_aggregation": "max of per-rank elapsed durations, not sum; ranks have no common wall origin",
+            "profiled_rows": "diagnostic only; excluded from latency correlation",
+            "operator_events": "separate eager prefill passes; nested inclusive current-stream GPU "
+                               "events on selected layers, not additive or kernel-only; no Kineto",
+            "graph_events": "separate recaptured full-decode graphs with HIP event-record nodes; "
+                            "disjoint inclusive event spans, not KERNEL_ONLY; no Kineto or eager fallback",
+            "fixed_decode_inputs": "opt-in teacher forcing from first baseline repetition per shape; "
+                                   "trajectory hashes, not tokens, are recorded; fixed token inputs do not "
+                                   "guarantee identical intermediate activations or expert routing",
+            "routing": "separate recaptured full graphs retaining top-k output references; no GPU nodes "
+                       "added; copies after measured synchronization, CPU hashes/histograms after the "
+                       "whole repetition. Retaining buffers "
+                       "can change graph memory allocation. Logical/padding selections are separate; "
+                       "valid zero-weight IDs still count as selections, not proof of executed GEMMs.",
+        },
+    }
+    # Avoid serializing authentication fields from ServerArgs into artifacts.
+    for key in list(manifest["server_args"]):
+        if any(s in key.lower() for s in ("api_key", "password", "auth_token")):
+            manifest["server_args"].pop(key)
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, default=str) + "\n")
+    try:
+        bench._set_envs_and_config(server_args)
+        port_args = bench.PortArgs.init_new(server_args)
+        # torch.spawn propagates child failures and terminates the peer workers.
+        mp.spawn(_worker, args=(server_args, port_args, options),
+                 nprocs=server_args.tp_size, join=True)
+        all_records = []
+        for rank in range(server_args.tp_size):
+            all_records.extend(read_batches(output_dir / f"batches-rank{rank}.jsonl"))
+        validate_rank_cohorts(all_records, tensor_parallel_size=server_args.tp_size)
+        with (output_dir / "batches.jsonl").open("x") as stream:
+            for record in sorted(all_records, key=lambda r: (r.batch_id, r.rank)):
+                stream.write(json.dumps(record.to_dict()) + "\n")
+        for prefix in ("operator", "graph", "routing"):
+            if prefix == "routing":
+                enabled = options["routing_layers"] or options["routing_all_layers"]
+            elif prefix == "graph":
+                enabled = options["graph_event_layers"] or options["graph_decoder_event"]
+            else:
+                enabled = options["operator_event_layers"]
+            if enabled:
+                event_records = []
+                for rank in range(server_args.tp_size):
+                    event_records.extend(read_batches(output_dir / f"{prefix}-batches-rank{rank}.jsonl"))
+                validate_rank_cohorts(event_records, tensor_parallel_size=server_args.tp_size)
+                with (output_dir / f"{prefix}-batches.jsonl").open("x") as stream:
+                    for record in sorted(event_records, key=lambda r: (r.batch_id, r.rank)):
+                        stream.write(json.dumps(record.to_dict()) + "\n")
+        manifest["status"] = "complete"
+        manifest["devices"] = [json.loads((output_dir / f"runtime-rank{rank}.json").read_text())
+                               for rank in range(server_args.tp_size)]
+    except BaseException as exc:
+        manifest.update(status="failed", error=f"{type(exc).__name__}: {exc}")
+        raise
+    finally:
+        manifest_path.write_text(json.dumps(manifest, indent=2, default=str) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontier/validation/sglang_graph_events.py
+++ b/frontier/validation/sglang_graph_events.py
@@ -1,0 +1,250 @@
+"""Capture-time scope instrumentation for SGLang full decode HIP graphs."""
+
+from __future__ import annotations
+
+from functools import wraps
+import math
+
+from frontier.validation.sglang_operator_events import OperatorEventObserver, qwen_decoder_layers
+
+
+DEFAULT_COMPONENTS = ("input_layernorm", "gdn", "full_attention",
+                      "attention_reduce_and_mlp_norm", "mlp_including_tp_reduce")
+
+
+class _UntimedBoundary:
+    def record(self, stream):
+        pass
+    def elapsed_time(self, other):
+        return 0.0
+
+
+class GraphOperatorEventObserver(OperatorEventObserver):
+    def __init__(self, model, layer_ids, *, components=DEFAULT_COMPONENTS, api=None, current_stream=None):
+        if api is None:
+            import torch
+            from frontier.validation.hip_graph_events import HipGraphEvents
+            if not torch.version.hip:
+                raise ValueError("HIP graph events require ROCm PyTorch")
+            api, current_stream = HipGraphEvents(), torch.cuda.current_stream
+        self.api = api
+        components = tuple(components)
+        self.components = set(components)
+        self._current_component = None
+        self.captures = {}
+        self.by_size = {}
+        self._validated = False
+        super().__init__(model, layer_ids, event_factory=self._event, current_stream=current_stream)
+        available = {component for _, _, _, component, _ in self._plans}
+        # The default spans both mixer kinds; a model selecting only one kind
+        # need not expose the other. Explicit unknown names fail admission.
+        missing = self.components - available
+        if (not self.components or len(self.components) != len(components)
+                or (missing and components != DEFAULT_COMPONENTS)):
+            raise ValueError(f"Unknown/empty graph timing components: {sorted(missing)}")
+
+    def _event(self):
+        return (self.api.create_event() if self._current_component in self.components
+                else _UntimedBoundary())
+
+    def _wrap(self, original, identities):
+        measured = super()._wrap(original, identities)
+
+        @wraps(original)
+        def capture_only(*args, **kwargs):
+            info = self.api.capture_info(self.current_stream())
+            if info is None:
+                return original(*args, **kwargs)  # no instrumentation in eager warmup
+            capture_id = info[0]
+            self._validated = False
+            if "decoder_layer" in identities.values():
+                batch = kwargs.get("forward_batch", args[3] if len(args) > 3 else None)
+                if batch is None or not batch.forward_mode.is_decode():
+                    raise ValueError("Graph operator events require non-speculative decode")
+                size = int(batch.batch_size)
+                if capture_id not in self.captures:
+                    self.captures[capture_id] = {"physical_size": size, "samples": []}
+                capture = self.captures[capture_id]
+                if capture["physical_size"] != size:
+                    raise ValueError("A captured graph cannot change physical batch size")
+                self._samples = capture["samples"]
+                if size in self.by_size and self.by_size[size] != capture_id:
+                    raise ValueError("Multiple graph variants for one physical size are unsupported")
+                self.by_size[size] = capture_id
+                layer = next(iter(identities))
+            elif self._stack:
+                layer = self._samples[self._stack[0]]["layer_id"]
+            else:
+                return original(*args, **kwargs)
+            self._current_component = identities.get(layer)
+            return measured(*args, **kwargs)
+        return capture_only
+
+    def collect_graph(self, physical_size):
+        if not self._validated:
+            self.validate_captures()
+        if physical_size not in self.by_size:
+            raise ValueError(f"No instrumented graph for physical batch {physical_size}")
+        capture_id = self.by_size[physical_size]
+        # Parent collection validates coverage and clears its working list.
+        # Keep the captured handles alive and reusable across graph replays.
+        self._samples = list(self.captures[capture_id]["samples"])
+        rows = super().collect()
+        return [{**row, "parent_id": None, "measurement_type": "HIP_GRAPH_EVENT",
+                 "capture_id": capture_id, "physical_size": physical_size}
+                for row in rows if row["component"] in self.components]
+
+    def validate_captures(self):
+        if not self.captures:
+            raise ValueError("No full decode graphs were instrumented")
+        expected = {(layer, component) for _, _, layer, component, _ in self._plans}
+        for capture in self.captures.values():
+            actual = [(row["layer_id"], row["component"]) for row in capture["samples"]]
+            if len(actual) != len(expected) or set(actual) != expected:
+                raise ValueError("Each graph must capture every selected scope exactly once")
+            by_id = {row["sample_id"]: row for row in capture["samples"]}
+            for row in capture["samples"]:
+                if row["component"] not in self.components:
+                    continue
+                parent = row["parent_id"]
+                while parent is not None:
+                    ancestor = by_id[parent]
+                    if ancestor["component"] in self.components:
+                        raise ValueError("Nested graph timers bias parent spans; select disjoint scopes")
+                    parent = ancestor["parent_id"]
+        self._validated = True
+
+
+class GraphDecoderEventObserver:
+    """Place only two event nodes around the complete decoder-layer sequence."""
+
+    def __init__(self, model, *, api=None, current_stream=None):
+        if api is None:
+            import torch
+            from frontier.validation.hip_graph_events import HipGraphEvents
+            if not torch.version.hip:
+                raise ValueError("HIP graph events require ROCm PyTorch")
+            api, current_stream = HipGraphEvents(), torch.cuda.current_stream
+        layers = qwen_decoder_layers(model)
+        self.api, self.current_stream = api, current_stream
+        self.first_layer_id, self.last_layer_id = min(layers), max(layers)
+        self.first, self.last = layers[self.first_layer_id], layers[self.last_layer_id]
+        self.captures, self.by_size, self._restores = {}, {}, []
+        self._validated = False
+
+    @staticmethod
+    def _batch(args, kwargs):
+        batch = kwargs.get("forward_batch", args[3] if len(args) > 3 else None)
+        if batch is None or not batch.forward_mode.is_decode():
+            raise ValueError("Decoder graph events require non-speculative decode")
+        return batch
+
+    def _capture(self, args, kwargs):
+        info = self.api.capture_info(self.current_stream())
+        if info is None:
+            return None
+        batch = self._batch(args, kwargs)
+        capture_id, physical_size = info[0], int(batch.batch_size)
+        if physical_size in self.by_size and self.by_size[physical_size] != capture_id:
+            raise ValueError("Multiple graph variants for one physical size are unsupported")
+        self.by_size[physical_size] = capture_id
+        capture = self.captures.setdefault(capture_id, {
+            "physical_size": physical_size, "start": None, "end": None})
+        if capture["physical_size"] != physical_size:
+            raise ValueError("A captured graph cannot change physical batch size")
+        self._validated = False
+        return capture_id, capture
+
+    def _wrap_first(self, original):
+        @wraps(original)
+        def first(*args, **kwargs):
+            resolved = self._capture(args, kwargs)
+            if resolved is None:
+                return original(*args, **kwargs)
+            _, capture = resolved
+            if capture["start"] is not None:
+                raise ValueError("Decoder graph start was captured more than once")
+            capture["start"] = self.api.create_event()
+            capture["start"].record(self.current_stream())
+            return original(*args, **kwargs)
+        return first
+
+    def _wrap_last(self, original):
+        @wraps(original)
+        def last(*args, **kwargs):
+            resolved = self._capture(args, kwargs)
+            if resolved is None:
+                return original(*args, **kwargs)
+            _, capture = resolved
+            if capture["start"] is None or capture["end"] is not None:
+                raise ValueError("Decoder graph end has no unique matching start")
+            result = original(*args, **kwargs)
+            capture["end"] = self.api.create_event()
+            capture["end"].record(self.current_stream())
+            return result
+        return last
+
+    def _wrap_single(self, original):
+        @wraps(original)
+        def single(*args, **kwargs):
+            resolved = self._capture(args, kwargs)
+            if resolved is None:
+                return original(*args, **kwargs)
+            _, capture = resolved
+            if capture["start"] is not None or capture["end"] is not None:
+                raise ValueError("Decoder graph was captured more than once")
+            capture["start"] = self.api.create_event()
+            capture["start"].record(self.current_stream())
+            result = original(*args, **kwargs)
+            capture["end"] = self.api.create_event()
+            capture["end"].record(self.current_stream())
+            return result
+        return single
+
+    def __enter__(self):
+        owners = (self.first,) if self.first is self.last else (self.first, self.last)
+        for owner in owners:
+            original = owner.forward
+            self._restores.append((owner, "forward" in vars(owner), original))
+        if self.first is self.last:
+            self.first.forward = self._wrap_single(self.first.forward)
+        else:
+            self.first.forward = self._wrap_first(self.first.forward)
+            self.last.forward = self._wrap_last(self.last.forward)
+        return self
+
+    def validate_captures(self):
+        if not self.captures:
+            raise ValueError("No full decoder graphs were instrumented")
+        if any(capture["start"] is None or capture["end"] is None
+               for capture in self.captures.values()):
+            raise ValueError("Every decoder graph requires exactly one start and end")
+        self._validated = True
+
+    def collect_graph(self, physical_size):
+        if not self._validated:
+            self.validate_captures()
+        if physical_size not in self.by_size:
+            raise ValueError(f"No instrumented decoder graph for physical batch {physical_size}")
+        capture_id = self.by_size[physical_size]
+        capture = self.captures[capture_id]
+        duration = float(capture["start"].elapsed_time(capture["end"]))
+        if not math.isfinite(duration) or duration <= 0:
+            raise ValueError("Invalid decoder graph event duration")
+        return {
+            "component": "decoder",
+            "first_layer_id": self.first_layer_id,
+            "last_layer_id": self.last_layer_id,
+            "measurement_type": "HIP_GRAPH_EVENT",
+            "capture_id": capture_id,
+            "physical_size": physical_size,
+            "inclusive_gpu_ms": duration,
+        }
+
+    def __exit__(self, *exc):
+        for owner, was_local, original in reversed(self._restores):
+            if was_local:
+                owner.forward = original
+            else:
+                delattr(owner, "forward")
+        self._restores.clear()

--- a/frontier/validation/sglang_operator_events.py
+++ b/frontier/validation/sglang_operator_events.py
@@ -1,0 +1,139 @@
+"""Opt-in eager operator GPU-event measurements on the loaded SGLang model.
+
+Scopes are nested/inclusive, not additive. Install only for separate diagnostic
+passes, after ordinary benchmark repetitions and graph capture. No weights,
+tensors, model outputs or persistent SGLang source files are modified.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+import math
+
+
+def qwen_decoder_layers(model, layer_ids=None):
+    """Resolve selected runtime layers once, shared by timing/routing observers."""
+    layers = {}
+    for name, module in model.named_modules():
+        if type(module).__name__ in {"Qwen3_5LinearDecoderLayer", "Qwen3_5AttentionDecoderLayer"}:
+            index = int(name.rsplit(".", 1)[-1])
+            if index in layers:
+                raise ValueError(f"Duplicate decoder layer {index}")
+            layers[index] = module
+    layer_ids = sorted(layers) if layer_ids is None else list(layer_ids)
+    if (not layer_ids or len(set(layer_ids)) != len(layer_ids) or set(layer_ids) - set(layers)
+            or any(type(i) is not int or i < 0 for i in layer_ids)):
+        raise ValueError("Requested unique operator-event layers must exist in the Qwen3.5 model")
+    return {i: layers[i] for i in layer_ids}
+
+
+class OperatorEventObserver:
+    def __init__(self, model, layer_ids: list[int], *, event_factory=None, current_stream=None):
+        if event_factory is None:
+            import torch
+            event_factory = lambda: torch.cuda.Event(enable_timing=True)
+            current_stream = torch.cuda.current_stream
+        self.event_factory = event_factory
+        self.current_stream = current_stream
+        self._restores = []
+        self._samples = []
+        self._stack = []
+        self._plans = []
+        for layer_id, layer in qwen_decoder_layers(model, layer_ids).items():
+            self._plan(layer, "forward", layer_id, "decoder_layer")
+            for name in ("input_layernorm", "post_attention_layernorm"):
+                self._plan(getattr(layer, name), "forward", layer_id, name)
+            if hasattr(layer, "linear_attn"):
+                self._plan(layer.linear_attn, "forward", layer_id, "gdn")
+                self._plan(layer.linear_attn, "_forward_input_proj", layer_id, "gdn_input_projections")
+                for name in ("attn", "norm", "out_proj"):
+                    self._plan(getattr(layer.linear_attn, name), "forward", layer_id, f"gdn_{name}")
+            else:
+                self._plan(layer, "self_attention", layer_id, "full_attention")
+                for name in ("qkv_proj", "rotary_emb", "attn", "o_proj"):
+                    self._plan(getattr(layer, name), "forward", layer_id, f"attention_{name}")
+            self._plan(layer.layer_communicator, "prepare_mlp", layer_id, "attention_reduce_and_mlp_norm")
+            self._plan(layer.mlp, "forward", layer_id, "mlp_including_tp_reduce")
+            if layer.mlp.shared_expert is None:
+                raise ValueError("Operator-event contract requires a separate shared expert")
+            for name in ("shared_expert", "gate", "topk", "experts"):
+                self._plan(getattr(layer.mlp, name), "forward", layer_id, f"moe_{name}")
+
+    def _plan(self, owner, attribute, layer, component):
+        original = getattr(owner, attribute)
+        if not callable(original):
+            raise ValueError(f"Missing callable {component}.{attribute}")
+        self._plans.append((owner, attribute, layer, component, original))
+
+    def __enter__(self):
+        # Rotary modules can be cached/shared across decoder layers. Wrap an
+        # object once and resolve ownership from the active decoder scope,
+        # otherwise calls from unselected layers would be mislabeled.
+        grouped = {}
+        for owner, attribute, layer, component, original in self._plans:
+            key = (id(owner), attribute)
+            if key not in grouped:
+                grouped[key] = (owner, attribute, original, {})
+            grouped[key][3][layer] = component
+        for owner, attribute, original, identities in grouped.values():
+            self._restores.append((owner, attribute, attribute in vars(owner), original))
+            setattr(owner, attribute, self._wrap(original, identities))
+        return self
+
+    def _wrap(self, original, identities):
+        @wraps(original)
+        def measured(*args, **kwargs):
+            if "decoder_layer" in identities.values():
+                if len(identities) != 1 or self._stack:
+                    raise ValueError("Decoder scopes must be distinct and non-nested")
+                layer = next(iter(identities))
+            else:
+                if not self._stack:
+                    return original(*args, **kwargs)
+                layer = self._samples[self._stack[0]]["layer_id"]
+                if layer not in identities:
+                    return original(*args, **kwargs)
+            component = identities[layer]
+            stream = self.current_stream()
+            start, end = self.event_factory(), self.event_factory()
+            sample_id = len(self._samples)
+            sample = {"sample_id": sample_id, "parent_id": self._stack[-1] if self._stack else None,
+                      "layer_id": layer, "component": component, "start": start, "end": end}
+            self._samples.append(sample)
+            self._stack.append(sample_id)
+            start.record(stream)
+            try:
+                return original(*args, **kwargs)
+            finally:
+                end.record(stream)
+                self._stack.pop()
+                if self.current_stream() != stream:
+                    raise ValueError("Operator scope changed its current stream")
+        return measured
+
+    def collect(self) -> list[dict]:
+        """Call only after the normal end-of-step device synchronization."""
+        if self._stack:
+            raise ValueError("Cannot collect inside an unfinished scope")
+        if self._samples:
+            expected = {(layer, component) for _, _, layer, component, _ in self._plans}
+            observed = [(sample["layer_id"], sample["component"]) for sample in self._samples]
+            if len(observed) != len(expected) or set(observed) != expected:
+                raise ValueError("Operator scopes must execute exactly once per selected layer")
+        result = []
+        for sample in self._samples:
+            duration = float(sample["start"].elapsed_time(sample["end"]))
+            if not math.isfinite(duration) or duration < 0:
+                raise ValueError("Invalid operator GPU-event timing")
+            result.append({k: v for k, v in sample.items() if k not in {"start", "end"}} |
+                          {"inclusive_gpu_ms": duration, "measurement_type": "CUDA_EVENT"})
+        self._samples.clear()
+        return result
+
+    def __exit__(self, *exc):
+        for owner, attribute, was_local, original in reversed(self._restores):
+            if was_local:
+                setattr(owner, attribute, original)
+            else:
+                delattr(owner, attribute)
+        self._restores.clear()

--- a/frontier/validation/sglang_routing.py
+++ b/frontier/validation/sglang_routing.py
@@ -1,0 +1,139 @@
+"""Retain graph-produced top-k buffers and read them only after measured forward.
+
+No GPU operation is added during capture. Retaining outputs can alter graph
+pool allocation, so routing passes remain separate, quality-checked diagnostics.
+"""
+
+from functools import wraps
+
+from frontier.validation.routing import snapshot_routing
+from frontier.validation.sglang_operator_events import qwen_decoder_layers
+
+
+class RoutingGraphObserver:
+    def __init__(self, model, layer_ids=None, *, api=None, current_stream=None, copy_to_cpu=None):
+        if api is None:
+            import torch
+            from frontier.validation.hip_graph_events import HipGraphEvents
+            if not torch.version.hip:
+                raise ValueError("Routing graph observation requires ROCm")
+            api, current_stream = HipGraphEvents(), torch.cuda.current_stream
+        self.api, self.current_stream = api, current_stream
+        self.copy_to_cpu = copy_to_cpu or self._copy_to_cpu
+        self.layers = qwen_decoder_layers(model, layer_ids)
+        self.captures, self.by_size, self._restores = {}, {}, []
+        self._active = None
+        self._validated = False
+        topk_owners = set()
+        for layer in self.layers.values():
+            if (layer.mlp.shared_expert is None or layer.mlp.num_fused_shared_experts != 0
+                    or getattr(layer.mlp, "alt_stream", None) is not None
+                    or layer.mlp.topk.topk_config.num_fused_shared_experts != 0):
+                raise ValueError("Routing contract requires separate shared experts and a single stream")
+            if not callable(layer.forward) or not callable(layer.mlp.topk.forward):
+                raise ValueError("Routing layers require callable forward/top-k boundaries")
+            if id(layer.mlp.topk) in topk_owners:
+                raise ValueError("Routing top-k modules must have distinct layer ownership")
+            topk_owners.add(id(layer.mlp.topk))
+
+    @staticmethod
+    def _copy_to_cpu(buffers):
+        import torch
+        # Stacking/copies occur AFTER outer GPU and wall timings are finalized.
+        # No hooks, clones, counters or reductions are inserted in the graph.
+        ids = torch.stack([pair[0] for pair in buffers]).detach().cpu().numpy()
+        weights = torch.stack([pair[1] for pair in buffers]).detach().cpu().numpy()
+        return ids, weights
+
+    def _install(self, owner, attribute, wrapper):
+        original = getattr(owner, attribute)
+        self._restores.append((owner, attribute, attribute in vars(owner), original))
+        setattr(owner, attribute, wrapper(original))
+
+    def __enter__(self):
+        for layer_id, layer in self.layers.items():
+            self._install(layer, "forward", lambda original, layer_id=layer_id: self._root(original, layer_id))
+            self._install(layer.mlp.topk, "forward", lambda original, layer_id=layer_id: self._topk(original, layer_id))
+        return self
+
+    def _root(self, original, layer_id):
+        @wraps(original)
+        def capture(*args, **kwargs):
+            info = self.api.capture_info(self.current_stream())
+            if info is None:
+                return original(*args, **kwargs)
+            batch = kwargs.get("forward_batch", args[3] if len(args) > 3 else None)
+            if self._active is not None or batch is None or not batch.forward_mode.is_decode():
+                raise ValueError("Routing graph requires distinct non-speculative decode layer scopes")
+            capture_id, physical = info[0], int(batch.batch_size)
+            state = self.captures.setdefault(capture_id, {"physical_size": physical, "outputs": {}})
+            if (state["physical_size"] != physical
+                    or self.by_size.setdefault(physical, capture_id) != capture_id):
+                raise ValueError("Routing graph physical size/variant mismatch")
+            self._validated = False
+            self._active = capture_id, layer_id, self.current_stream()
+            try:
+                return original(*args, **kwargs)
+            finally:
+                self._active = None
+        return capture
+
+    def _topk(self, original, layer_id):
+        @wraps(original)
+        def capture(*args, **kwargs):
+            output = original(*args, **kwargs)
+            if self._active is None:
+                return output
+            capture_id, active_layer, stream = self._active
+            if active_layer != layer_id or self.current_stream() != stream:
+                raise ValueError("Routing module ownership or stream mismatch")
+            state = self.captures[capture_id]
+            if layer_id in state["outputs"]:
+                raise ValueError("Each layer must emit top-k exactly once per graph")
+            ids, weights = getattr(output, "topk_ids", None), getattr(output, "topk_weights", None)
+            shape = (state["physical_size"], self.layers[layer_id].mlp.topk.topk_config.top_k)
+            if ids is None or weights is None or tuple(ids.shape) != shape or tuple(weights.shape) != shape:
+                raise ValueError("Requires standard top-k IDs/weights with the physical graph shape")
+            # Retain original references only; never modify the runtime outputs.
+            state["outputs"][layer_id] = (ids, weights)
+            return output
+        return capture
+
+    def validate_captures(self):
+        if self._active is not None or not self.captures:
+            raise ValueError("No complete routing graphs")
+        for state in self.captures.values():
+            if set(state["outputs"]) != set(self.layers):
+                raise ValueError("Routing graph is missing selected layers")
+        self._validated = True
+
+    def snapshot_graph(self, *, physical_size, logical_size, batch_id, rank):
+        if not self._validated:
+            self.validate_captures()
+        if physical_size not in self.by_size:
+            raise ValueError("No routing graph for physical size")
+        capture_id = self.by_size[physical_size]
+        state = self.captures[capture_id]
+        ids, weights = self.copy_to_cpu([state["outputs"][i] for i in self.layers])
+        return dict(ids=ids, weights=weights, batch_id=batch_id, rank=rank,
+                    capture_id=capture_id, logical_size=logical_size)
+
+    def summarize_snapshot(self, snapshot):
+        result = []
+        for index, (layer_id, layer) in enumerate(self.layers.items()):
+            result.append(snapshot_routing(snapshot["ids"][index], snapshot["weights"][index],
+                batch_id=snapshot["batch_id"], rank=snapshot["rank"],
+                layer_id=layer_id, capture_id=snapshot["capture_id"], logical_size=snapshot["logical_size"],
+                num_experts=layer.mlp.num_experts, top_k=layer.mlp.topk.topk_config.top_k))
+        return result
+
+    def collect_graph(self, **kwargs):
+        return self.summarize_snapshot(self.snapshot_graph(**kwargs))
+
+    def __exit__(self, *exc):
+        for owner, attribute, was_local, original in reversed(self._restores):
+            if was_local:
+                setattr(owner, attribute, original)
+            else:
+                delattr(owner, attribute)
+        self._restores.clear()

--- a/frontier/validation/trace.py
+++ b/frontier/validation/trace.py
@@ -1,0 +1,119 @@
+"""Associate synchronized batch markers with kernels in a Kineto trace."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import math
+from pathlib import Path
+
+from frontier.validation.batch_record import read_batches
+
+
+def interval_union_us(events: list[dict]) -> float:
+    """GPU busy time: overlaps count once, unlike the sum of kernel durations."""
+    end = float("-inf")
+    total = 0.0
+    for event in sorted(events, key=lambda e: float(e["ts"])):
+        start = float(event["ts"])
+        stop = start + float(event["dur"])
+        total += max(0.0, stop - max(start, end))
+        end = max(end, stop)
+    return total
+
+
+def extract_batch_kernels(trace: dict) -> dict[str, list[dict]]:
+    """Use synchronized CPU marker intervals; tolerate uncorrelated HIP graphs.
+
+    A trace must contain exactly one GPU. Separate rank files preserve rank
+    identity; summing kernels from every GPU is never a latency estimate.
+    """
+    kernels, markers = [], []
+    for event in trace.get("traceEvents", []):
+        if event.get("ph") != "X":
+            continue
+        name = str(event.get("name", ""))
+        is_marker = event.get("cat") == "user_annotation" and name.startswith("frontier.batch:")
+        if event.get("cat") == "kernel" or is_marker:
+            ts, dur = float(event["ts"]), float(event["dur"])
+            if not math.isfinite(ts) or not math.isfinite(dur) or dur < 0:
+                raise ValueError("Trace event has invalid timestamp/duration")
+            (kernels if event.get("cat") == "kernel" else markers).append(event)
+    devices = {e.get("args", {}).get("device", e.get("pid")) for e in kernels}
+    if len(devices) != 1:
+        raise ValueError("Batch trace must contain kernels from exactly one GPU")
+    if not markers:
+        raise ValueError("No frontier.batch markers found")
+    result = {}
+    previous_end = float("-inf")
+    for marker in sorted(markers, key=lambda e: float(e["ts"])):
+        name = marker["name"].removeprefix("frontier.batch:")
+        start, stop = float(marker["ts"]), float(marker["ts"]) + float(marker["dur"])
+        if start < previous_end or name in result:
+            raise ValueError("Batch markers overlap or duplicate an ID")
+        previous_end = stop
+        selected = [e for e in kernels if start <= float(e["ts"]) and
+                    float(e["ts"]) + float(e["dur"]) <= stop]
+        if not selected:
+            raise ValueError(f"Batch {name} has no kernels; profiler boundary may be incomplete")
+        result[name] = sorted(selected, key=lambda e: float(e["ts"]))
+    return result
+
+
+def summarize_batch_kernels(events: list[dict], *, phase: str, gdn_layers: int) -> dict:
+    kernel_sum = sum(float(e["dur"]) for e in events) / 1000
+    busy = interval_union_us(events) / 1000
+    span = (max(float(e["ts"]) + float(e["dur"]) for e in events)
+            - min(float(e["ts"]) for e in events)) / 1000
+    allreduce = [e for e in events if any(name in str(e["name"]) for name in
+                 ("quickreduce::allreduce", "cross_device_reduce", "ncclDevKernel_AllReduce",
+                  "ncclKernel_AllReduce"))]
+    summary = {
+        "kernel_count": len(events), "step_kernel_sum_ms": kernel_sum,
+        "step_gpu_busy_ms": busy, "step_gpu_span_ms": span,
+        "step_gpu_gap_ms": max(0, span - busy),
+        "step_kernel_overlap_ms": max(0, kernel_sum - busy),
+        "allreduce_kernel_sum_ms": sum(float(e["dur"]) for e in allreduce) / 1000,
+        "allreduce_count": len(allreduce),
+    }
+    if gdn_layers:
+        from frontier.profiling.gdn.sglang_trace import extract_sglang_gdn_event_samples
+        samples = extract_sglang_gdn_event_samples(events, phase=phase)
+        count = len(samples["gdn_layer_e2e"])
+        if count != gdn_layers:
+            raise ValueError(f"Batch contains {count} GDN layers; expected exactly {gdn_layers}")
+        summary["gdn_samples_ms"] = samples
+        summary["gdn_kernel_sum_ms"] = sum(samples["gdn_layer_e2e"])
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace", required=True)
+    parser.add_argument("--ledger", required=True)
+    parser.add_argument("--rank", required=True, type=int)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    from frontier.profiling.common.model_config import ModelConfig
+    config = ModelConfig.from_model_name(args.model)
+    opener = gzip.open if args.trace.endswith(".gz") else open
+    with opener(args.trace, "rt", encoding="utf-8") as stream:
+        batches = extract_batch_kernels(json.load(stream))
+    records = {r.batch_id: r for r in read_batches(args.ledger) if r.rank == args.rank}
+    rows = []
+    for batch_id, kernels in batches.items():
+        record = records[batch_id]
+        if not record.profiled:
+            raise ValueError("Trace markers must refer to profiled ledger rows")
+        rows.append({"batch_id": batch_id, "rank": args.rank, "shape": record.to_dict(),
+                     **summarize_batch_kernels(kernels, phase=record.phase,
+                                              gdn_layers=config.get_num_gdn_layers())})
+    with Path(args.output).open("x") as stream:
+        json.dump(rows, stream, indent=2)
+        stream.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_hip_graph_events_gpu.py
+++ b/tests/integration/test_hip_graph_events_gpu.py
@@ -1,0 +1,94 @@
+"""Explicit opt-in GPU test; never reserve GPUs during ordinary CPU tests."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(os.environ.get("FRONTIER_RUN_HIP_GRAPH_TEST") != "1",
+                    reason="Set FRONTIER_RUN_HIP_GRAPH_TEST=1 on an idle ROCm GPU")
+def test_hip_graph_event_nodes_preserve_results_and_replay_timestamps():
+    torch = pytest.importorskip("torch")
+    if not torch.version.hip or not torch.cuda.is_available():
+        pytest.skip("ROCm GPU required")
+    from frontier.validation.hip_graph_events import HipGraphEvents
+
+    api = HipGraphEvents()
+    stream = torch.cuda.Stream()
+    tensor = torch.ones(1024, device="cuda")
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(10):
+            tensor.add_(1)
+    stream.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        start, end = api.create_event(), api.create_event()
+        start.record(stream)
+        for _ in range(100):
+            tensor.add_(1)
+        end.record(stream)
+    tensor.zero_()
+    outer_start, outer_end = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+    for repetition in range(3):
+        outer_start.record()
+        graph.replay()
+        outer_end.record()
+        torch.cuda.synchronize()
+        assert bool((tensor == 100 * (repetition + 1)).all())
+        assert 0 < start.elapsed_time(end) <= outer_start.elapsed_time(outer_end)
+    del graph
+    api.close_after_graphs_destroyed()
+
+
+@pytest.mark.skipif(os.environ.get("FRONTIER_RUN_HIP_GRAPH_TEST") != "1",
+                    reason="Set FRONTIER_RUN_HIP_GRAPH_TEST=1 on an idle ROCm GPU")
+def test_routing_buffers_follow_gpu_graph_replay_without_modifying_outputs():
+    from types import SimpleNamespace
+    torch = pytest.importorskip("torch")
+    if not torch.version.hip or not torch.cuda.is_available():
+        pytest.skip("ROCm GPU required")
+    from frontier.validation.sglang_routing import RoutingGraphObserver
+
+    class Qwen3_5LinearDecoderLayer:
+        def __init__(self):
+            self.mlp = SimpleNamespace(num_experts=4, num_fused_shared_experts=0,
+                shared_expert=object(), topk=SimpleNamespace(forward=self.route,
+                    topk_config=SimpleNamespace(top_k=2, num_fused_shared_experts=0)))
+
+        def route(self, scores):
+            values, ids = torch.topk(scores, 2, dim=-1)
+            return SimpleNamespace(topk_ids=ids, topk_weights=torch.softmax(values, dim=-1))
+
+        def forward(self, scores, forward_batch=None):
+            return self.mlp.topk.forward(scores)
+
+    layer = Qwen3_5LinearDecoderLayer()
+    model = SimpleNamespace(named_modules=lambda: [("layers.0", layer)])
+    batch = SimpleNamespace(batch_size=3, forward_mode=SimpleNamespace(is_decode=lambda: True))
+    scores = torch.tensor([[4., 3., 2., 1.], [1., 2., 4., 3.], [1., 2., 3., 4.]], device="cuda")
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(10):
+            layer.forward(scores)
+    stream.synchronize()
+    observer = RoutingGraphObserver(model)
+    graph = torch.cuda.CUDAGraph()
+    with observer, torch.cuda.graph(graph, stream=stream):
+        output = layer.forward(scores, forward_batch=batch)
+    observer.validate_captures()
+    graph.replay()
+    torch.cuda.synchronize()
+    expected = layer.route(scores)
+    assert torch.equal(output.topk_ids, expected.topk_ids)
+    assert torch.equal(output.topk_weights, expected.topk_weights)
+    saved = observer.snapshot_graph(physical_size=3, logical_size=2, batch_id="b", rank=0)
+    scores.neg_()
+    graph.replay()
+    torch.cuda.synchronize()
+    later = observer.collect_graph(physical_size=3, logical_size=2, batch_id="c", rank=0)[0]
+    earlier = observer.summarize_snapshot(saved)[0]
+    assert earlier.logical_assignment_sha256 != later.logical_assignment_sha256
+    assert earlier.logical_expert_counts == (1, 1, 1, 1)
+    assert earlier.padding_expert_counts == (0, 0, 1, 1)

--- a/tests/integration/test_validation_simulator_matrix.py
+++ b/tests/integration/test_validation_simulator_matrix.py
@@ -1,0 +1,62 @@
+"""64 CPU-only serving scenarios guarding unchanged simulator execution.
+
+These are structural regression checks using dummy timings, not numerical
+correlation evidence. Run explicitly when changing capture/replay integration.
+"""
+
+from itertools import product
+from pathlib import Path
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+CASES = list(product(
+    ("meta-llama/Llama-2-7b-hf", "Phi-tiny-MoE-instruct"),
+    ("offline", "online"), (32, 128), (1, 4), (1.0, 8.0), (False, True),
+))
+
+
+@pytest.mark.parametrize("model,mode,length,count,qps,graphs", CASES)
+def test_capture_integration_preserves_serving_matrix(tmp_path, model, mode, length, count, qps, graphs):
+    command = [sys.executable, "-m", "frontier.main",
+        "--simulation_mode", mode, "--sys_arch", "co-location",
+        "--cc_backend_config_type", "analytical", "--cluster_config_num_replicas", "1",
+        "--replica_config_model_name", model, "--replica_config_device", "mi355x",
+        "--replica_config_network_device", "mi355x_ubb",
+        "--replica_config_attn_tensor_parallel_size", "2",
+        "--replica_config_moe_tensor_parallel_size", "2",
+        "--replica_config_moe_expert_parallel_size", "1",
+        "--replica_config_num_pipeline_stages", "1",
+        "--replica_scheduler_config_type", "sglang",
+        "--sglang_scheduler_config_block_size", "1",
+        "--sglang_scheduler_config_num_blocks_mode", "explicit",
+        "--sglang_scheduler_config_num_blocks", "4096",
+        "--sglang_scheduler_config_max_tokens_in_batch", "256",
+        "--sglang_scheduler_config_enable_chunked_prefill",
+        "--decode_cuda_graph_mode", "full_decode_only" if graphs else "none",
+        "--random_forrest_execution_time_predictor_config_enable_dummy_mode",
+        "--request_generator_config_type", "synthetic",
+        "--synthetic_request_generator_config_num_requests", str(count),
+        "--length_generator_config_type", "fixed",
+        "--fixed_request_length_generator_config_prefill_tokens", str(length),
+        "--fixed_request_length_generator_config_decode_tokens", "3",
+        "--interval_generator_config_type", "poisson",
+        "--poisson_request_interval_generator_config_qps", str(qps),
+        "--metrics_config_output_dir", str(tmp_path),
+        "--metrics_config_run_id", "regression",
+        "--metrics_config_write_metrics", "--metrics_config_store_request_metrics",
+        "--no-metrics_config_store_plots", "--no-metrics_config_write_json_trace",
+        "--no-metrics_config_enable_chrome_trace"]
+    result = subprocess.run(command, cwd=Path(__file__).resolve().parents[2],
+                            env={**os.environ, "FRONTIER_LOG_LEVEL": "ERROR"},
+                            capture_output=True, text=True, timeout=90)
+    assert result.returncode == 0, result.stdout[-3000:] + result.stderr[-3000:]
+    metrics = list(tmp_path.rglob("request_metrics.csv"))
+    assert len(metrics) == 1
+    import pandas as pd
+    requests = pd.read_csv(metrics[0])
+    assert len(requests) == count
+    assert (requests["ttft"] >= 0).all()

--- a/tests/unit/test_batch_validation.py
+++ b/tests/unit/test_batch_validation.py
@@ -1,0 +1,187 @@
+from dataclasses import replace
+from itertools import product
+from types import SimpleNamespace
+import json
+
+import pytest
+
+from frontier.validation.batch_record import BatchRecord, read_batches, validate_rank_cohorts
+from frontier.validation.replay import replay_batches, summarize_errors
+from frontier.validation.sglang_capture import decode_trajectory, snapshot_forward_batch
+from frontier.validation.trace import extract_batch_kernels, interval_union_us
+
+
+def record(**updates):
+    fields = dict(batch_id="b", rank=0, phase="decode", request_ids=("a", "b", "c"),
+                  query_lens=(1, 1, 1), context_lens=(1024, 2048, 4096),
+                  prefill_mask=(False,) * 3, graph_mode="FULL", capture_size=4,
+                  forward_gpu_ms=20.0, step_wall_ms=22.0)
+    fields.update(updates)
+    return BatchRecord(**fields)
+
+
+def test_record_roundtrip_and_duplicate_detection(tmp_path):
+    path = tmp_path / "batches.jsonl"
+    path.write_text(json.dumps(record().to_dict()) + "\n")
+    assert read_batches(path) == [record()]
+    path.write_text(path.read_text() * 2)
+    with pytest.raises(ValueError, match="Duplicate batch/rank"):
+        read_batches(path)
+
+
+@pytest.mark.parametrize("change", [
+    {"rank": -1}, {"rank": True}, {"schema_version": 2},
+    {"query_lens": (0, 1, 1)}, {"query_lens": (2, 1, 1)},
+    {"context_lens": (0, 1, 1)}, {"context_lens": (-1, 1, 1)},
+    {"prefill_mask": (False, False)}, {"prefill_mask": (0, 0, 0)},
+    {"phase": "prefill"}, {"capture_size": 2},
+    {"graph_mode": "NONE"}, {"graph_mode": "PIECEWISE"},
+    {"request_ids": ("a", "a", "c")}, {"request_ids": (1, 2, 3)},
+    {"forward_gpu_ms": float("nan")}, {"forward_gpu_ms": 0},
+    {"step_wall_ms": -1}, {"profiled": "false"},
+    {"decode_input_sha256": "short"}, {"decode_input_sha256": "G" * 64},
+    {"decode_input_sha256": 0},
+])
+def test_record_rejects_invalid_runtime_contract(change):
+    with pytest.raises(ValueError):
+        record(**change)
+
+
+def test_tp_cohort_requires_all_ranks_and_matching_shapes():
+    with pytest.raises(ValueError, match="Incomplete"):
+        validate_rank_cohorts([record()], tensor_parallel_size=2)
+    with pytest.raises(ValueError, match="disagree"):
+        validate_rank_cohorts([record(), record(rank=1, capture_size=8)], tensor_parallel_size=2)
+    assert len(validate_rank_cohorts([record(), record(rank=1)], tensor_parallel_size=2)) == 1
+    with pytest.raises(ValueError, match="disagree"):
+        validate_rank_cohorts([record(), record(rank=1, decode_input_sha256="a" * 64)],
+                              tensor_parallel_size=2)
+
+
+def test_fixed_decode_trajectory_excludes_last_output_and_retains_step_order():
+    rows, digest = decode_trajectory([11, 12, 21, 22, 31, 32], 2, 3)
+    assert rows == ((11, 12), (21, 22))
+    assert digest == decode_trajectory([11, 12, 21, 22, 99, 99], 2, 3)[1]
+    assert digest != decode_trajectory([11, 12, 99, 22, 31, 32], 2, 3)[1]
+    assert record(decode_input_sha256=digest).decode_input_sha256 == digest
+
+
+@pytest.mark.parametrize("tokens,bs,steps", [([1], 1, 2), ([1, -1], 1, 2),
+    ([True, 2], 1, 2), ([], 0, 2), ([1], 1, 1)])
+def test_incomplete_or_invalid_decode_trajectory_fails(tokens, bs, steps):
+    with pytest.raises(ValueError, match="trajectory"):
+        decode_trajectory(tokens, bs, steps)
+
+
+# 64 concrete snapshots across dense/MoE, prefill/decode, lengths, request
+# counts, and graph toggles. Scheduling mode/QPS cannot alter locked shapes.
+@pytest.mark.parametrize("is_moe,phase,size,context,graphs", list(product(
+    (False, True), ("prefill", "decode"), (1, 3, 8, 17), (128, 4096), (False, True)
+)))
+def test_locked_replay_shape_matrix(is_moe, phase, size, context, graphs):
+    prefill = phase == "prefill"
+    full = graphs and not prefill
+    padded = ((size + 3) // 4) * 4
+    row = record(phase=phase, request_ids=tuple(str(i) for i in range(size)),
+                 query_lens=(16 if prefill else 1,) * size,
+                 context_lens=(context,) * size, prefill_mask=(prefill,) * size,
+                 graph_mode="FULL" if full else "NONE", capture_size=padded if full else 0)
+    batch = row.to_frontier_batch(is_moe=is_moe)
+    assert batch.is_moe == is_moe
+    assert batch.size == size
+    assert batch.total_num_tokens == size * (16 if prefill else 1)
+    assert batch.num_prefill_tokens == (size * 16 if prefill else 0)
+    assert [r.num_processed_tokens for r in batch.requests] == [context] * size
+    assert batch.get_decode_cuda_graph_runtime_mode() == row.graph_mode
+    from frontier.types import ClusterType
+    assert batch.get_effective_total_tokens_for_compute(ClusterType.MONOLITHIC) == (
+        padded if full else batch.total_num_tokens
+    )
+    from frontier.gdn.predictor import GDNBatchFeatures
+    features = GDNBatchFeatures.from_batch(batch)
+    assert features.batch_size == (padded if full else size)
+    assert features.batch_num_tokens == (padded if full else batch.total_num_tokens)
+
+
+def test_mixed_snapshot_preserves_continuation_prefill_and_decode():
+    batch = record(phase="mixed", prefill_mask=(True, False, True),
+                   query_lens=(128, 1, 16), context_lens=(0, 100, 256),
+                   graph_mode="NONE", capture_size=0).to_frontier_batch(is_moe=True)
+    assert batch.num_prefill_tokens == 144
+    assert batch.num_decode_tokens == 1
+    assert [r.is_prefill_complete for r in batch.requests] == [False, True, False]
+
+
+def test_snapshot_preserves_original_prompt_and_decode_progress():
+    batch = record(prompt_lens=(1024, 1024, 1024)).to_frontier_batch(is_moe=True)
+    assert [r.num_processed_decode_tokens for r in batch.requests] == [0, 1024, 3072]
+    with pytest.raises(ValueError, match="progress"):
+        record(prompt_lens=(2000, 2000, 2000))
+
+
+def test_replay_uses_model_milliseconds_and_slowest_rank_excludes_profiled_rows():
+    class Predictor:
+        def predict_stage_execution_time(self, batch, **kwargs):
+            assert not hasattr(batch, "forward_gpu_ms")
+            assert kwargs["num_layers"] == 92
+            return SimpleNamespace(model_time_ms=22.0, total_time=999.0)
+    rows = replay_batches([
+        record(), record(rank=1, forward_gpu_ms=25.0),
+        record(batch_id="trace", profiled=True), record(batch_id="trace", rank=1, profiled=True)
+    ], Predictor(), model_config=SimpleNamespace(is_moe=True, num_layers=92), tensor_parallel_size=2)
+    assert len(rows) == 1
+    assert rows[0]["observed_forward_gpu_ms"] == 25
+    assert rows[0]["signed_error_pct"] == pytest.approx(-12)
+    assert summarize_errors(rows)["all"]["mape_pct"] == pytest.approx(12)
+
+
+def test_dummy_and_missing_observations_cannot_report_parity():
+    with pytest.raises(ValueError, match="Dummy"):
+        replay_batches([record()], SimpleNamespace(_enable_dummy_mode=True),
+                       model_config=None, tensor_parallel_size=1)
+    with pytest.raises(ValueError, match="Missing forward"):
+        replay_batches([record(forward_gpu_ms=None)], object(),
+                       model_config=None, tensor_parallel_size=1)
+
+
+def test_sglang_cpu_snapshot_decode_context_excludes_current_token():
+    batch = SimpleNamespace(batch_size=3, seq_lens_cpu=[1025, 2049, 4097],
+                            forward_mode=SimpleNamespace(is_decode=lambda: True))
+    result = snapshot_forward_batch(batch)
+    assert result["context_lens"] == (1024, 2048, 4096)
+
+
+def test_sglang_cpu_snapshot_continuation_and_no_device_copy():
+    batch = SimpleNamespace(batch_size=2, extend_seq_lens_cpu=[1, 128],
+                            extend_prefix_lens_cpu=[128, 0], forward_mode=SimpleNamespace(
+                                is_decode=lambda: False, is_extend=lambda: True,
+                                is_mixed=lambda: False))
+    result = snapshot_forward_batch(batch)
+    assert result["prefill_mask"] == (True, True)  # a one-token extend is still prefill
+    batch.extend_prefix_lens_cpu = SimpleNamespace(device=SimpleNamespace(type="cuda"))
+    with pytest.raises(ValueError, match="CPU-resident"):
+        snapshot_forward_batch(batch)
+
+
+def event(name, ts, dur, cat="kernel", device=0):
+    return dict(name=name, ts=ts, dur=dur, cat=cat, ph="X", args={"device": device})
+
+
+def test_trace_groups_by_synchronized_marker_and_counts_overlap_once():
+    kernels = [event("gemm", 10, 10), event("reduce", 15, 15), event("sample", 40, 5)]
+    assert interval_union_us(kernels) == 25
+    trace = {"traceEvents": [event("frontier.batch:b", 0, 50, "user_annotation"),
+                            event("frontier.batch:b", 5, 42, "gpu_user_annotation"), *kernels]}
+    assert extract_batch_kernels(trace) == {"b": kernels}
+    trace["traceEvents"].append(event("other GPU", 20, 5, device=1))
+    with pytest.raises(ValueError, match="exactly one GPU"):
+        extract_batch_kernels(trace)
+
+
+def test_trace_rejects_missing_or_overlapping_markers():
+    with pytest.raises(ValueError, match="No frontier.batch"):
+        extract_batch_kernels({"traceEvents": [event("gemm", 0, 10)]})
+    with pytest.raises(ValueError, match="overlap"):
+        extract_batch_kernels({"traceEvents": [event("gemm", 5, 5),
+            event("frontier.batch:a", 0, 20, "user_annotation"),
+            event("frontier.batch:b", 10, 20, "user_annotation")]})

--- a/tests/unit/test_collectives_rocm_runner.py
+++ b/tests/unit/test_collectives_rocm_runner.py
@@ -1,0 +1,33 @@
+from frontier.profiling.collectives.collectives_input import CollectivesInput
+from frontier.profiling.collectives.main import SUPPORTED_COLLECTIVE_PRECISIONS
+from frontier.profiling.utils import get_collectives_inputs
+
+
+def test_single_node_collective_grid_uses_exact_worker_counts() -> None:
+    inputs = get_collectives_inputs(
+        num_nodes=1,
+        num_workers_per_node_combinations=[1, 2, 4, 8],
+        max_collective_size=1024,
+        collective="all_reduce",
+        total_gpus_available=8,
+        precision="BF16",
+    )
+
+    assert [item.num_workers for item in inputs] == [2, 4, 8]
+    assert [item.num_workers_per_node for item in inputs] == [2, 4, 8]
+    assert all(item.precision == "BF16" for item in inputs)
+
+
+def test_partial_node_worker_layout_is_invalid() -> None:
+    collectives_input = CollectivesInput(
+        num_workers=2,
+        num_workers_per_node=4,
+        collective_size=1024,
+        collective="all_reduce",
+    )
+
+    assert not collectives_input.is_valid(total_gpus_available=8, num_nodes=1)
+
+
+def test_collective_cli_exposes_supported_runtime_dtypes() -> None:
+    assert SUPPORTED_COLLECTIVE_PRECISIONS == ("FP16", "BF16", "FP32")

--- a/tests/unit/test_gdn_config_contract.py
+++ b/tests/unit/test_gdn_config_contract.py
@@ -1,0 +1,82 @@
+import pytest
+
+from frontier.gdn import (
+    GatedDeltaNetConfig,
+    SequenceMixerType,
+    build_sequence_mixer_schedule,
+)
+
+
+def test_interval_schedule_matches_qwen_three_gdn_then_attention() -> None:
+    schedule = build_sequence_mixer_schedule(
+        num_layers=8,
+        layer_types=None,
+        full_attention_interval=4,
+        has_gated_delta_net=True,
+    )
+
+    assert schedule == (
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.FULL_ATTENTION,
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.FULL_ATTENTION,
+    )
+
+
+def test_explicit_hf_linear_attention_alias_normalizes_to_gdn() -> None:
+    schedule = build_sequence_mixer_schedule(
+        num_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+        full_attention_interval=None,
+        has_gated_delta_net=True,
+    )
+
+    assert schedule == (
+        SequenceMixerType.GATED_DELTA_NET,
+        SequenceMixerType.FULL_ATTENTION,
+    )
+
+
+def test_schedule_rejects_gdn_without_shape_contract() -> None:
+    with pytest.raises(ValueError, match="shape configuration is incomplete"):
+        build_sequence_mixer_schedule(
+            num_layers=4,
+            layer_types=None,
+            full_attention_interval=4,
+            has_gated_delta_net=False,
+        )
+
+
+def test_gdn_state_layout_rejects_non_divisible_tensor_parallelism() -> None:
+    config = GatedDeltaNetConfig(
+        conv_kernel_size=4,
+        key_head_dim=128,
+        value_head_dim=128,
+        num_key_heads=16,
+        num_value_heads=128,
+    )
+
+    with pytest.raises(ValueError, match="key heads must be divisible"):
+        config.get_state_layout(tensor_parallel_size=3)
+
+
+def test_speculative_tokens_expand_only_conv_state_width() -> None:
+    config = GatedDeltaNetConfig(
+        conv_kernel_size=4,
+        key_head_dim=128,
+        value_head_dim=128,
+        num_key_heads=16,
+        num_value_heads=128,
+    )
+
+    layout = config.get_state_layout(
+        tensor_parallel_size=8,
+        num_speculative_tokens=4,
+    )
+
+    assert layout.conv_state_shape == (7, 2560)
+    assert layout.recurrent_state_shape == (16, 128, 128)

--- a/tests/unit/test_gdn_correlation.py
+++ b/tests/unit/test_gdn_correlation.py
@@ -1,0 +1,71 @@
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from frontier.validation.batch_record import BatchRecord
+from frontier.validation.gdn_correlation import correlate
+from tests.unit.test_gdn_sglang_trace import _write_trace
+
+
+MODEL = "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+
+
+def capture_fixture(tmp_path: Path):
+    capture = tmp_path / "capture"
+    capture.mkdir()
+    (capture / "manifest.json").write_text(json.dumps({
+        "status": "complete", "model_path": MODEL, "versions": {"sglang": "test"},
+        "topology": {"tp": 8, "ep": 1, "pp": 1, "nodes": 1},
+    }))
+    records = []
+    for size in (16, 24, 32):
+        events, offset = [], 0.0
+        for step, phase in enumerate(("prefill", "decode", "decode")):
+            template = _write_trace(tmp_path, phase, repeats=69)
+            with gzip.open(template, "rt") as stream:
+                kernels = json.load(stream)["traceEvents"]
+            batch_id = f"b{size}-s{step}"
+            # A linear, analytically checkable latency curve in each phase.
+            scale = size / 16
+            for kernel in kernels:
+                kernel["ts"] = offset + float(kernel["ts"]) * scale + 1
+                kernel["dur"] *= scale
+                kernel["args"] = {"device": 0}
+            duration = kernels[-1]["ts"] + kernels[-1]["dur"] - offset + 1
+            events.append({"name": f"frontier.batch:{batch_id}", "ph": "X",
+                           "cat": "user_annotation", "ts": offset, "dur": duration})
+            events.extend(kernels)
+            offset += duration + 10
+            record = BatchRecord(batch_id=batch_id, rank=0, phase=phase,
+                request_ids=tuple(str(i) for i in range(size)),
+                query_lens=(1024 if phase == "prefill" else 1,) * size,
+                context_lens=(0 if phase == "prefill" else 1024 + step - 1,) * size,
+                prefill_mask=(phase == "prefill",) * size,
+                graph_mode="NONE" if phase == "prefill" else "FULL",
+                capture_size=0 if phase == "prefill" else size, profiled=True, step=step)
+            records.append(record)
+        with gzip.open(capture / f"b{size}-rank0.trace.json.gz", "wt") as stream:
+            json.dump({"traceEvents": events}, stream)
+    (capture / "batches.jsonl").write_text("".join(json.dumps(r.to_dict()) + "\n" for r in records))
+    return capture
+
+
+def test_trace_calibration_pools_repeated_decode_rows_and_excludes_validation(tmp_path):
+    frame, summaries, rows, report = correlate(capture_fixture(tmp_path), model=MODEL,
+        device="mi355x", calibration_sizes={16, 32}, validation_sizes={24})
+    assert set(frame["batch_size"]) == {16, 32}
+    assert len(frame) == 4  # repeated decode passes pool samples before fitting
+    assert len(rows) == 3
+    assert len(summaries) == 9
+    assert max(row["absolute_error_pct"] for row in rows) < 1e-10
+    assert report["by_phase"]["decode"]["batches"] == 2
+
+
+def test_calibration_rejects_overlap_and_missing_validation_shapes(tmp_path):
+    path = capture_fixture(tmp_path)
+    with pytest.raises(ValueError, match="disjoint"):
+        correlate(path, model=MODEL, device="mi355x", calibration_sizes={16, 24}, validation_sizes={24})
+    with pytest.raises(ValueError, match="Missing complete"):
+        correlate(path, model=MODEL, device="mi355x", calibration_sizes={16, 32}, validation_sizes={8})

--- a/tests/unit/test_gdn_memory_accounting.py
+++ b/tests/unit/test_gdn_memory_accounting.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+from typing import cast
+
+from frontier.config import ReplicaConfig
+from frontier.config.kv_cache_transfer_config import AnalyticalKVCacheTransferConfig
+from frontier.kv_cache_transfer.analytical_kv_cache_transfer_predictor import (
+    AnalyticalKVCacheTransferPredictor,
+)
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.scheduler.utils.memory_planner import MemoryPlanner
+from frontier.types import ClusterType
+from frontier.utils.param_counter import ParamCounter
+
+
+MODEL_NAME = "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+
+
+def _replica_config(*, tp_size: int = 1, pp_size: int = 1):
+    return cast(
+        ReplicaConfig,
+        SimpleNamespace(
+            model_config=ModelConfig.from_model_name(MODEL_NAME),
+            model_name=MODEL_NAME,
+            attn_tensor_parallel_size=tp_size,
+            moe_tensor_parallel_size=tp_size,
+            moe_expert_parallel_size=1,
+            num_pipeline_stages=pp_size,
+        ),
+    )
+
+
+def test_qwen_gdn_parameter_formula_matches_live_vllm_module() -> None:
+    counter = ParamCounter(_replica_config(), ClusterType.MONOLITHIC)
+
+    assert counter.get_num_gdn_params_per_layer() == 438_387_072
+    assert counter.get_gdn_parameter_memory_bytes_per_layer() == 876_774_400
+    assert counter.get_num_attention_params_per_layer() == 285_212_672
+    assert counter.get_num_attention_parameters_per_device() == 36_808_599_424
+    assert (
+        counter.get_attention_parameter_memory_per_device_bytes()
+        == 73_617_216_512
+    )
+
+
+def test_qwen_hybrid_parameter_memory_uses_largest_exact_pp_stage() -> None:
+    counter = ParamCounter(
+        _replica_config(tp_size=1, pp_size=4),
+        ClusterType.MONOLITHIC,
+    )
+
+    # Stage 0 owns 18 GDN + 5 full-attention layers; the other stages own
+    # 17 GDN + 6 full-attention layers, so stage 0 is the largest weight shard.
+    assert counter.get_num_attention_parameters_per_device() == 9_317_030_656
+    expected_bytes = 18 * 876_774_400 + 5 * (2 * 285_212_672)
+    assert counter.get_attention_parameter_memory_per_device_bytes() == expected_bytes
+
+
+def test_memory_planner_reserves_fixed_gdn_state_before_dense_kv_blocks() -> None:
+    replica_config = _replica_config(tp_size=4, pp_size=4)
+    replica = SimpleNamespace(
+        num_layers=92,
+        num_layers_per_pipeline_stage=23,
+        num_pipeline_stages=4,
+        max_request_tokens=4096,
+        kv_heads_per_tensor_parallel_worker=1,
+        attention_head_dim=256,
+        total_memory_gb=100,
+        memory_margin_fraction=0.0,
+    )
+    planner = MemoryPlanner(
+        replica_config=replica_config,
+        replica=replica,
+        cluster_type=ClusterType.MONOLITHIC,
+        max_num_seqs=128,
+    )
+
+    state_per_request = 18 * 2_127_872
+    assert planner._get_num_gdn_layers_per_device() == 18
+    assert planner._get_num_full_attention_layers_per_device() == 6
+    assert (
+        planner.get_gdn_state_memory_per_device_per_request_bytes()
+        == state_per_request
+    )
+
+    # Isolate the cache calculation from the model's very large MoE weights.
+    planner._get_parameter_memory_per_device = lambda: 0
+    requested_bytes = 100 * 1024**3
+    page_size = 2 * 16 * (2 * 1 * 256)
+    expected_blocks = (
+        requested_bytes - 128 * state_per_request
+    ) // page_size // 6
+    assert planner.get_num_blocks(block_size=16, gpu_memory_utilization=1.0) == (
+        expected_blocks
+    )
+
+
+def test_hybrid_kv_transfer_includes_dense_tokens_and_fixed_gdn_state() -> None:
+    predictor = AnalyticalKVCacheTransferPredictor(
+        AnalyticalKVCacheTransferConfig(kv_cache_dtype_size_bytes=2)
+    )
+    replica_config = _replica_config()
+    request = SimpleNamespace(num_prefill_tokens=16)
+
+    size_bytes = predictor.get_kv_cache_size_for_request(request, replica_config)
+
+    dense_kv_bytes = 16 * 23 * 4 * 256 * 2 * 2
+    gdn_state_bytes = 69 * 8_511_488
+    assert size_bytes == dense_kv_bytes + gdn_state_bytes
+
+
+def test_hybrid_kv_transfer_charges_gdn_state_once_per_request() -> None:
+    predictor = AnalyticalKVCacheTransferPredictor(
+        AnalyticalKVCacheTransferConfig(kv_cache_dtype_size_bytes=2)
+    )
+    replica_config = _replica_config()
+    batch = SimpleNamespace(
+        requests=[
+            SimpleNamespace(num_prefill_tokens=16),
+            SimpleNamespace(num_prefill_tokens=32),
+        ]
+    )
+
+    size_bytes = predictor.get_kv_cache_size(batch, replica_config)
+
+    dense_kv_bytes = 48 * 23 * 4 * 256 * 2 * 2
+    gdn_state_bytes = 2 * 69 * 8_511_488
+    assert size_bytes == dense_kv_bytes + gdn_state_bytes

--- a/tests/unit/test_gdn_operator_family.py
+++ b/tests/unit/test_gdn_operator_family.py
@@ -1,0 +1,92 @@
+import pandas as pd
+
+from frontier.entities.time_components import (
+    AttentionOperatorTimes,
+    AttentionTime,
+    canonical_operator_execution_time_attrs,
+)
+from frontier.gdn import GATED_DELTA_NET_FAMILY
+from frontier.gdn.profiling_schema import (
+    get_required_gdn_profiling_columns,
+    validate_gdn_profiling_dataframe,
+)
+from frontier.operators.families import get_operator_family
+from frontier.operators.spec import OperatorPhase, OperatorRole
+
+
+def test_gdn_family_is_registered_with_phase_specific_cores() -> None:
+    assert get_operator_family("gated_delta_net") is GATED_DELTA_NET_FAMILY
+    operators = {operator.name: operator for operator in GATED_DELTA_NET_FAMILY.operators}
+
+    assert operators["gdn_core_prefill"].role is OperatorRole.PREFILL_KERNEL
+    assert operators["gdn_core_prefill"].phases == (OperatorPhase.PREFILL,)
+    assert operators["gdn_core_decode"].role is OperatorRole.DECODE_KERNEL
+    assert operators["gdn_core_decode"].phases == (OperatorPhase.DECODE,)
+    assert operators["gdn_core_mixed"].role is OperatorRole.MIXED_KERNEL
+    assert operators["gdn_core_mixed"].phases == (OperatorPhase.MIXED,)
+
+
+def test_gdn_structured_times_replace_legacy_attention_carriers_once() -> None:
+    operator_times = AttentionOperatorTimes(
+        {
+            "gdn_input_projections": 1.0,
+            "gdn_core_prefill": 2.0,
+            "gdn_output_projection": 3.0,
+        }
+    )
+    component = AttentionTime(
+        attention_layer_pre_proj_execution_time=1.0,
+        attention_prefill_execution_time=2.0,
+        attention_layer_post_proj_execution_time=3.0,
+        operator_times=operator_times,
+    )
+
+    assert component.total_time() == 6.0
+    attrs = canonical_operator_execution_time_attrs()
+    assert attrs["gdn_input_projections"] == (
+        "attention_layer_pre_proj_execution_time"
+    )
+    assert attrs["gdn_core_decode"] == "attention_decode_execution_time"
+
+
+def test_gdn_csv_schema_requires_backend_state_and_validation_timing() -> None:
+    columns = get_required_gdn_profiling_columns()
+    row = {column: 1 for column in columns}
+    row.update(
+        {
+            "measurement_type": "CUDA_EVENT",
+            "model_architecture_profile": "qwen3_5_moe",
+            "quant_signature": "none",
+            "device": "mi355x",
+            "runtime_stack_signature": "unit",
+            "gdn_runtime_backend": "vllm_rocm",
+            "gdn_rank_aggregation": "single_rank",
+            "gdn_prefill_backend": "triton",
+            "gdn_decode_backend": "packed_recurrent_triton",
+            "gqa_interleaved_layout": False,
+            "packed_recurrent_decode": True,
+            "model_dtype": "bfloat16",
+            "conv_state_dtype": "bfloat16",
+            "recurrent_state_dtype": "bfloat16",
+            "has_initial_state": False,
+        }
+    )
+
+    validate_gdn_profiling_dataframe(pd.DataFrame([row]))
+
+
+def test_gdn_csv_schema_rejects_missing_runtime_backend() -> None:
+    columns = [
+        column
+        for column in get_required_gdn_profiling_columns()
+        if column != "gdn_runtime_backend"
+    ]
+    row = {column: 1 for column in columns}
+    row["measurement_type"] = "CUDA_EVENT"
+
+    try:
+        validate_gdn_profiling_dataframe(pd.DataFrame([row]))
+    except ValueError as exc:
+        assert "gdn_runtime_backend" in str(exc)
+    else:
+        raise AssertionError("missing GDN runtime backend was accepted")

--- a/tests/unit/test_gdn_prediction.py
+++ b/tests/unit/test_gdn_prediction.py
@@ -1,0 +1,254 @@
+from types import MethodType, SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from frontier.entities.time_components import AttentionOperatorTimes, AttentionTime
+from frontier.execution_time_predictor.sklearn_execution_time_predictor import (
+    SklearnExecutionTimePredictor,
+)
+from frontier.gdn.predictor import GDNBatchFeatures, ProfiledGDNPredictor
+from frontier.gdn.profiling_schema import get_required_gdn_profiling_columns
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.types import ClusterType, MeasurementType
+
+
+MODEL_NAME = "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+
+
+def _profile_row(
+    *,
+    batch_size: int,
+    prefill_tokens: int,
+    decode_tokens: int,
+    max_query_len: int,
+    has_initial_state: bool,
+    core_name: str,
+    core_time: float,
+) -> dict:
+    config = ModelConfig.from_model_name(MODEL_NAME)
+    gdn_config = config.get_gdn_config()
+    row = {column: 0 for column in get_required_gdn_profiling_columns()}
+    row.update(
+        {
+            "measurement_type": "CUDA_EVENT",
+            "model_architecture_profile": "qwen3_5_moe",
+            "quant_signature": config.get_quant_signature(),
+            "device": "mi355x",
+            "runtime_stack_signature": "vllm=test;torch=test;hip=test;triton=test",
+            "gdn_runtime_backend": "vllm_rocm_standard_dispatch",
+            "gdn_rank_aggregation": "single_rank",
+            "gdn_prefill_backend": "triton",
+            "gdn_decode_backend": "packed_recurrent_triton",
+            "gqa_interleaved_layout": False,
+            "packed_recurrent_decode": True,
+            "model_dtype": "torch.bfloat16",
+            "conv_state_dtype": "bfloat16",
+            "recurrent_state_dtype": "float32",
+            "weight_source": "synthetic_bf16",
+            "num_tensor_parallel_workers": 1,
+            "hidden_size": config.embedding_dim,
+            "conv_kernel_size": gdn_config.conv_kernel_size,
+            "key_head_dim": gdn_config.key_head_dim,
+            "value_head_dim": gdn_config.value_head_dim,
+            "num_key_heads": gdn_config.num_key_heads,
+            "num_value_heads": gdn_config.num_value_heads,
+            "batch_size": batch_size,
+            "batch_num_tokens": prefill_tokens + decode_tokens,
+            "batch_num_prefill_tokens": prefill_tokens,
+            "batch_num_decode_tokens": decode_tokens,
+            "max_query_len": max_query_len,
+            "has_initial_state": has_initial_state,
+            "time_stats.gdn_input_projections.median": 0.1,
+            f"time_stats.{core_name}.median": core_time,
+            "time_stats.gdn_output_projection.median": 0.3,
+        }
+    )
+    return row
+
+
+@pytest.fixture
+def profile_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            _profile_row(
+                batch_size=1,
+                prefill_tokens=16,
+                decode_tokens=0,
+                max_query_len=16,
+                has_initial_state=False,
+                core_name="gdn_core_prefill",
+                core_time=0.2,
+            ),
+            _profile_row(
+                batch_size=1,
+                prefill_tokens=0,
+                decode_tokens=1,
+                max_query_len=1,
+                has_initial_state=True,
+                core_name="gdn_core_decode",
+                core_time=0.4,
+            ),
+            _profile_row(
+                batch_size=2,
+                prefill_tokens=16,
+                decode_tokens=1,
+                max_query_len=16,
+                has_initial_state=True,
+                core_name="gdn_core_mixed",
+                core_time=0.5,
+            ),
+        ]
+    )
+
+
+def _build_predictor(dataframe: pd.DataFrame) -> ProfiledGDNPredictor:
+    return ProfiledGDNPredictor(
+        dataframe,
+        model_config=ModelConfig.from_model_name(MODEL_NAME),
+        device="mi355x",
+        tensor_parallel_size=1,
+        measurement_type=MeasurementType.CUDA_EVENT,
+    )
+
+
+def test_profiled_gdn_predictor_uses_exact_phase_specific_rows(
+    profile_dataframe: pd.DataFrame,
+) -> None:
+    predictor = _build_predictor(profile_dataframe)
+
+    prefill = predictor.predict_operator_times(
+        GDNBatchFeatures(1, 16, 16, 0, 16, False)
+    )
+    decode = predictor.predict_operator_times(
+        GDNBatchFeatures(1, 1, 0, 1, 1, True)
+    )
+    mixed = predictor.predict_operator_times(
+        GDNBatchFeatures(2, 17, 16, 1, 16, True)
+    )
+
+    assert prefill == {
+        "gdn_input_projections": 0.1,
+        "gdn_core_prefill": 0.2,
+        "gdn_output_projection": 0.3,
+    }
+    assert decode["gdn_core_decode"] == 0.4
+    assert mixed["gdn_core_mixed"] == 0.5
+
+
+def test_profiled_gdn_predictor_builds_legacy_and_structured_times_once(
+    profile_dataframe: pd.DataFrame,
+) -> None:
+    predictor = _build_predictor(profile_dataframe)
+    request = SimpleNamespace(num_processed_tokens=16, is_prefill_complete=True)
+    batch = SimpleNamespace(
+        num_tokens=[1],
+        requests=[request],
+        total_num_tokens=1,
+        num_prefill_tokens=0,
+        num_decode_tokens=1,
+    )
+
+    result = predictor.predict_attention_time(batch, norm_time_ms=0.05)
+
+    assert result.attention_layer_pre_proj_execution_time == 0.1
+    assert result.attention_decode_execution_time == 0.4
+    assert result.attention_layer_post_proj_execution_time == 0.3
+    assert result.total_time() == pytest.approx(0.85)
+    assert result.operator_times.op_times["gdn_core_decode"] == 0.4
+
+
+def test_profiled_gdn_predictor_rejects_mixed_runtime_stacks(
+    profile_dataframe: pd.DataFrame,
+) -> None:
+    profile_dataframe.loc[1, "runtime_stack_signature"] = "different"
+
+    with pytest.raises(ValueError, match="incompatible runtime contracts"):
+        _build_predictor(profile_dataframe)
+
+
+def test_unseen_decode_projections_cannot_learn_prefill_latency_scale():
+    rows = []
+    for size in (16, 32):
+        for prefill in (True, False):
+            row = _profile_row(
+                batch_size=size, prefill_tokens=size * 1024 if prefill else 0,
+                decode_tokens=0 if prefill else size, max_query_len=1024 if prefill else 1,
+                has_initial_state=not prefill,
+                core_name="gdn_core_prefill" if prefill else "gdn_core_decode",
+                core_time=2.0 if prefill else 0.04,
+            )
+            row["time_stats.gdn_input_projections.median"] = 10.0 if prefill else 0.03
+            row["time_stats.gdn_output_projection.median"] = 5.0 if prefill else 0.01
+            rows.append(row)
+    predictor = _build_predictor(pd.DataFrame(rows).fillna(0))
+    result = predictor.predict_operator_times(GDNBatchFeatures(24, 24, 0, 24, 1, True))
+    assert result == pytest.approx({"gdn_input_projections": 0.03,
+                                    "gdn_core_decode": 0.04,
+                                    "gdn_output_projection": 0.01})
+
+
+def test_qwen_hybrid_stage_attention_is_exact_weighted_average() -> None:
+    class ConcretePredictor(SklearnExecutionTimePredictor):
+        def _get_grid_search_params(self):
+            return {}
+
+        def _get_estimator(self):
+            raise AssertionError("estimator is not used by this contract test")
+
+    predictor = object.__new__(ConcretePredictor)
+    predictor._model_config = ModelConfig.from_model_name(MODEL_NAME)
+    predictor._num_layers_per_pipeline_stage = 92
+
+    def predict_layer(self, batch, layer_id, cluster_type):
+        del batch, cluster_type
+        if self._model_config.is_gdn_layer(layer_id):
+            return AttentionTime(
+                attention_layer_pre_proj_execution_time=1.0,
+                attention_prefill_execution_time=2.0,
+                attention_layer_post_proj_execution_time=3.0,
+                operator_times=AttentionOperatorTimes(
+                    {
+                        "gdn_input_projections": 1.0,
+                        "gdn_core_prefill": 2.0,
+                        "gdn_output_projection": 3.0,
+                    }
+                ),
+            )
+        return AttentionTime(
+            attention_layer_pre_proj_execution_time=5.0,
+            attention_prefill_execution_time=7.0,
+            attention_layer_post_proj_execution_time=11.0,
+        )
+
+    predictor.predict_attention_layer_time = MethodType(predict_layer, predictor)
+    averaged = predictor._predict_stage_attention_time(
+        batch=object(),
+        stage_id=0,
+        num_layers=92,
+        layer_id=0,
+        cluster_type=ClusterType.MONOLITHIC,
+    )
+
+    assert averaged.operator_times is None
+    assert averaged.attention_layer_pre_proj_execution_time == pytest.approx(
+        (69 * 1.0 + 23 * 5.0) / 92
+    )
+    assert averaged.total_time() * 92 == pytest.approx(69 * 6.0 + 23 * 23.0)
+
+
+def test_matching_batch_sweep_interpolates_between_measured_endpoints():
+    rows = []
+    for size, time in ((16, 1.0), (32, 2.0)):
+        rows.append(_profile_row(batch_size=size, prefill_tokens=size * 128,
+                                  decode_tokens=0, max_query_len=128,
+                                  has_initial_state=False, core_name="gdn_core_prefill",
+                                  core_time=time))
+    predictor = _build_predictor(pd.DataFrame(rows))
+    midpoint = predictor.predict_operator_times(GDNBatchFeatures(24, 24 * 128, 24 * 128, 0, 128, False))
+    assert midpoint["gdn_core_prefill"] == pytest.approx(1.5)
+    endpoint = predictor.predict_operator_times(GDNBatchFeatures(16, 16 * 128, 16 * 128, 0, 128, False))
+    assert endpoint["gdn_core_prefill"] == 1.0
+    # Outside the calibrated interval retain RF fallback, never extrapolate.
+    outside = predictor.predict_operator_times(GDNBatchFeatures(64, 64 * 128, 64 * 128, 0, 128, False))
+    assert 1.0 <= outside["gdn_core_prefill"] <= 2.0

--- a/tests/unit/test_gdn_profiler_inputs.py
+++ b/tests/unit/test_gdn_profiler_inputs.py
@@ -1,0 +1,86 @@
+from argparse import Namespace
+
+import pytest
+
+from frontier.profiling.gdn.inputs import GDNProfileInput
+from frontier.profiling.gdn.main import build_profile_inputs
+
+
+def test_gdn_profile_input_classifies_prefill_decode_and_mixed() -> None:
+    prefill = GDNProfileInput.prefill(seq_len=128)
+    decode = GDNProfileInput.decode(batch_size=8, context_len=512)
+    mixed = GDNProfileInput.mixed(
+        decode_batch_size=4,
+        decode_context_len=512,
+        prefill_seq_len=128,
+    )
+
+    assert prefill.phase == "prefill"
+    assert prefill.num_prefill_tokens == 128
+    assert not prefill.has_initial_state
+    assert decode.phase == "decode"
+    assert decode.num_decode_tokens == 8
+    assert decode.has_initial_state
+    assert mixed.phase == "mixed"
+    assert mixed.query_lens == (1, 1, 1, 1, 128)
+    assert mixed.num_decode_tokens == 4
+    assert mixed.num_prefill_tokens == 128
+    assert prefill.state_block_ids == (1,)
+    assert decode.state_block_ids == tuple(range(1, 9))
+    assert mixed.state_block_ids == (1, 2, 3, 4, 5)
+
+
+def test_gdn_profile_input_rejects_prefill_before_decode() -> None:
+    with pytest.raises(ValueError, match="decode-first"):
+        GDNProfileInput(
+            query_lens=(128, 1),
+            context_lens=(0, 512),
+        )
+
+
+def test_gdn_cli_plan_includes_cold_hot_decode_and_mixed() -> None:
+    args = Namespace(
+        prefill_seq_lens=[16, 128],
+        prefill_batch_sizes=[1],
+        decode_batch_sizes=[1, 8],
+        decode_context_len=512,
+        continuation_context_len=256,
+        include_continuation_prefill=True,
+        include_mixed=True,
+    )
+
+    inputs = build_profile_inputs(args)
+
+    assert [profile_input.phase for profile_input in inputs] == [
+        "prefill",
+        "prefill",
+        "prefill",
+        "prefill",
+        "decode",
+        "decode",
+        "mixed",
+    ]
+    assert [
+        profile_input.has_initial_state for profile_input in inputs[:4]
+    ] == [False, False, True, True]
+
+
+def test_gdn_cli_plan_crosses_prefill_lengths_and_batch_sizes() -> None:
+    args = Namespace(
+        prefill_seq_lens=[128, 1024],
+        prefill_batch_sizes=[1, 16],
+        decode_batch_sizes=[],
+        decode_context_len=1024,
+        continuation_context_len=1024,
+        include_continuation_prefill=False,
+        include_mixed=False,
+    )
+
+    inputs = build_profile_inputs(args)
+
+    assert [(item.batch_size, item.num_tokens) for item in inputs] == [
+        (1, 128),
+        (1, 1024),
+        (16, 2048),
+        (16, 16384),
+    ]

--- a/tests/unit/test_gdn_sglang_trace.py
+++ b/tests/unit/test_gdn_sglang_trace.py
@@ -1,0 +1,103 @@
+import gzip
+import json
+
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.gdn.sglang_trace import (
+    build_sglang_profile_row,
+    extract_sglang_gdn_samples,
+    parse_sglang_trace_shape,
+)
+
+
+def _event(name: str, ts: float, dur: float) -> dict:
+    return {
+        "cat": "kernel",
+        "ph": "X",
+        "name": name,
+        "ts": ts,
+        "dur": dur,
+    }
+
+
+def _write_trace(tmp_path, phase: str, repeats: int = 1):
+    events = []
+    ts = 0.0
+    for _ in range(repeats):
+        anchor = (
+            "chunk_gated_delta_rule_fwd_kernel_h_blockdim64"
+            if phase == "prefill"
+            else "fused_recurrent_gated_delta_rule_packed_decode_kernel"
+        )
+        for name, dur in (
+            ("_gemma_fused_add_rmsnorm_kernel", 100.0),
+            ("projection_gemm", 10.0),
+            ("projection_ba_gemm", 20.0),
+            ("elementwise_kernel_manual_unroll", 3.0),
+            ("_causal_conv1d_update_kernel", 4.0),
+            (anchor, 5.0),
+            ("core_output_copy", 6.0),
+            ("_layer_norm_fwd_1pass_kernel", 7.0),
+            ("output_projection_gemm", 8.0),
+            ("quickreduce::allreduce", 200.0),
+        ):
+            events.append(_event(name, ts, dur))
+            ts += dur
+    path = tmp_path / f"profile_batch32_input1024_output64_{phase}.trace.json.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as stream:
+        json.dump({"traceEvents": events}, stream)
+    return path
+
+
+def test_extract_sglang_trace_excludes_input_norm_and_all_reduce(tmp_path) -> None:
+    path = _write_trace(tmp_path, "decode", repeats=69)
+    samples = extract_sglang_gdn_samples(path)
+
+    assert len(samples["gdn_layer_e2e"]) == 69
+    assert samples["gdn_input_projections"][0] == pytest.approx(0.030)
+    assert samples["gdn_core_decode"][0] == pytest.approx(0.018)
+    assert samples["gdn_output_projection"][0] == pytest.approx(0.015)
+    assert samples["gdn_layer_e2e"][0] == pytest.approx(0.063)
+
+
+def test_sglang_trace_shape_and_profile_contract(tmp_path) -> None:
+    path = _write_trace(tmp_path, "prefill", repeats=69)
+    assert parse_sglang_trace_shape(path) == {
+        "batch_size": 32,
+        "input_len": 1024,
+        "output_len": 64,
+        "phase": "prefill",
+    }
+
+    row = build_sglang_profile_row(
+        path,
+        model_config=ModelConfig.from_model_name(
+            "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+        ),
+        device="mi355x",
+        tensor_parallel_size=8,
+        runtime_stack_signature="sglang=test;torch=test;rocm=test;aiter=test",
+    )
+    assert row["measurement_type"] == "KERNEL_ONLY"
+    assert row["gdn_runtime_backend"] == "sglang_rocm_aiter_trace"
+    assert row["num_tensor_parallel_workers"] == 8
+    assert row["batch_num_tokens"] == 32 * 1024
+    assert row["batch_num_prefill_tokens"] == 32 * 1024
+    assert row["batch_num_decode_tokens"] == 0
+    assert row["trace_profiled_iterations"] == 1
+    assert row["time_stats"]["gdn_core_decode"]["median"] == 0.0
+
+
+def test_sglang_trace_rejects_partial_model_pass(tmp_path) -> None:
+    path = _write_trace(tmp_path, "decode", repeats=68)
+    with pytest.raises(ValueError, match="positive multiple"):
+        build_sglang_profile_row(
+            path,
+            model_config=ModelConfig.from_model_name(
+                "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+            ),
+            device="mi355x",
+            tensor_parallel_size=8,
+            runtime_stack_signature="test",
+        )

--- a/tests/unit/test_graph_event_report.py
+++ b/tests/unit/test_graph_event_report.py
@@ -1,0 +1,142 @@
+from dataclasses import replace
+import json
+
+import pytest
+
+from frontier.validation.graph_event_report import (
+    expected_scopes, summarize_decoder_graph_events, summarize_graph_events,
+)
+from frontier.validation.report import summarize_capture, summarize_profile_perturbation
+from frontier.validation.sglang_graph_events import DEFAULT_COMPONENTS
+from tests.unit.test_operator_trace import timing
+
+
+def fixture():
+    baseline = [timing(batch_id="base", rank=r, forward_gpu_ms=10 + r) for r in range(2)]
+    records = [replace(r, batch_id="events", profiled=True) for r in baseline]
+    quality = summarize_profile_perturbation(baseline + records, tensor_parallel_size=2)
+    samples = [{"batch_id": "events", "rank": rank, "layer_id": 0, "component": "gdn",
+                "measurement_type": "HIP_GRAPH_EVENT", "parent_id": None,
+                "physical_size": 1, "capture_id": 10 + rank, "inclusive_gpu_ms": 1 + rank}
+               for rank in range(2)]
+    return records, samples, quality
+
+
+def summarize(records, samples, quality):
+    return summarize_graph_events(records, samples, quality=quality,
+                                  tensor_parallel_size=2, expected={(0, "gdn")})
+
+
+def test_model_schedule_resolves_disjoint_default_scopes():
+    expected = expected_scopes(["gdn", "gdn", "gdn", "attention"], [0, 3], DEFAULT_COMPONENTS)
+    assert len(expected) == 8
+    assert (0, "gdn") in expected and (3, "full_attention") in expected
+    assert (3, "gdn") not in expected
+    with pytest.raises(ValueError, match="Nested"):
+        expected_scopes(["gdn"], [0], ["gdn", "gdn_attn"])
+    with pytest.raises(ValueError, match="exist"):
+        expected_scopes(["gdn"], [1], DEFAULT_COMPONENTS)
+    with pytest.raises(ValueError, match="Unknown"):
+        expected_scopes(["gdn"], [0], ["unknown"])
+
+
+def test_report_preserves_rank_identity_and_never_exports_native_profiles():
+    records, samples, quality = fixture()
+    result = summarize(records, samples, quality)
+    assert result["scope_samples"] == 2
+    assert result["decode_batches"] == 1
+    assert result["all_decode_batches_pass_latency_check"]
+    assert not result["native_profile_export_admitted"]
+    assert [r["gpu_median_of_repeat_medians_ms"] for r in result["summaries"]] == [1, 2]
+    quality["batches"][0]["passes_latency_check"] = False
+    rejected = summarize(records, samples, quality)
+    assert not rejected["all_decode_batches_pass_latency_check"]
+    assert rejected["scope_samples"] == 2  # retain, do not silently trim rejected samples
+    assert all(r["samples_failing_forward_latency_check"] == 1 for r in rejected["summaries"])
+
+
+@pytest.mark.parametrize("change", [
+    {"batch_id": "unrelated"}, {"rank": 3}, {"layer_id": 1}, {"layer_id": False},
+    {"component": "full_attention"}, {"parent_id": 1}, {"capture_id": 0},
+    {"physical_size": 4}, {"measurement_type": "KERNEL_ONLY"},
+    {"inclusive_gpu_ms": -1}, {"inclusive_gpu_ms": float("nan")}, {"inclusive_gpu_ms": 12},
+])
+def test_malformed_or_misattributed_graph_scope_fails(change):
+    records, samples, quality = fixture()
+    samples[0].update(change)
+    with pytest.raises(ValueError):
+        summarize(records, samples, quality)
+
+
+def test_scope_coverage_and_quality_are_required():
+    records, samples, quality = fixture()
+    with pytest.raises(ValueError, match="Incomplete"):
+        summarize(records, samples[:1], quality)
+    with pytest.raises(ValueError, match="duplicate"):
+        summarize(records, samples + samples[:1], quality)
+    with pytest.raises(ValueError, match="perturbation"):
+        summarize(records, samples, {"batches": []})
+    with pytest.raises(ValueError, match="full-decode"):
+        summarize([replace(r, profiled=False) for r in records], samples, quality)
+
+
+def test_disjoint_scope_sum_cannot_exceed_same_rank_forward():
+    records, samples, quality = fixture()
+    samples += [{**row, "component": "input_layernorm", "inclusive_gpu_ms": 10}
+                for row in samples]
+    with pytest.raises(ValueError, match="exceed"):
+        summarize_graph_events(records, samples, quality=quality, tensor_parallel_size=2,
+                               expected={(0, "gdn"), (0, "input_layernorm")})
+
+
+def test_whole_decoder_summary_preserves_rank_and_forward_boundary_gap():
+    records, _, quality = fixture()
+    samples = [{
+        "batch_id": "events", "rank": rank, "component": "decoder",
+        "first_layer_id": 0, "last_layer_id": 3,
+        "measurement_type": "HIP_GRAPH_EVENT", "physical_size": 1,
+        "capture_id": 10 + rank, "inclusive_gpu_ms": 9 + rank,
+    } for rank in range(2)]
+    result = summarize_decoder_graph_events(
+        records, samples, tensor_parallel_size=2, num_layers=4, quality=quality)
+    assert result["decoder_scope_samples"] == 2
+    assert result["all_decode_batches_pass_latency_check"]
+    assert [row["forward_minus_decoder_median_ms"]
+            for row in result["summaries"]] == [1, 1]
+    assert not result["native_profile_export_admitted"]
+
+
+def test_whole_decoder_summary_rejects_wrong_boundary_and_missing_rank():
+    records, _, quality = fixture()
+    sample = {
+        "batch_id": "events", "rank": 0, "component": "decoder",
+        "first_layer_id": 0, "last_layer_id": 2,
+        "measurement_type": "HIP_GRAPH_EVENT", "physical_size": 1,
+        "capture_id": 10, "inclusive_gpu_ms": 9,
+    }
+    with pytest.raises(ValueError, match="boundary"):
+        summarize_decoder_graph_events(
+            records, [sample], tensor_parallel_size=2, num_layers=4, quality=quality)
+    sample["last_layer_id"] = 3
+    with pytest.raises(ValueError, match="Incomplete"):
+        summarize_decoder_graph_events(
+            records, [sample], tensor_parallel_size=2, num_layers=4, quality=quality)
+
+
+def test_capture_report_includes_separate_graph_output_diagnostics(tmp_path):
+    (tmp_path / "manifest.json").write_text(json.dumps({"status": "complete", "topology": {"tp": 1},
+        "options": {"freeze_decode_inputs": True}}))
+    baseline = timing(step_wall_ms=11, decode_input_sha256="a" * 64)
+    graph = replace(baseline, batch_id="graph", profiled=True)
+    for name, row in (("batches", baseline), ("graph-batches", graph)):
+        (tmp_path / f"{name}.jsonl").write_text(json.dumps(row.to_dict()) + "\n")
+    check = {"batch_size": 1, "input_len": 1024, "output_tokens": 16,
+             "different_from_first_repeat": 0, "tp_output_agreement": True, "output_sha256": "first"}
+    (tmp_path / "output-checks-rank0.json").write_text(json.dumps([check]))
+    (tmp_path / "graph-output-checks-rank0.json").write_text(json.dumps([
+        {**check, "output_sha256": "second", "different_from_first_repeat": 1}]))
+    result = summarize_capture(tmp_path, skip_decode_steps=0)
+    assert result["graph_event_perturbation"]["all_pass_latency_check"]
+    assert result["graph_output_repeatability"]["fixed_decode_inputs"]
+    assert result["graph_output_repeatability"]["max_changed_output_fraction"] == 1 / 16
+    assert result["graph_output_repeatability"]["repetitions_matching_any_baseline_output_digest"] == 0

--- a/tests/unit/test_hip_graph_events.py
+++ b/tests/unit/test_hip_graph_events.py
@@ -1,0 +1,129 @@
+"""Exercise public HIP ABI/dependency handling without importing torch or HIP."""
+
+import ctypes as C
+from types import SimpleNamespace
+
+import pytest
+
+from frontier.validation.hip_graph_events import HipGraphEvents
+
+
+class Function:
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __call__(self, *args):
+        return self.callback(*args)
+
+
+def put(pointer, kind, value):
+    C.cast(pointer, C.POINTER(kind))[0] = value
+
+
+class Library:
+    def __init__(self):
+        self.capture_status, self.capture_id, self.graph = 1, 42, 7
+        self.dependencies = (C.c_void_p * 2)(10, 11)
+        self.event_id, self.duration = 100, 0.125
+        self.calls, self.destroyed = [], []
+        self.failure = None
+        for name in ("hipStreamGetCaptureInfo_v2", "hipStreamUpdateCaptureDependencies",
+                     "hipGraphAddEventRecordNode", "hipEventCreateWithFlags",
+                     "hipEventElapsedTime", "hipEventDestroy"):
+            setattr(self, name, Function(lambda *args, name=name: self.call(name, *args)))
+
+    def call(self, name, *args):
+        if name == self.failure:
+            return 99
+        if name == "hipStreamGetCaptureInfo_v2":
+            stream, status, capture_id, graph, dependencies, count = args
+            assert stream.value == 3
+            put(status, C.c_int, self.capture_status)
+            put(capture_id, C.c_ulonglong, self.capture_id)
+            put(graph, C.c_void_p, self.graph)
+            put(dependencies, C.POINTER(C.c_void_p), C.cast(self.dependencies, C.POINTER(C.c_void_p)))
+            put(count, C.c_size_t, len(self.dependencies))
+        elif name == "hipEventCreateWithFlags":
+            handle, flags = args
+            assert flags == 0  # timing must remain enabled
+            put(handle, C.c_void_p, self.event_id)
+            self.event_id += 1
+        elif name == "hipGraphAddEventRecordNode":
+            node, graph, dependencies, count, event = args
+            self.calls.append(("add", graph.value, [dependencies[i] for i in range(count)], event.value))
+            put(node, C.c_void_p, 200)
+        elif name == "hipStreamUpdateCaptureDependencies":
+            stream, dependencies, count, flags = args
+            self.calls.append(("update", stream.value,
+                               [C.cast(dependencies, C.POINTER(C.c_void_p))[i] for i in range(count)], flags))
+        elif name == "hipEventElapsedTime":
+            put(args[0], C.c_float, self.duration)
+        elif name == "hipEventDestroy":
+            self.destroyed.append(args[0].value)
+        return 0
+
+
+@pytest.fixture
+def api(monkeypatch):
+    library = Library()
+    monkeypatch.setattr(C, "CDLL", lambda path: library)
+    return HipGraphEvents("test-library"), library, SimpleNamespace(cuda_stream=3)
+
+
+def test_explicit_nodes_preserve_all_dependencies_and_set_the_new_stream_sink(api):
+    events, library, stream = api
+    start, end = events.create_event(), events.create_event()
+    start.record(stream)
+    end.record(stream)
+    assert library.calls[:2] == [("add", 7, [10, 11], 100), ("update", 3, [200], 1)]
+    assert start.elapsed_time(end) == pytest.approx(0.125)
+    assert len(events.events) == 2
+    events.close_after_graphs_destroyed()
+    events.close_after_graphs_destroyed()
+    assert library.destroyed == [101, 100]
+
+
+def test_capture_status_and_hip_errors_do_not_fall_back_to_other_timing_methods(api):
+    events, library, stream = api
+    event = events.create_event()
+    library.capture_status = 0
+    assert events.capture_info(stream) is None
+    with pytest.raises(ValueError, match="active capture"):
+        event.record(stream)
+    library.capture_status = 2
+    with pytest.raises(ValueError, match="invalidated"):
+        events.capture_info(stream)
+    library.capture_status, library.graph = 1, 0
+    with pytest.raises(ValueError, match="no graph"):
+        events.capture_info(stream)
+    library.graph, library.failure = 7, "hipGraphAddEventRecordNode"
+    with pytest.raises(RuntimeError, match="HIP status 99"):
+        event.record(stream)
+    assert library.calls == []  # never update dependencies after a failed insertion
+
+
+@pytest.mark.parametrize("duration", [-1.0, float("inf"), float("nan")])
+def test_invalid_durations_fail(api, duration):
+    events, library, stream = api
+    start, end = events.create_event(), events.create_event()
+    start.record(stream)
+    end.record(stream)
+    library.duration = duration
+    with pytest.raises(ValueError, match="Invalid"):
+        start.elapsed_time(end)
+
+
+def test_event_endpoints_must_share_a_capture_and_owner(api):
+    events, library, stream = api
+    start, end = events.create_event(), events.create_event()
+    with pytest.raises(ValueError, match="same HIP capture"):
+        start.elapsed_time(end)
+    start.record(stream)
+    library.capture_id += 1
+    end.record(stream)
+    with pytest.raises(ValueError, match="same HIP capture"):
+        start.elapsed_time(end)
+    start.capture_id = end.capture_id
+    end.api = object()
+    with pytest.raises(ValueError, match="same HIP capture"):
+        start.elapsed_time(end)

--- a/tests/unit/test_operator_trace.py
+++ b/tests/unit/test_operator_trace.py
@@ -1,0 +1,148 @@
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from frontier.validation.batch_record import BatchRecord
+from frontier.validation.operator_trace import decompose_decoder, model_layer_kinds
+from frontier.validation.report import summarize_profile_perturbation
+
+
+def trace(phase="decode", kinds=("gdn", "attention"), epilogues=True):
+    gemm = ["Cijk_Alik_gemm"] + (["Cijk_SB_epilogue"] if epilogues else [])
+    ar = "aiter::cross_device_reduce"
+    names = ["prepare", "_vocab_parallel_embedding_kernel", ar]
+    for kind in kinds:
+        names += ["_gemma_fused_add_rmsnorm_kernel"]
+        if kind == "gdn":
+            names += gemm * 2 + ["at::native::transform", "_causal_conv1d_update_kernel",
+                "chunk_gated_delta_rule_fwd_kernel_h_blockdim64" if phase == "prefill"
+                else "fused_recurrent_gated_delta_rule_packed_decode_kernel",
+                "_layer_norm_fwd_1pass_kernel"] + gemm
+        else:
+            names += gemm + ["_fused_qk_gemma_rmsnorm_gate_kernel", "_triton_mrope_forward_fused",
+                             "sglang::store_kvcache<512>"]
+            names += (["FmhaBatchPrefillWithPagedKVCacheKernel"] if phase == "prefill" else
+                      ["paged_attention_ll4mi_QKV_mfma16_kernel", "paged_attention_ll4mi_reduce_kernel"])
+            names += ["_fused_sigmoid_mul_kernel"] + gemm
+        names += [ar, "_gemma_fused_add_rmsnorm_kernel"] + gemm + ["act_and_mul_kernel"]
+        names += gemm * 2 + ["topkGatingSoftmax", "aiter::opus_moe_sorting_entry<P0>",
+                            "aiter::opus_moe_sorting_entry<P23>",
+                            "fused_mx_quant_moe_sort_kernel", "mfma_moe1_silu_mul",
+                            "fused_mx_quant_moe_sort_kernel", "mfma_moe2_combine",
+                            "_fused_gate_sigmoid_mul_add_kernel", ar]
+    names += ["_gemma_fused_add_rmsnorm_kernel", "logits", "sampling"]
+    return [dict(name=n, ts=i * 10, dur=5, cat="kernel", ph="X", args={"device": 0, "stream": 0})
+            for i, n in enumerate(names)]
+
+
+@pytest.mark.parametrize("phase", ["prefill", "decode"])
+@pytest.mark.parametrize("epilogues", [False, True])
+@pytest.mark.parametrize("kinds", [("gdn",), ("attention",), ("gdn", "gdn", "gdn", "attention")])
+def test_partition_conserves_every_decoder_kernel_once(phase, epilogues, kinds):
+    events = trace(phase, kinds, epilogues)
+    result = decompose_decoder(events, phase=phase, layer_kinds=list(kinds))
+    rows = result["components"]
+    indices = [i for r in rows for i in range(r["first_kernel"], r["end_kernel_exclusive"])]
+    assert indices == list(range(3, len(events) - 3))
+    assert result["outside_decoder_kernel_count"] == 6
+    assert result["decoder_kernel_sum_ms"] == pytest.approx(len(indices) * .005)
+    assert sum(result["component_totals_ms"].values()) == pytest.approx(result["decoder_kernel_sum_ms"])
+    assert sum(r["component"] == "mlp_tp_allreduce" for r in rows) == len(kinds)
+    assert sum(r["component"] == "shared_gate_sigmoid_mul_add" for r in rows) == len(kinds)
+
+
+@pytest.mark.parametrize("kernel", ["_gemma_fused_add_rmsnorm_kernel", "Cijk_Alik_gemm",
+    "fused_recurrent_gated_delta_rule_packed_decode_kernel", "_layer_norm_fwd_1pass_kernel",
+    "_fused_qk_gemma_rmsnorm_gate_kernel", "_triton_mrope_forward_fused", "sglang::store_kvcache<512>",
+    "paged_attention_ll4mi_QKV_mfma16_kernel", "paged_attention_ll4mi_reduce_kernel",
+    "_fused_sigmoid_mul_kernel", "act_and_mul_kernel", "topkGatingSoftmax",
+    "fused_mx_quant_moe_sort_kernel", "mfma_moe1_silu_mul", "mfma_moe2_combine",
+    "_fused_gate_sigmoid_mul_add_kernel", "aiter::cross_device_reduce"])
+def test_unknown_operator_cannot_be_silently_dropped(kernel):
+    events = trace()
+    next(e for e in events if e["name"] == kernel)["name"] = "unknown_fused_replacement"
+    with pytest.raises(ValueError):
+        decompose_decoder(events, phase="decode", layer_kinds=["gdn", "attention"])
+
+
+def test_order_phase_schedule_and_stream_are_strict():
+    original = trace()
+    for kinds in (["attention", "gdn"], ["gdn"], ["gdn", "attention", "gdn"]):
+        with pytest.raises(ValueError):
+            decompose_decoder(original, phase="decode", layer_kinds=kinds)
+    with pytest.raises(ValueError, match="core"):
+        decompose_decoder(original, phase="prefill", layer_kinds=["gdn", "attention"])
+    for mutation in (lambda e: e[6]["args"].update(stream=1),
+                     lambda e: e[6]["args"].update(device=1),
+                     lambda e: e[6].update(ts=-1),
+                     lambda e: e[6].update(dur=float("nan"))):
+        events = deepcopy(original)
+        mutation(events)
+        with pytest.raises(ValueError):
+            decompose_decoder(events, phase="decode", layer_kinds=["gdn", "attention"])
+
+
+def test_overlap_is_reported_without_correcting_kernel_sums():
+    events = trace()
+    events[10]["dur"] = 12
+    result = decompose_decoder(events, phase="decode", layer_kinds=["gdn", "attention"])
+    assert result["decoder_kernel_overlap_ms"] == pytest.approx(.002)
+
+
+def test_layer_schedule_is_model_owned():
+    from frontier.profiling.common.model_config import ModelConfig
+    config = ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+    schedule = model_layer_kinds(config)
+    assert schedule == ["gdn", "gdn", "gdn", "attention"] * 23
+
+
+def timing(**updates):
+    fields = dict(batch_id="b", rank=0, phase="decode", request_ids=("a",),
+                  query_lens=(1,), context_lens=(1024,), prefill_mask=(False,),
+                  graph_mode="FULL", capture_size=1, forward_gpu_ms=10., step=1)
+    fields.update(updates)
+    return BatchRecord(**fields)
+
+
+def test_quality_matches_exact_early_step_and_uses_max_rank_not_sum():
+    baseline = [timing(batch_id=f"b{i}", repetition=i, forward_gpu_ms=t)
+                for i, t in enumerate((9., 10., 11.))]
+    records = baseline + [timing(batch_id="late", step=8, context_lens=(1031,), forward_gpu_ms=3.),
+                          timing(batch_id="trace", profiled=True, forward_gpu_ms=11.)]
+    records += [replace(r, rank=1, forward_gpu_ms=r.forward_gpu_ms * 2) for r in records]
+    report = summarize_profile_perturbation(records, tensor_parallel_size=2)
+    row = report["batches"][0]
+    assert row["baseline_forward_gpu_median_ms"] == 20.
+    assert row["profiled_forward_gpu_ms"] == 22.
+    assert row["signed_change_pct"] == pytest.approx(10.)
+    assert not report["all_pass_latency_check"]
+
+
+@pytest.mark.parametrize("change", [{"context_lens": (2048,)}, {"capture_size": 2}, {"step": 3}])
+def test_quality_rejects_unmatched_trace_shapes(change):
+    with pytest.raises(ValueError, match="No matching"):
+        summarize_profile_perturbation([timing(), timing(batch_id="trace", profiled=True, **change)],
+                                      tensor_parallel_size=1)
+
+
+def test_quality_empty_missing_timing_and_negative_perturbation():
+    assert not summarize_profile_perturbation([timing()], tensor_parallel_size=1)["all_pass_latency_check"]
+    with pytest.raises(ValueError, match="timing"):
+        summarize_profile_perturbation([timing(forward_gpu_ms=None)], tensor_parallel_size=1)
+    report = summarize_profile_perturbation([
+        timing(), timing(batch_id="trace", profiled=True, forward_gpu_ms=8.)], tensor_parallel_size=1)
+    assert not report["all_pass_latency_check"]  # faster profiles are suspect too
+    with pytest.raises(ValueError, match="threshold"):
+        summarize_profile_perturbation([timing()], tensor_parallel_size=1, max_absolute_change_pct=float("nan"))
+
+
+def test_quality_requires_identical_fixed_input_trajectories():
+    baseline = timing(decode_input_sha256="a" * 64)
+    for digest in (None, "b" * 64):
+        with pytest.raises(ValueError, match="No matching"):
+            summarize_profile_perturbation([baseline, timing(batch_id="trace", profiled=True,
+                decode_input_sha256=digest)], tensor_parallel_size=1)
+    result = summarize_profile_perturbation([baseline, timing(batch_id="trace", profiled=True,
+        decode_input_sha256="a" * 64)], tensor_parallel_size=1)
+    assert result["batches"][0]["fixed_decode_inputs"]

--- a/tests/unit/test_param_counter_share_expert_memory_contract.py
+++ b/tests/unit/test_param_counter_share_expert_memory_contract.py
@@ -25,8 +25,8 @@ def test_qwen3_next_param_counter_excludes_shared_expert_from_system_metrics_mem
 
     assert counter._get_share_expert_params_per_layer(tensor_parallel_size=1) == 0
     assert counter.get_num_mlp_parameters_per_device() == 3_223_322_624
-    assert counter.get_num_parameters_per_device() == 3_261_071_360
-    assert 2 * counter.get_num_parameters_per_device() == 6_522_142_720
+    assert counter.get_num_parameters_per_device() == 3_290_759_552
+    assert 2 * counter.get_num_parameters_per_device() == 6_581_519_104
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_primitive_calibration.py
+++ b/tests/unit/test_primitive_calibration.py
@@ -1,0 +1,144 @@
+from copy import deepcopy
+from dataclasses import asdict, replace
+
+import pytest
+
+from frontier.profiling.runtime.sglang_primitives import attach_kernel_evidence, validate_plan
+from frontier.runtime_cost.primitives import PrimitiveCalibration, aggregate_profiles
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload, RuntimeIdentity
+
+
+IDENTITY = RuntimeIdentity("a" * 64, "synthetic-unit-device", 8, "synthetic-unit-stack")
+NAMES = ("gemma_norm", "gemma_residual_norm", "shared_gate", "attention_post", "tp_allreduce")
+
+
+def profiles(split="calibration", sizes=(16, 32)):
+    # Invented arithmetic costs exercise mechanics only, never performance fixtures.
+    return [{"schema_version": 1, "identity": asdict(IDENTITY), "split": split,
+        "rank": rank, "world_size": 8, "versions": {"synthetic": True},
+        "hardware": {"name": "synthetic-unit-device"}, "extra_collective_environment": {},
+        "producer_source_sha256": "b" * 64, "method": "synthetic-unit-test-only",
+        "rows": [{"primitive": name, "physical_size": size, "invocations_per_graph": count,
+            "rank": rank, "backend": "ca" if name == "tp_allreduce" else "synthetic",
+            "samples_ms": [size * .01 + .1 + rank * .001] * 20,
+            "measurement_type": "HIP_GRAPH_REPLAY", "correctness_checked": True,
+            "kernel_trace_kind": "representative_graph", "kernel_trace_invocations": 2, "kernel_count": 2,
+            "kernel_names": ["synthetic-unit-kernel"] if rank == 0 else []}
+            for name in NAMES for size in sizes for count in (32, 128)]} for rank in range(8)]
+
+
+def test_rank_alignment_uses_per_repetition_max_not_max_rank_median():
+    data = profiles()
+    for rank in range(8):
+        data[rank]["rows"][0]["samples_ms"] = [1. if i % 8 == rank else .1 for i in range(24)]
+    rows, source = aggregate_profiles(data, split="calibration", identity=IDENTITY)
+    row = next(r for r in rows if r["primitive"] == "gemma_norm" and r["physical_size"] == 16 and r["invocations_per_graph"] == 32)
+    assert row["median_ms"] == 1. and max(row["rank_medians_ms"]) == .1
+    assert source.startswith("sha256:")
+
+
+@pytest.mark.parametrize("mutation", ["missing_rank", "duplicate_rank", "split", "identity", "row_rank",
+    "missing_row", "duplicate_row", "backend", "nan", "zero", "few_repetitions", "alignment",
+    "correctness", "measurement", "trace", "provenance", "environment", "boolean_size"])
+def test_incomplete_or_untrustworthy_profiles_fail(mutation):
+    data = profiles()
+    row = data[0]["rows"][0]
+    if mutation == "missing_rank": data.pop()
+    elif mutation == "duplicate_rank": data[-1]["rank"] = 0
+    elif mutation == "split": data[0]["split"] = "validation"
+    elif mutation == "identity": data[0]["identity"]["device"] = "other"
+    elif mutation == "row_rank": row["rank"] = 1
+    elif mutation == "missing_row": data[0]["rows"].pop()
+    elif mutation == "duplicate_row": data[0]["rows"].append(deepcopy(row))
+    elif mutation == "backend": data[0]["rows"][-1]["backend"] = "rccl"
+    elif mutation == "nan": row["samples_ms"][0] = float("nan")
+    elif mutation == "zero": row["samples_ms"][0] = 0
+    elif mutation == "few_repetitions": row["samples_ms"] = [1.] * 19
+    elif mutation == "alignment": row["samples_ms"].append(1.)
+    elif mutation == "correctness": row["correctness_checked"] = False
+    elif mutation == "measurement": row["measurement_type"] = "KERNEL_ONLY"
+    elif mutation == "trace": row["kernel_names"] = []
+    elif mutation == "provenance": data[0]["producer_source_sha256"] = "c" * 64
+    elif mutation == "environment": data[0]["extra_collective_environment"] = {"NCCL_TEST": "1"}
+    elif mutation == "boolean_size": row["physical_size"] = True
+    with pytest.raises(ValueError):
+        aggregate_profiles(data, split="calibration", identity=IDENTITY)
+
+
+def test_fit_is_bounded_and_validation_never_changes_predictions():
+    fit = PrimitiveCalibration(profiles(), identity=IDENTITY)
+    prediction = fit.primitive_ms("gemma_norm", 24)
+    assert prediction == pytest.approx(.347)
+    report = fit.validate(profiles("validation", (24,)))
+    assert report["all_primitives_passed"]
+    assert not report["full_forward_parity_admitted"]
+    changed = profiles("validation", (24,))
+    for payload in changed:
+        for row in payload["rows"]: row["samples_ms"] = [10.] * 20
+    assert not fit.validate(changed)["all_primitives_passed"]
+    assert fit.primitive_ms("gemma_norm", 24) == prediction
+    for size in (15, 33, True, 24.5):
+        with pytest.raises(ValueError): fit.primitive_ms("gemma_norm", size)
+    with pytest.raises(ValueError, match="overlaps"):
+        fit.validate(profiles("validation", (16,)))
+    changed = profiles("validation", (24,))
+    for payload in changed: payload["producer_source_sha256"] = "d" * 64
+    with pytest.raises(ValueError, match="provenance"):
+        fit.validate(changed)
+
+
+def query(component, layer=0):
+    return CostQuery(IDENTITY, layer, "attention", component, DecodeWorkload(20, (1029,) * 20 + (1,) * 4),
+        residual_from_layer=layer - 1 if component == "input_layernorm" and layer else
+        layer if component == "post_attention_layernorm" else None)
+
+
+def test_partial_provider_preserves_fusion_ownership_and_does_not_fill_other_costs():
+    fit = PrimitiveCalibration(profiles(), identity=IDENTITY)
+    for component, layer, primitive in (("input_layernorm", 0, "gemma_norm"),
+        ("input_layernorm", 1, "gemma_residual_norm"), ("post_attention_layernorm", 0, "gemma_residual_norm"),
+        ("attn_post_proj_gate", 0, "attention_post"), ("shared_gate_sigmoid_mul_add", 0, "shared_gate"),
+        ("attention_tp_allreduce", 0, "tp_allreduce"), ("mlp_tp_allreduce", 0, "tp_allreduce")):
+        q = query(component, layer)
+        estimate = fit(q)
+        assert estimate.source.endswith("/" + primitive) and estimate.query_key == q.key
+        assert estimate.measurement_type == "HIP_GRAPH_REPLAY"
+        assert estimate.basis == ("calibrated_collective" if q.is_collective else "isolated_compute")
+    with pytest.raises(ValueError, match="Missing"):
+        fit(query("attn_decode"))
+    with pytest.raises(ValueError, match="another runtime"):
+        fit(replace(query("input_layernorm"), identity=replace(IDENTITY, device="other")))
+
+
+@pytest.mark.parametrize("mode", ["sensitivity", "spread"])
+def test_unstable_calibration_rejected(mode):
+    data = profiles()
+    for payload in data:
+        for row in payload["rows"]:
+            if row["primitive"] == "gemma_norm" and row["invocations_per_graph"] == 32:
+                row["samples_ms"] = [1., 2.] * 10 if mode == "spread" else [2.] * 20
+    fit = PrimitiveCalibration(data, identity=IDENTITY)
+    assert not fit.quality["gemma_norm"]["admitted"]
+    with pytest.raises(ValueError, match="quality-rejected"):
+        fit(query("input_layernorm"))
+
+
+def test_kernel_evidence_is_separate_and_rejects_empty_partial_ranges():
+    records = [{"primitive": "gemma_norm", "physical_size": 16, "invocations_per_graph": 32, "kernel_trace_invocations": 2}]
+    events = [{"name": "primitive:gemma_norm:b16:n32", "cat": "user_annotation", "ph": "X", "ts": 10, "dur": 10},
+        {"name": "primitive:gemma_norm:b16:n32", "cat": "gpu_user_annotation", "ph": "X", "ts": 10, "dur": 10}]
+    with pytest.raises(ValueError, match="incomplete"):
+        attach_kernel_evidence(records, events)
+    events.extend({"name": "norm", "cat": "kernel", "ph": "X", "ts": ts, "dur": 1} for ts in (11, 15))
+    attach_kernel_evidence(records, events)
+    assert records[0]["kernel_count"] == 2
+    events[-1]["ts"] = 100
+    with pytest.raises(ValueError, match="incomplete"):
+        attach_kernel_evidence(records, events)
+
+
+@pytest.mark.parametrize("sizes,counts,reps,split", [([], [2], 20, "calibration"),
+    ([16, 16], [2], 20, "calibration"), ([16], [1], 20, "calibration"),
+    ([16], [2], 4, "calibration"), ([16], [2], 20, "unknown")])
+def test_profile_plan_validation(sizes, counts, reps, split):
+    with pytest.raises(ValueError): validate_plan(sizes, counts, reps, split)

--- a/tests/unit/test_profiling_accelerator.py
+++ b/tests/unit/test_profiling_accelerator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from frontier.config.device_sku_config import BaseDeviceSKUConfig
+from frontier.config.node_sku_config import BaseNodeSKUConfig
+from frontier.profiling.common.accelerator import (
+    accelerator_platform,
+    get_available_gpu_ids,
+    set_process_visible_device,
+)
+from frontier.types import DeviceSKUType, NodeSKUType
+
+
+def _completed(command: list[str], stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(command, returncode, stdout, "")
+
+
+def test_accelerator_platform_distinguishes_rocm_cuda_and_cpu() -> None:
+    assert accelerator_platform(SimpleNamespace(version=SimpleNamespace(hip="7.2", cuda=None))) == "rocm"
+    assert accelerator_platform(SimpleNamespace(version=SimpleNamespace(hip=None, cuda="12.8"))) == "cuda"
+    assert accelerator_platform(SimpleNamespace(version=SimpleNamespace(hip=None, cuda=None))) == "cpu"
+
+
+def test_rocm_visibility_precedes_cuda_compatibility_visibility() -> None:
+    environ = {
+        "ROCR_VISIBLE_DEVICES": "4,5,6",
+        "CUDA_VISIBLE_DEVICES": "0,1",
+    }
+    assert get_available_gpu_ids(2, environ=environ) == [4, 5]
+
+
+def test_discovery_uses_amd_smi_json_without_torch_initialization() -> None:
+    calls: list[list[str]] = []
+
+    def runner(command, **_kwargs):
+        calls.append(command)
+        return _completed(command, json.dumps([{"gpu": 0}, {"gpu": 1}]))
+
+    assert get_available_gpu_ids(2, environ={}, command_runner=runner) == [0, 1]
+    assert calls == [["amd-smi", "list", "--json"]]
+
+
+def test_discovery_falls_back_to_nvidia_smi() -> None:
+    def runner(command, **_kwargs):
+        if command[0] == "amd-smi":
+            raise FileNotFoundError(command[0])
+        return _completed(command, "0\n1\n")
+
+    assert get_available_gpu_ids(2, environ={}, command_runner=runner) == [0, 1]
+
+
+def test_discovery_rejects_non_integer_visibility_tokens() -> None:
+    with pytest.raises(RuntimeError, match="integer GPU IDs"):
+        get_available_gpu_ids(1, environ={"HIP_VISIBLE_DEVICES": "gpu-uuid"})
+
+
+def test_discovery_reports_insufficient_visible_gpus() -> None:
+    with pytest.raises(RuntimeError, match="Requested 2 GPUs but only found 1"):
+        get_available_gpu_ids(2, environ={"CUDA_VISIBLE_DEVICES": "7"})
+
+
+def test_set_process_visible_device_uses_native_rocm_variables() -> None:
+    environ = {"CUDA_VISIBLE_DEVICES": "4"}
+    torch_module = SimpleNamespace(version=SimpleNamespace(hip="7.2", cuda=None))
+
+    description = set_process_visible_device(
+        2,
+        torch_module=torch_module,
+        environ=environ,
+    )
+
+    assert description == "ROCR_VISIBLE_DEVICES=2"
+    assert environ == {"ROCR_VISIBLE_DEVICES": "2"}
+
+
+def test_set_process_visible_device_uses_cuda_variable() -> None:
+    environ = {"ROCR_VISIBLE_DEVICES": "4", "HIP_VISIBLE_DEVICES": "4"}
+    torch_module = SimpleNamespace(version=SimpleNamespace(hip=None, cuda="12.8"))
+
+    description = set_process_visible_device(
+        3,
+        torch_module=torch_module,
+        environ=environ,
+    )
+
+    assert description == "CUDA_VISIBLE_DEVICES=3"
+    assert environ == {"CUDA_VISIBLE_DEVICES": "3"}
+
+
+def test_mi355x_device_and_ubb_node_configs_are_registered() -> None:
+    device = BaseDeviceSKUConfig.create_from_type(DeviceSKUType.MI355X)
+    node = BaseNodeSKUConfig.create_from_type(NodeSKUType.MI355X_UBB)
+
+    assert device.fp16_tflops == 2516
+    assert device.total_memory_gb == 288
+    assert node.device_sku_type is DeviceSKUType.MI355X
+    assert node.num_devices_per_node == 8

--- a/tests/unit/test_profiling_confirmation_moe.py
+++ b/tests/unit/test_profiling_confirmation_moe.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+
+from frontier.config.model_config import QuantizationConfig
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.utils.confirmation import build_moe_config_sections
+from frontier.types import ActivationType, NormType
+
+
+def _args() -> SimpleNamespace:
+    return SimpleNamespace(
+        disable_ray=True,
+        num_gpus=8,
+        device="mi355x",
+        output_dir="out",
+        profile_method="cuda_event",
+        num_tensor_parallel_workers=[1],
+        expert_parallel_sizes=[8],
+        use_fp8=False,
+        per_channel_quant=False,
+        block_shape=None,
+        enable_load_imbalance=False,
+        load_distributions=["uniform"],
+        num_samples_per_distribution=1,
+        max_tokens=1,
+    )
+
+
+def _model(quantization_config: QuantizationConfig | None) -> ModelConfig:
+    return ModelConfig(
+        name="moe-confirmation-test",
+        num_layers=1,
+        num_q_heads=8,
+        num_kv_heads=1,
+        embedding_dim=1024,
+        mlp_hidden_dim=256,
+        max_position_embeddings=128,
+        use_gated_mlp=True,
+        use_bias=False,
+        use_qkv_bias=False,
+        activation=ActivationType.SILU,
+        norm=NormType.RMS_NORM,
+        post_attn_norm=False,
+        vocab_size=1024,
+        is_moe=True,
+        num_experts=8,
+        num_experts_per_tok=2,
+        dtype="bfloat16",
+        quantization_config=quantization_config,
+    )
+
+
+def test_moe_confirmation_reports_selective_mxfp4_grouped_gemm() -> None:
+    model = _model(
+        QuantizationConfig(
+            quant_method="fp4",
+            activation_scheme="dynamic",
+            quantized_operations=["moe_grouped_gemm"],
+        )
+    )
+
+    sections = build_moe_config_sections(
+        args=_args(),
+        model_config=model,
+        num_tokens_count=1,
+        use_vllm_kernel=True,
+        precision_str="BF16",
+        torch_dtype="torch.bfloat16",
+    )
+
+    precision_section = dict(dict(sections)["Precision & Quantization"])
+    operations = dict(dict(sections)["MoE Operations by Parallelism"])[""]
+
+    assert precision_section["Base Precision (dtype)"] == "BF16 (torch.bfloat16)"
+    assert precision_section["Grouped GEMM Precision"] == "FP4"
+    assert "method=fp4" in precision_section["Quantization"]
+    assert "moe_gating_linear          : BF16" in operations
+    assert "moe_grouped_gemm           : FP4" in operations
+
+
+def test_moe_confirmation_keeps_unquantized_grouped_gemm_at_base_precision() -> None:
+    sections = build_moe_config_sections(
+        args=_args(),
+        model_config=_model(None),
+        num_tokens_count=1,
+        use_vllm_kernel=True,
+        precision_str="BF16",
+        torch_dtype="torch.bfloat16",
+    )
+
+    precision_section = dict(dict(sections)["Precision & Quantization"])
+
+    assert precision_section["Grouped GEMM Precision"] == "BF16"
+    assert precision_section["Quantization"] == "Disabled"

--- a/tests/unit/test_profiling_timing_stats_contract.py
+++ b/tests/unit/test_profiling_timing_stats_contract.py
@@ -28,6 +28,15 @@ def test_cuda_event_timer_stats_include_sample_count() -> None:
     assert stats["attn_prefill"]["max"] == 2.75
 
 
+def test_timer_stats_can_summarize_distributed_materialized_samples() -> None:
+    stats = TimerStatsStore.get_stats_from_times(
+        {"gdn_core_decode": [0.25, 0.5, 0.75]}
+    )
+
+    assert stats["gdn_core_decode"]["count"] == 3
+    assert stats["gdn_core_decode"]["median"] == 0.5
+
+
 def test_record_function_tracer_stats_include_sample_count(tmp_path: Path) -> None:
     trace_path = tmp_path / "trace.json"
     trace_path.write_text(

--- a/tests/unit/test_qwen35_quark_model_config.py
+++ b/tests/unit/test_qwen35_quark_model_config.py
@@ -1,0 +1,109 @@
+from frontier.config.model_config import BaseModelConfig, QuantizationConfig
+from frontier.config.precision_type import PrecisionType
+from frontier.config.quantization_manager import QuantizationManager
+from frontier.gdn import SequenceMixerType
+from frontier.profiling.common.model_config import ModelConfig
+
+
+def test_quark_mxfp4_config_maps_to_selective_fp4_operations() -> None:
+    quantization = QuantizationConfig.from_dict(
+        {
+            "quant_method": "quark",
+            "global_quant_config": {
+                "weight": {"dtype": "fp4", "group_size": 32},
+                "input_tensors": {
+                    "dtype": "fp4",
+                    "group_size": 32,
+                    "is_dynamic": True,
+                },
+            },
+            "frontier_quantized_operations": ["moe_grouped_gemm"],
+        }
+    )
+
+    assert quantization.quant_method == "fp4"
+    assert quantization.activation_scheme == "dynamic"
+    assert quantization.quantized_operations == ["moe_grouped_gemm"]
+
+
+def test_qwen38_profile_config_preserves_hybrid_moe_shape_and_precision() -> None:
+    model_name = "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+    base_config = BaseModelConfig.create_from_name(model_name)
+    profile_config = ModelConfig.from_model_name(model_name)
+
+    assert base_config.num_layers == 92
+    assert base_config.num_experts == 512
+    assert base_config.num_experts_per_tok == 10
+    assert base_config.embedding_dim == 8192
+    assert base_config.mlp_hidden_dim == 2048
+    assert base_config.quantization_config is not None
+    assert base_config.quantization_config.quant_method == "fp4"
+    assert base_config.quantization_config.quantized_operations == [
+        "moe_grouped_gemm"
+    ]
+    assert base_config.partial_rotary_factor == 0.25
+    assert profile_config.use_qk_norm is True
+    assert profile_config.attn_output_gate is True
+    assert profile_config.partial_rotary_factor == 0.25
+    assert profile_config.share_expert_dim == 2048
+    assert base_config.get_model_architecture_profile().profile_id == "qwen3_5_moe"
+    assert profile_config.get_model_architecture_profile().profile_id == "qwen3_5_moe"
+    assert base_config.get_num_gdn_layers() == 69
+    assert base_config.get_num_full_attention_layers() == 23
+    assert profile_config.get_num_gdn_layers() == 69
+    assert profile_config.get_num_full_attention_layers() == 23
+    assert base_config.get_sequence_mixer_type(0) is SequenceMixerType.GATED_DELTA_NET
+    assert base_config.get_sequence_mixer_type(3) is SequenceMixerType.FULL_ATTENTION
+    assert base_config.get_sequence_mixer_layer_ids(
+        SequenceMixerType.FULL_ATTENTION
+    ) == list(range(3, 92, 4))
+
+    gdn_config = base_config.get_gdn_config()
+    assert gdn_config is not None
+    assert gdn_config.conv_dim == 20480
+    assert gdn_config.key_dim == 2048
+    assert gdn_config.value_dim == 16384
+
+
+def test_qwen38_gdn_state_layout_matches_vllm_shapes() -> None:
+    config = BaseModelConfig.create_from_name(
+        "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+    )
+    gdn_config = config.get_gdn_config()
+    assert gdn_config is not None
+
+    expected_bytes_by_tp = {
+        1: 8_511_488,
+        2: 4_255_744,
+        4: 2_127_872,
+        8: 1_063_936,
+    }
+    for tp_size, expected_bytes in expected_bytes_by_tp.items():
+        state_layout = gdn_config.get_state_layout(tensor_parallel_size=tp_size)
+        assert state_layout.conv_state_shape == (3, 20480 // tp_size)
+        assert state_layout.recurrent_state_shape == (
+            128 // tp_size,
+            128,
+            128,
+        )
+        assert state_layout.total_bytes == expected_bytes
+
+    assert (
+        gdn_config.get_state_layout(tensor_parallel_size=1).total_bytes
+        * config.get_num_gdn_layers()
+        == 587_292_672
+    )
+
+
+def test_qwen38_quantization_manager_keeps_non_routed_ops_bf16() -> None:
+    manager = QuantizationManager()
+    config = BaseModelConfig.create_from_name(
+        "Qwen3.8-2.4T-A95B-Quark-MXFP4"
+    )
+    try:
+        manager.configure_from_model_config(config)
+        assert manager.get_precision("moe_grouped_gemm") is PrecisionType.FP4
+        assert manager.get_precision("attn_pre_proj") is PrecisionType.BF16
+        assert manager.get_precision("share_expert_up_proj") is PrecisionType.BF16
+    finally:
+        manager.load_config()

--- a/tests/unit/test_rotary_embedding_vllm_compat.py
+++ b/tests/unit/test_rotary_embedding_vllm_compat.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import torch
+
+from frontier.profiling.common.layers.rotary_embedding import _call_vllm_get_rope
+
+
+def test_vllm_legacy_rope_factory_contract() -> None:
+    captured = {}
+
+    def legacy_get_rope(
+        head_size,
+        rotary_dim,
+        max_position,
+        base,
+        is_neox_style,
+        rope_scaling,
+        dtype,
+    ):
+        captured.update(locals())
+        return "legacy"
+
+    result = _call_vllm_get_rope(
+        legacy_get_rope,
+        head_size=128,
+        rotary_dim=64,
+        max_position=8192,
+        base=1_000_000,
+        is_neox_style=True,
+        rope_scaling=None,
+        dtype=torch.bfloat16,
+    )
+
+    assert result == "legacy"
+    assert captured["rotary_dim"] == 64
+    assert captured["base"] == 1_000_000
+
+
+def test_vllm_current_rope_factory_contract() -> None:
+    captured = {}
+
+    def current_get_rope(
+        head_size,
+        max_position,
+        is_neox_style=True,
+        rope_parameters=None,
+        dtype=None,
+        dual_chunk_attention_config=None,
+    ):
+        captured.update(locals())
+        return "current"
+
+    result = _call_vllm_get_rope(
+        current_get_rope,
+        head_size=128,
+        rotary_dim=64,
+        max_position=8192,
+        base=1_000_000,
+        is_neox_style=False,
+        rope_scaling={"rope_type": "linear", "factor": 2.0},
+        dtype=torch.bfloat16,
+    )
+
+    assert result == "current"
+    assert captured["rope_parameters"] == {
+        "rope_type": "linear",
+        "factor": 2.0,
+        "rope_theta": 1_000_000,
+        "rope_dim": 64,
+    }

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -1,0 +1,75 @@
+from dataclasses import replace
+from types import SimpleNamespace
+import gzip
+import json
+
+import numpy as np
+import pytest
+
+from frontier.validation.routing import read_routing, snapshot_routing
+
+
+def sample(ids=None, weights=None, **changes):
+    options = dict(batch_id="b", rank=0, layer_id=0, capture_id=1,
+                   logical_size=2, num_experts=4, top_k=2)
+    options.update(changes)
+    return snapshot_routing([[0, 1], [1, 2], [0, 0]] if ids is None else ids,
+        [[.5, .5], [.4, .6], [0., 0.]] if weights is None else weights, **options)
+
+
+def test_padding_and_zero_weight_assignments_are_not_labeled_live_tokens():
+    row = sample()
+    assert row.logical_expert_counts == (1, 2, 1, 0)
+    assert row.padding_expert_counts == (2, 0, 0, 0)
+    assert row.logical_positive_weight_slots == 4 and row.padding_positive_weight_slots == 0
+    assert row.to_lane_workload(include_padding=False).local_token_counts == (1, 2, 1, 0)
+    assert row.to_lane_workload(include_padding=True).local_token_counts == (3, 2, 1, 0)
+    model = SimpleNamespace(num_experts=4, num_experts_per_tok=2, embedding_dim=8, mlp_hidden_dim=16)
+    logical = row.native_load_features(model_config=model, include_padding=False)
+    physical = row.native_load_features(model_config=model, include_padding=True)
+    assert logical["total_routed_tokens"] == 4 and physical["total_routed_tokens"] == 6
+    assert logical["max_load_ratio"] == 2
+    assert physical["max_load_ratio"] == 2
+    model.num_experts = 8
+    with pytest.raises(ValueError, match="match model"):
+        row.native_load_features(model_config=model, include_padding=False)
+
+
+def test_sentinels_only_in_padding_and_slot_order_is_distinct_from_expert_set():
+    row = sample(ids=[[0, 1], [1, 2], [-1, -1]])
+    assert row.padding_expert_counts == (0, 0, 0, 0) and row.invalid_padding_slots == 2
+    reordered = sample(ids=[[1, 0], [2, 1], [-1, -1]])
+    assert row.logical_assignment_sha256 != reordered.logical_assignment_sha256
+    assert row.logical_expert_set_sha256 == reordered.logical_expert_set_sha256
+    assert row.logical_weights_sha256 == reordered.logical_weights_sha256
+
+
+@pytest.mark.parametrize("changes", [
+    {"ids": [[0, 0], [1, 2], [0, 0]]}, {"ids": [[-1, 1], [1, 2], [0, 0]]},
+    {"ids": [[0, 4], [1, 2], [0, 0]]}, {"ids": [[0., 1.], [1., 2.], [0., 0.]]},
+    {"weights": [[.5, .5], [.4, float("nan")], [0., 0.]]},
+    {"weights": [[.5, -.5], [.4, .6], [0., 0.]]},
+    {"ids": [[0, 1], [1, 2], [-1, -1]], "weights": [[.5, .5], [.4, .6], [.1, 0.]]},
+    {"logical_size": 4}, {"top_k": 3}, {"rank": True},
+])
+def test_invalid_topk_fails(changes):
+    with pytest.raises(ValueError):
+        sample(**changes)
+
+
+def test_roundtrip_schema_and_duplicate_coverage(tmp_path):
+    row = sample()
+    path = tmp_path / "routing.jsonl.gz"
+    with gzip.open(path, "wt") as stream:
+        stream.write(json.dumps(row.to_dict()) + "\n")
+    assert list(read_routing(path)) == [row]
+    with gzip.open(path, "at") as stream:
+        stream.write(json.dumps(row.to_dict()) + "\n")
+    with pytest.raises(ValueError, match="Duplicate"):
+        list(read_routing(path))
+    with pytest.raises(ValueError, match="Logical counts"):
+        replace(row, logical_expert_counts=(2, 2, 2, 0))
+    with pytest.raises(ValueError, match="Padding counts"):
+        replace(row, padding_expert_counts=(0, 0, 0, 0))
+    with pytest.raises(ValueError, match="digest"):
+        replace(row, logical_assignment_sha256="bad")

--- a/tests/unit/test_routing_report.py
+++ b/tests/unit/test_routing_report.py
@@ -1,0 +1,77 @@
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from frontier.validation.routing_report import (
+    audit_routing, compare_routing_passes, graph_routing_enabled,
+)
+from tests.unit.test_batch_validation import record
+from tests.unit.test_routing import sample
+
+
+MODEL = SimpleNamespace(num_layers=1, num_experts=4, num_experts_per_tok=2, embedding_dim=8, mlp_hidden_dim=16)
+
+
+def test_graph_routing_accepts_layer_or_decoder_event_capture():
+    assert graph_routing_enabled({"graph_event_layers": [0]})
+    assert graph_routing_enabled({"graph_event_layers": [], "graph_decoder_event": True})
+    assert not graph_routing_enabled({"graph_event_layers": []})
+
+
+def fixtures():
+    rows = [record(rank=rank, batch_id="b", request_ids=("a", "b"), query_lens=(1, 1),
+        context_lens=(1024, 1024), prefill_mask=(False, False), step=1, capture_size=3,
+        profiled=True, decode_input_sha256="a" * 64) for rank in (0, 1)]
+    return rows, [sample(rank=rank) for rank in (0, 1)]
+
+
+def audit(records, routes, writer=None):
+    return audit_routing(records, routes, layer_ids=[0], tensor_parallel_size=2,
+                         model_config=MODEL, feature_writer=writer)
+
+
+def test_full_coverage_rank_agreement_and_native_features():
+    records, routes = fixtures()
+    features = []
+    report, references = audit(records, routes, features.append)
+    assert report["all_model_layers_covered"] and report["routing_records"] == 2
+    assert not report["tp_logical_mismatches"] and not report["tp_padding_mismatches"]
+    assert len(features) == 1  # rank-0 feature export, not TP-summed counts
+    assert features[0]["physical_features"]["total_routed_tokens"] == 6
+    assert len(references) == 1
+    comparison = compare_routing_passes(references, references)
+    assert comparison["identical_logical_assignments"] == 1
+    assert comparison["logical_histogram_l1_fraction_max"] == 0
+
+
+def test_tp_route_divergence_is_reported_even_with_identical_histograms():
+    records, routes = fixtures()
+    routes[1] = sample(ids=[[1, 0], [2, 1], [0, 0]], rank=1)
+    report, _ = audit(records, routes)
+    assert report["tp_logical_mismatches"] == [("b", 1, 0)]
+    assert not report["tp_padding_mismatches"]
+
+
+def test_paired_pass_comparison_retains_per_token_set_and_histogram_distinctions():
+    records, routes = fixtures()
+    _, base = audit(records, routes)
+    changed = [sample(ids=[[1, 0], [2, 1], [0, 0]], rank=rank) for rank in (0, 1)]
+    _, observed = audit(records, changed)
+    result = compare_routing_passes(base, observed)
+    assert result["identical_logical_assignments"] == 0
+    assert result["identical_logical_expert_sets"] == 1
+    assert result["logical_histogram_l1_fraction_median"] == 0
+    with pytest.raises(ValueError, match="No matching"):
+        compare_routing_passes({}, observed)
+
+
+def test_incomplete_duplicate_wrong_shape_and_greedy_inputs_fail():
+    records, routes = fixtures()
+    for bad in (routes[:1], routes + routes[:1], [replace(routes[0], batch_id="other"), routes[1]]):
+        with pytest.raises(ValueError):
+            audit(records, bad)
+    with pytest.raises(ValueError, match="fixed-input"):
+        audit([replace(r, decode_input_sha256=None) for r in records], routes)
+    with pytest.raises(ValueError, match="shape/model"):
+        audit([replace(r, capture_size=4) for r in records], routes)

--- a/tests/unit/test_runtime_cost_correlation.py
+++ b/tests/unit/test_runtime_cost_correlation.py
@@ -1,0 +1,122 @@
+from copy import deepcopy
+from dataclasses import asdict
+
+import pytest
+
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload, RuntimeIdentity
+from frontier.validation.batch_record import BatchRecord
+from frontier.validation.runtime_cost_correlation import correlate_exact_decoder
+
+
+IDENTITY = RuntimeIdentity("a" * 64, "synthetic-unit-device", 2, "synthetic-unit-stack")
+WORKLOAD = DecodeWorkload(2, (1025, 2049, 1, 1))
+QUERY = CostQuery(IDENTITY, 0, "gdn", "input_layernorm", WORKLOAD)
+
+
+def record(rank):
+    return BatchRecord(
+        batch_id="exact-batch", rank=rank, phase="decode",
+        request_ids=("a", "b"), query_lens=(1, 1), context_lens=(1024, 2048),
+        prefill_mask=(False, False), graph_mode="FULL", capture_size=4,
+        forward_gpu_ms=10.0 + rank, step_wall_ms=12.0, profiled=True,
+        decode_input_sha256="c" * 64,
+    )
+
+
+def fixtures():
+    prediction = {
+        "schema_version": 1,
+        "batch_id": "exact-batch",
+        "identity": asdict(IDENTITY),
+        "profile_coverage": {"complete": True, "missing": [], "queries": 1},
+        "queries": [{"query": asdict(QUERY), "query_key": QUERY.key}],
+        "prediction": {
+            "decoder_ms": 8.5,
+            "routing_conditioned": True,
+            "full_forward_parity_admitted": False,
+            "diagnostic": False,
+        },
+    }
+    records = [record(0), record(1)]
+    samples = [{
+        "batch_id": "exact-batch", "rank": rank, "component": "decoder",
+        "measurement_type": "HIP_GRAPH_EVENT", "first_layer_id": 0,
+        "last_layer_id": 0, "physical_size": 4, "inclusive_gpu_ms": 8.0 + rank,
+    } for rank in range(2)]
+    routing = {
+        "routing_records": 2, "all_model_layers_covered": True,
+        "tp_logical_mismatches": [], "tp_padding_mismatches": [],
+    }
+    quality = {"batches": [{
+        "batch_id": "exact-batch", "passes_latency_check": True,
+        "signed_change_pct": 0.5,
+    }]}
+    return prediction, records, samples, routing, quality
+
+
+def correlate(*, mutate=None, queries=(QUERY,), capture_pass=True):
+    prediction, records, samples, routing, quality = fixtures()
+    values = {
+        "prediction": prediction, "records": records, "samples": samples,
+        "routing": routing, "quality": quality,
+    }
+    if mutate:
+        mutate(values)
+    return correlate_exact_decoder(
+        values["prediction"], values["records"], values["samples"],
+        identity=IDENTITY, expected_queries=queries, routing_audit=values["routing"],
+        quality=values["quality"], all_capture_batches_pass=capture_pass,
+    )
+
+
+def test_exact_decoder_correlation_uses_slowest_rank_and_applies_no_correction():
+    result = correlate()
+    assert result["predicted_decoder_ms"] == 8.5
+    assert result["observed_decoder_max_rank_ms"] == 9.0
+    assert result["signed_error_ms"] == -0.5
+    assert result["absolute_relative_error"] == pytest.approx(0.5 / 9.0)
+    assert result["profiled_forward_max_rank_ms"] == 11.0
+    assert result["forward_minus_decoder_ms"] == 2.0
+    assert result["observer_latency_check_passed"]
+    assert result["all_capture_decode_batches_passed"]
+    assert not result["correction_applied"]
+    assert not result["full_forward_parity_admitted"]
+
+
+@pytest.mark.parametrize("mutation", [
+    lambda value: value["prediction"]["profile_coverage"].update(complete=False),
+    lambda value: value["prediction"]["queries"][0].update(query_key="b" * 64),
+    lambda value: value["prediction"]["prediction"].update(diagnostic=True),
+    lambda value: value["routing"]["tp_logical_mismatches"].append({"layer": 0}),
+    lambda value: value["records"].pop(),
+    lambda value: value["samples"].pop(),
+    lambda value: value["samples"][0].update(inclusive_gpu_ms=20.0),
+    lambda value: value["quality"]["batches"][0].update(passes_latency_check=False),
+])
+def test_correlation_rejects_nonexact_or_untrusted_inputs(mutation):
+    with pytest.raises(ValueError):
+        correlate(mutate=mutation)
+
+
+def test_correlation_rejects_noncontiguous_layer_plan_and_nonboolean_capture_gate():
+    changed = CostQuery(IDENTITY, 2, "gdn", "input_layernorm", WORKLOAD,
+                        residual_from_layer=1)
+
+    def use_changed_query(value):
+        value["prediction"]["queries"] = [
+            {"query": asdict(changed), "query_key": changed.key}]
+
+    with pytest.raises(ValueError, match="contiguous"):
+        correlate(queries=(changed,), mutate=use_changed_query)
+    with pytest.raises(ValueError, match="perturbation gate"):
+        correlate(capture_pass=1)
+    with pytest.raises(ValueError, match="perturbation gate"):
+        correlate(capture_pass=False)
+
+
+def test_correlation_rejects_duplicate_quality_rows():
+    def duplicate(value):
+        value["quality"]["batches"].append(deepcopy(value["quality"]["batches"][0]))
+
+    with pytest.raises(ValueError, match="perturbation gate"):
+        correlate(mutate=duplicate)

--- a/tests/unit/test_runtime_mapping.py
+++ b/tests/unit/test_runtime_mapping.py
@@ -1,0 +1,48 @@
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.validation.runtime_mapping import map_runtime_components
+
+
+def mapping(components, **kwargs):
+    options = dict(phase="decode", layer_id=0, measurement_type="HIP_GRAPH_EVENT",
+        model_config=ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4"))
+    options.update(kwargs)
+    return map_runtime_components(components, **options)
+
+
+def test_combined_mlp_reduction_and_missing_gates_cannot_be_imported_twice():
+    result = mapping(["mlp_tp_allreduce", "shared_gate_sigmoid_mul_add"])
+    reduction, gate = result["mappings"]
+    assert reduction["relationship"] == "fused_collective"
+    assert len(reduction["native_targets"]) == 2
+    assert gate["relationship"] == "native_gap" and not gate["native_targets"]
+    assert not result["native_measurement_family_supported"]
+    assert not any(row["native_csv_export_admitted"] for row in result["mappings"])
+    attention = mapping(["attn_post_proj_gate"], layer_id=3, measurement_type="KERNEL_ONLY")
+    assert attention["mappings"][0]["relationship"] == "native_gap"
+    assert attention["native_measurement_family_supported"]
+
+
+def test_fused_residuals_keep_cross_layer_ownership():
+    first = mapping(["input_layernorm"])["mappings"][0]
+    later = mapping(["input_layernorm"], layer_id=1)["mappings"][0]
+    assert len(first["native_targets"]) == 1
+    assert later["native_targets"][1] == {"operator": "add_ffn_residual", "family": "memory", "layer_offset": -1}
+    assert later["relationship"] == "fused_cross_layer"
+
+
+def test_partial_event_scopes_are_not_whole_native_operators():
+    result = mapping(["gdn_attn", "gdn_out_proj", "moe_experts"])
+    assert [row["relationship"] for row in result["mappings"]] == ["partial", "partial", "composite"]
+    assert {t["operator"] for t in result["mappings"][2]["native_targets"]} == {"moe_shuffling", "moe_grouped_gemm"}
+
+
+@pytest.mark.parametrize("components,kwargs", [
+    (["invented"], {}), (["gdn_core_prefill"], {}), (["gdn"], {"layer_id": 3}),
+    (["full_attention"], {}), (["gdn"], {"phase": "mixed"}),
+    (["gdn", "gdn"], {}), (["gdn"], {"measurement_type": "EVENT_AS_KERNELS"}),
+])
+def test_unknown_or_mismatched_runtime_mapping_fails(components, kwargs):
+    with pytest.raises(ValueError):
+        mapping(components, **kwargs)

--- a/tests/unit/test_sglang_attention_primitives.py
+++ b/tests/unit/test_sglang_attention_primitives.py
@@ -1,0 +1,122 @@
+from copy import deepcopy
+
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.runtime.sglang_attention import (
+    ATTENTION_PRIMITIVES,
+    attention_decode_spec,
+    validate_attention_decode_spec,
+    validate_attention_workload,
+)
+from frontier.profiling.runtime.sglang_primitives import DEFAULT_PRIMITIVES
+from frontier.runtime_cost.primitives import PrimitiveCalibration
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload
+from tests.unit.test_primitive_calibration import IDENTITY, profiles
+
+
+@pytest.fixture
+def model():
+    return ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+
+
+def test_qwen38_tp8_attention_decode_contract(model):
+    spec = attention_decode_spec(model, 8)
+    assert spec["q_heads"] == 8
+    assert spec["kv_heads"] == 1
+    assert spec["head_dim"] == 256
+    assert spec["rotary_dim"] == 64
+    assert spec["projected_qkv_gate_width"] == 4608
+    assert spec["local_qkv_weight_shape"] == (4608, 8192)
+    assert spec["attention_backend"] == "aiter.paged_attention_ragged"
+    assert spec["kv_cache_layout"] == "NHD"
+    assert spec["page_size"] == 1
+    assert spec["output_gate"]
+    assert not spec["includes_output_projection"]
+    validate_attention_decode_spec(spec, 8)
+
+
+def test_context_sensitive_primitives_are_opt_in(model):
+    assert not set(ATTENTION_PRIMITIVES) & set(DEFAULT_PRIMITIVES)
+    assert validate_attention_workload(
+        24, 20, (1029,) * 20 + (1,) * 4, attention_decode_spec(model, 8)
+    ) == {
+        "logical_size": 20,
+        "padding_count": 4,
+        "active_context_length": 1029,
+        "padding_context_length": 1,
+    }
+
+
+def attention_profiles(model, split="calibration", sizes=(16, 32), context=1029):
+    result = profiles(split, sizes)
+    spec = attention_decode_spec(model, 8)
+    for payload in result:
+        base = [row for row in payload["rows"] if row["primitive"] == "gemma_norm"]
+        payload["rows"] = []
+        for name in ATTENTION_PRIMITIVES:
+            for row in base:
+                row = deepcopy(row)
+                size = row["physical_size"]
+                logical = size - 4
+                contexts = (context,) * logical + (1,) * 4
+                row.update(
+                    primitive=name,
+                    logical_size=logical,
+                    physical_context_lens=list(contexts),
+                    attention_decode_spec=deepcopy(spec),
+                    attention_workload=validate_attention_workload(
+                        size, logical, contexts, spec),
+                )
+                payload["rows"].append(row)
+    return result
+
+
+def test_all_attention_scopes_fit_and_price_exact_context(model):
+    fit = PrimitiveCalibration(attention_profiles(model), identity=IDENTITY)
+    validation = attention_profiles(model, "validation", (24,))
+    assert fit.validate(validation)["all_primitives_passed"]
+    workload = DecodeWorkload(20, (1029,) * 20 + (1,) * 4)
+    for component in ATTENTION_PRIMITIVES:
+        query = CostQuery(IDENTITY, 3, "attention", component, workload)
+        assert fit(query).basis == "isolated_compute"
+
+
+@pytest.mark.parametrize("contexts", [
+    (1030,) * 20 + (1,) * 4,
+    (1029,) * 20 + (2,) * 4,
+    (1029,) * 24,
+])
+def test_query_cannot_change_context_or_padding_ownership(model, contexts):
+    fit = PrimitiveCalibration(attention_profiles(model), identity=IDENTITY)
+    logical = 24 if len(set(contexts)) == 1 else 20
+    query = CostQuery(
+        IDENTITY, 3, "attention", "attn_decode", DecodeWorkload(logical, contexts))
+    with pytest.raises(ValueError, match="Attention"):
+        fit(query)
+
+
+@pytest.mark.parametrize("mutation", ["shape", "summary", "fit_context", "validation_context"])
+def test_changed_attention_contract_fails_closed(model, mutation):
+    data = attention_profiles(model)
+    if mutation == "shape":
+        data[0]["rows"][0]["attention_decode_spec"]["head_dim"] = 128
+        with pytest.raises(ValueError):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    elif mutation == "summary":
+        data[0]["rows"][0]["attention_workload"]["active_context_length"] = 7
+        with pytest.raises(ValueError, match="summary"):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    elif mutation == "fit_context":
+        for payload in data:
+            for row in payload["rows"]:
+                if row["physical_size"] == 32:
+                    row["physical_context_lens"][:28] = [1030] * 28
+                    row["attention_workload"]["active_context_length"] = 1030
+        with pytest.raises(ValueError, match="context lengths"):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    else:
+        fit = PrimitiveCalibration(data, identity=IDENTITY)
+        validation = attention_profiles(model, "validation", (24,), context=1030)
+        with pytest.raises(ValueError, match="context ownership"):
+            fit.validate(validation)

--- a/tests/unit/test_sglang_dense_primitives.py
+++ b/tests/unit/test_sglang_dense_primitives.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.runtime.sglang_dense import DENSE_PRIMITIVES, dense_primitive_spec, validate_dense_spec
+from frontier.runtime_cost.primitives import PrimitiveCalibration
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload
+from tests.unit.test_primitive_calibration import IDENTITY, profiles
+
+
+@pytest.fixture
+def model():
+    return ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+
+
+@pytest.mark.parametrize("name,width,outputs,weights", [
+    ("shared_expert_gate_up", 8192, (512,), ((512, 8192),)),
+    ("shared_expert_activation", 512, (256,), ()),
+    ("shared_expert_down", 256, (8192,), ((8192, 256),)),
+    ("moe_router_linear", 8192, (512,), ((512, 8192),)),
+    ("gdn_input_projections", 8192, (4608, 32), ((4608, 8192), (32, 8192))),
+    ("gdn_output_projection", 2048, (8192,), ((8192, 2048),)),
+])
+def test_native_shards_and_both_gdn_input_projections(model, name, width, outputs, weights):
+    spec = dense_primitive_spec(name, model, 8)
+    assert (spec["input_width"], spec["output_widths"], spec["local_weight_shapes"]) == (width, outputs, weights)
+    assert not spec["includes_reduction"]
+    assert spec["input_transform"] == ("gdn_rmsnorm_gated" if name == "gdn_output_projection" else "none")
+    validate_dense_spec(spec, 8, name)
+
+
+def test_router_is_replicated_and_gdn_heads_use_model_override(model):
+    assert dense_primitive_spec("moe_router_linear", model, 4)["local_weight_shapes"] == ((512, 8192),)
+    assert dense_primitive_spec("shared_expert_gate_up", model, 4)["output_widths"] == (1024,)
+    model.linear_num_value_heads = 64
+    assert dense_primitive_spec("gdn_input_projections", model, 8)["output_widths"] == (2560, 16)
+
+
+@pytest.mark.parametrize("tp", [0, True, 3])
+def test_invalid_sharding_fails(model, tp):
+    with pytest.raises(ValueError): dense_primitive_spec("gdn_input_projections", model, tp)
+
+
+def test_quantized_dense_weights_cannot_be_labeled_bf16(model):
+    model.quantization_config = replace(model.quantization_config, quantized_operations=None)
+    with pytest.raises(ValueError, match="unquantized"):
+        dense_primitive_spec("shared_expert_gate_up", model, 8)
+
+
+def dense_profiles(model, split="calibration", sizes=(16, 32)):
+    result = profiles(split, sizes)
+    for payload in result:
+        base = payload["rows"][:2 * len(sizes)]
+        payload["rows"] = []
+        for name in DENSE_PRIMITIVES:
+            for row in base:
+                row = deepcopy(row)
+                row.update(primitive=name, dense_spec=dense_primitive_spec(name, model, 8))
+                payload["rows"].append(row)
+    return result
+
+
+def test_all_dense_scopes_integrate_without_covering_core_or_routed_experts(model):
+    fit = PrimitiveCalibration(dense_profiles(model), identity=IDENTITY)
+    assert fit.validate(dense_profiles(model, "validation", (24,)))["all_primitives_passed"]
+    for component in DENSE_PRIMITIVES:
+        query = CostQuery(IDENTITY, 0, "gdn", component, DecodeWorkload(20, (1029,) * 20 + (1,) * 4))
+        assert fit(query).basis == "isolated_compute"
+    for component in ("gdn_core_decode", "mlp_tp_allreduce", "moe_routing_topk"):
+        with pytest.raises(ValueError, match="Missing"):
+            fit(CostQuery(IDENTITY, 0, "gdn", component, DecodeWorkload(1, (1029,))))
+
+
+@pytest.mark.parametrize("field,value", [("includes_reduction", True), ("weight_dtype", "float32"),
+    ("local_weight_shapes", ((64, 8192),)), ("input_width", True), ("output_partitions", ((513,),))])
+def test_malformed_rank_shape_evidence_fails(model, field, value):
+    data = dense_profiles(model)
+    data[0]["rows"][0]["dense_spec"][field] = value
+    with pytest.raises(ValueError): PrimitiveCalibration(data, identity=IDENTITY)
+
+
+def test_validation_cannot_silently_change_dense_shape(model):
+    fit = PrimitiveCalibration(dense_profiles(model), identity=IDENTITY)
+    validation = dense_profiles(model, "validation", (24,))
+    for payload in validation:
+        for row in payload["rows"]:
+            if row["primitive"] == "moe_router_linear":
+                spec = row["dense_spec"]
+                spec.update(output_partitions=((256,),), output_widths=(256,), local_weight_shapes=((256, 8192),))
+    with pytest.raises(ValueError, match="shape contract changed"):
+        fit.validate(validation)
+
+
+def test_gdn_output_cannot_drop_its_gated_norm():
+    model = ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+    spec = dense_primitive_spec("gdn_output_projection", model, 8)
+    spec["input_transform"] = "none"
+    with pytest.raises(ValueError, match="ownership"):
+        validate_dense_spec(spec, 8, "gdn_output_projection")

--- a/tests/unit/test_sglang_gdn_primitives.py
+++ b/tests/unit/test_sglang_gdn_primitives.py
@@ -1,0 +1,89 @@
+from copy import deepcopy
+
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.runtime.sglang_gdn import gdn_core_spec, validate_gdn_core_spec
+from frontier.profiling.runtime.sglang_primitives import DEFAULT_PRIMITIVES
+from frontier.runtime_cost.primitives import PrimitiveCalibration
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload
+from tests.unit.test_primitive_calibration import IDENTITY, profiles
+
+
+@pytest.fixture
+def model():
+    return ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+
+
+def test_qwen38_tp8_packed_decode_state_contract(model):
+    spec = gdn_core_spec(model, 8)
+    assert spec["q_heads"] == 2
+    assert spec["value_heads"] == 16
+    assert spec["mixed_qkv_width"] == 2560
+    assert spec["projected_qkvz_width"] == 4608
+    assert spec["projected_ba_width"] == 32
+    assert spec["conv_state_shape"] == (2560, 3)
+    assert spec["recurrent_state_shape"] == (16, 128, 128)
+    assert spec["padding_cache_index"] == -1
+    assert spec["includes_input_reordering"]
+    assert spec["includes_gate_materialization"]
+    assert not spec["includes_gated_norm"]
+    validate_gdn_core_spec(spec, 8)
+
+
+def test_stateful_core_is_opt_in_to_preserve_profiler_defaults():
+    assert "gdn_core_decode" not in DEFAULT_PRIMITIVES
+    assert "gdn_output_projection" in DEFAULT_PRIMITIVES
+
+
+def core_profiles(model, split="calibration", sizes=(16, 32)):
+    result = profiles(split, sizes)
+    for payload in result:
+        base = [row for row in payload["rows"] if row["primitive"] == "gemma_norm"]
+        payload["rows"] = []
+        for row in base:
+            row = deepcopy(row)
+            row.update(primitive="gdn_core_decode", logical_size=row["physical_size"] - 4,
+                       gdn_core_spec=gdn_core_spec(model, 8))
+            payload["rows"].append(row)
+    return result
+
+
+def test_core_fit_is_bounded_to_matching_padding_ownership(model):
+    fit = PrimitiveCalibration(core_profiles(model), identity=IDENTITY)
+    query = CostQuery(IDENTITY, 0, "gdn", "gdn_core_decode",
+                      DecodeWorkload(20, (1029,) * 20 + (1,) * 4))
+    assert fit(query).basis == "isolated_compute"
+    assert fit.validate(core_profiles(model, "validation", (24,)))["all_primitives_passed"]
+    unpadded = CostQuery(IDENTITY, 0, "gdn", "gdn_core_decode",
+                         DecodeWorkload(24, (1029,) * 24))
+    with pytest.raises(ValueError, match="padding"):
+        fit(unpadded)
+
+
+@pytest.mark.parametrize("mutation", ["state", "logical", "padding_fit", "validation_padding"])
+def test_malformed_or_changed_core_contract_fails(model, mutation):
+    data = core_profiles(model)
+    if mutation == "state":
+        data[0]["rows"][0]["gdn_core_spec"]["recurrent_state_shape"] = (8, 128, 128)
+        with pytest.raises(ValueError):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    elif mutation == "logical":
+        data[0]["rows"][0]["logical_size"] = 0
+        with pytest.raises(ValueError):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    elif mutation == "padding_fit":
+        for payload in data:
+            for row in payload["rows"]:
+                if row["physical_size"] == 32:
+                    row["logical_size"] = 24
+        with pytest.raises(ValueError, match="fixed padding"):
+            PrimitiveCalibration(data, identity=IDENTITY)
+    else:
+        fit = PrimitiveCalibration(data, identity=IDENTITY)
+        validation = core_profiles(model, "validation", (24,))
+        for payload in validation:
+            for row in payload["rows"]:
+                row["logical_size"] = 24
+        with pytest.raises(ValueError, match="padding ownership"):
+            fit.validate(validation)

--- a/tests/unit/test_sglang_graph_events.py
+++ b/tests/unit/test_sglang_graph_events.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+import pytest
+
+from frontier.validation.sglang_graph_events import (
+    GraphDecoderEventObserver, GraphOperatorEventObserver,
+)
+from tests.unit.test_sglang_operator_events import Event, Model
+
+
+class API:
+    capture_id = None
+    def capture_info(self, stream):
+        return None if self.capture_id is None else (self.capture_id,)
+    def create_event(self):
+        return Event()
+
+
+def setup():
+    model, api = Model(), API()
+    original = model.layer.forward
+    model.layer.forward = lambda value, forward_batch=None: original(value)
+    observer = GraphOperatorEventObserver(model, [0], api=api, current_stream=lambda: 0)
+    return model, api, observer
+
+
+def batch(size):
+    return SimpleNamespace(batch_size=size, forward_mode=SimpleNamespace(is_decode=lambda: True))
+
+
+def test_only_capture_is_instrumented_and_handles_survive_repeated_collection():
+    model, api, observer = setup()
+    expected = model.layer(1)
+    with observer:
+        assert model.layer(1) == expected
+        assert observer.captures == {}
+        for capture_id, size in ((10, 16), (11, 24)):
+            api.capture_id = capture_id
+            assert model.layer(1, forward_batch=batch(size)) == expected
+    observer.validate_captures()
+    first = observer.collect_graph(24)
+    assert len(first) == 4  # coarse disjoint scopes; untimed ownership markers are omitted
+    assert first == observer.collect_graph(24)
+    assert {r["physical_size"] for r in first} == {24}
+    assert {r["measurement_type"] for r in first} == {"HIP_GRAPH_EVENT"}
+    assert observer.collect_graph(16)[0]["capture_id"] == 10
+    with pytest.raises(ValueError, match="No instrumented"):
+        observer.collect_graph(20)  # logical batch must resolve its physical graph first
+
+
+def test_variants_missing_scopes_and_non_decode_fail():
+    model, api, observer = setup()
+    with pytest.raises(ValueError, match="No full"):
+        observer.validate_captures()
+    with observer:
+        api.capture_id = 1
+        with pytest.raises(ValueError, match="decode"):
+            model.layer(1)
+        model.layer(1, forward_batch=batch(16))
+        api.capture_id = 2
+        with pytest.raises(ValueError, match="variants"):
+            model.layer(1, forward_batch=batch(16))
+    observer.captures[1]["samples"].pop()
+    with pytest.raises(ValueError, match="every selected"):
+        observer.validate_captures()
+
+
+def test_nested_timers_are_rejected_and_leaf_timers_are_admitted():
+    for components, accepted in ((["gdn", "gdn_attn"], False),
+                                 (["gdn_attn", "gdn_norm", "moe_experts"], True)):
+        model, api, _ = setup()
+        observer = GraphOperatorEventObserver(model, [0], api=api, current_stream=lambda: 0,
+                                               components=components)
+        with observer:
+            api.capture_id = 1
+            model.layer(1, forward_batch=batch(16))
+        if accepted:
+            observer.validate_captures()
+            assert {r["component"] for r in observer.collect_graph(16)} == set(components)
+        else:
+            with pytest.raises(ValueError, match="Nested"):
+                observer.validate_captures()
+
+
+def test_whole_decoder_uses_one_event_pair_and_restores_layer():
+    model, api, _ = setup()
+    original = model.layer.forward
+    expected = model.layer(1)
+    observer = GraphDecoderEventObserver(model, api=api, current_stream=lambda: 0)
+    with observer:
+        assert model.layer(1, forward_batch=batch(16)) == expected
+        api.capture_id = 10
+        assert model.layer(1, forward_batch=batch(16)) == expected
+    observer.validate_captures()
+    row = observer.collect_graph(16)
+    assert row == {
+        "component": "decoder",
+        "first_layer_id": 0,
+        "last_layer_id": 0,
+        "measurement_type": "HIP_GRAPH_EVENT",
+        "capture_id": 10,
+        "physical_size": 16,
+        "inclusive_gpu_ms": 1.0,
+    }
+    assert model.layer.forward is original
+    assert observer.collect_graph(16) == row
+
+
+def test_whole_decoder_rejects_missing_and_duplicate_graph_variants():
+    model, api, _ = setup()
+    observer = GraphDecoderEventObserver(model, api=api, current_stream=lambda: 0)
+    with pytest.raises(ValueError, match="No full decoder"):
+        observer.validate_captures()
+    with observer:
+        api.capture_id = 1
+        model.layer(1, forward_batch=batch(16))
+        with pytest.raises(ValueError, match="more than once"):
+            model.layer(1, forward_batch=batch(16))
+        api.capture_id = 2
+        with pytest.raises(ValueError, match="variants"):
+            model.layer(1, forward_batch=batch(16))

--- a/tests/unit/test_sglang_moe_primitives.py
+++ b/tests/unit/test_sglang_moe_primitives.py
@@ -1,0 +1,200 @@
+from copy import deepcopy
+
+import pytest
+
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.profiling.runtime.sglang_moe import (
+    MOE_ROUTING_PRIMITIVES,
+    moe_routed_spec,
+    moe_routing_spec,
+    reconstruct_topk_ids,
+    validate_moe_route_workload,
+    validate_moe_routed_spec,
+    validate_moe_routing_spec,
+)
+from frontier.profiling.runtime.sglang_primitives import DEFAULT_PRIMITIVES
+from frontier.runtime_cost.primitives import PrimitiveCalibration
+from frontier.runtime_cost.routed_primitives import ExactRoutedCalibration
+from frontier.runtime_cost.sglang import CostQuery, DecodeWorkload
+from tests.unit.test_primitive_calibration import IDENTITY, profiles
+
+
+@pytest.fixture
+def model():
+    return ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+
+
+def test_qwen38_moe_topk_contract(model):
+    spec = moe_routing_spec(model)
+    assert spec == {
+        "hidden_size": 8192,
+        "num_experts": 512,
+        "top_k": 10,
+        "logits_dtype": "bfloat16",
+        "weights_dtype": "float32",
+        "ids_dtype": "int32",
+        "scoring": "softmax",
+        "renormalize": False,
+        "backend": "aiter.fused_moe.fused_topk/topk_softmax",
+        "includes_router_linear": False,
+        "includes_padding_mask": False,
+    }
+    validate_moe_routing_spec(spec)
+    assert not set(MOE_ROUTING_PRIMITIVES) & set(DEFAULT_PRIMITIVES)
+
+
+def test_qwen38_tp8_routed_mxfp4_contract(model):
+    spec = moe_routed_spec(model, 8)
+    assert spec["local_intermediate_size"] == 256
+    assert spec["w13_packed_shape"] == (512, 512, 4096)
+    assert spec["w2_packed_shape"] == (512, 8192, 128)
+    assert spec["w13_scale_shape"] == (512, 512, 256)
+    assert spec["w2_scale_shape"] == (512, 8192, 8)
+    assert spec["block_size_m"] == 32
+    assert not spec["includes_sorting"]
+    assert not spec["includes_tp_allreduce"]
+    validate_moe_routed_spec(spec, 8)
+
+
+def test_route_histogram_reconstruction_is_deterministic_and_unique(model):
+    spec = moe_routed_spec(model, 8)
+    counts = (4,) * 20 + (0,) * (spec["num_experts"] - 20)
+    workload = validate_moe_route_workload(8, counts, spec)
+    assert workload == {
+        "physical_size": 8,
+        "active_experts": 20,
+        "maximum_expert_load": 4,
+        "sorted_token_blocks": 20,
+    }
+    rows = reconstruct_topk_ids(8, counts, spec)
+    assert rows == reconstruct_topk_ids(8, counts, spec)
+    assert all(len(row) == spec["top_k"] and len(set(row)) == len(row) for row in rows)
+    rebuilt = [0] * spec["num_experts"]
+    for row in rows:
+        for expert in row:
+            rebuilt[expert] += 1
+    assert tuple(rebuilt) == counts
+
+
+def test_invalid_route_histograms_fail_closed(model):
+    spec = moe_routed_spec(model, 8)
+    with pytest.raises(ValueError):
+        validate_moe_route_workload(8, (80,) + (0,) * 511, spec)
+    with pytest.raises(ValueError):
+        validate_moe_route_workload(8, (1,) * 80, spec)
+
+
+def moe_profiles(model, split="calibration", sizes=(16, 32)):
+    result = profiles(split, sizes)
+    spec = moe_routing_spec(model)
+    for payload in result:
+        base = [row for row in payload["rows"] if row["primitive"] == "gemma_norm"]
+        payload["rows"] = []
+        for row in base:
+            row = deepcopy(row)
+            row.update(
+                primitive="moe_routing_topk",
+                backend=spec["backend"],
+                moe_routing_spec=deepcopy(spec),
+            )
+            payload["rows"].append(row)
+    return result
+
+
+def test_moe_topk_fits_holdout_and_prices_physical_work(model):
+    fit = PrimitiveCalibration(moe_profiles(model), identity=IDENTITY)
+    assert fit.validate(moe_profiles(model, "validation", (24,)))[
+        "all_primitives_passed"]
+    query = CostQuery(
+        IDENTITY, 3, "attention", "moe_routing_topk",
+        DecodeWorkload(20, (1029,) * 20 + (1,) * 4))
+    assert fit(query).basis == "isolated_compute"
+
+
+@pytest.mark.parametrize("field,value", [
+    ("num_experts", 256),
+    ("top_k", 8),
+    ("renormalize", True),
+    ("backend", "torch.topk"),
+])
+def test_changed_moe_topk_contract_fails_closed(model, field, value):
+    data = moe_profiles(model)
+    data[0]["rows"][0]["moe_routing_spec"][field] = value
+    with pytest.raises(ValueError):
+        PrimitiveCalibration(data, identity=IDENTITY)
+
+
+def routed_profiles(model, primitive="moe_sorting"):
+    spec = moe_routed_spec(model, 8)
+    counts = (10,) * 24 + (0,) * 488
+    query = CostQuery(
+        IDENTITY, 0, "gdn", primitive,
+        DecodeWorkload(20, (1029,) * 20 + (1,) * 4),
+        physical_expert_counts=counts)
+    workload = validate_moe_route_workload(24, counts, spec)
+    payloads = []
+    for rank in range(8):
+        rows = []
+        for graph_length, value in ((32, .0101), (128, .0100)):
+            rows.append({
+                "primitive": primitive,
+                "query_key": query.key,
+                "layer_id": 0,
+                "physical_size": 24,
+                "physical_expert_counts": list(counts),
+                "invocations_per_graph": graph_length,
+                "rank": rank,
+                "backend": (spec["sorting_backend"] if primitive == "moe_sorting"
+                            else spec["experts_backend"]),
+                "samples_ms": [value + rank * 1e-6] * 20,
+                "measurement_type": "HIP_GRAPH_REPLAY",
+                "correctness_checked": True,
+                "moe_routed_spec": deepcopy(spec),
+                "moe_route_workload": deepcopy(workload),
+                "kernel_names": (["aiter::opus_moe_sorting_entry<P0>"]
+                                 if primitive == "moe_sorting"
+                                 else ["fused_mx_quant_moe_sort_kernel",
+                                       "mfma_moe1_test", "mfma_moe2_test"])
+                                if rank == 0 else [],
+                "kernel_count": (2 if primitive == "moe_sorting" else 6)
+                                if rank == 0 else None,
+                "kernel_trace_kind": "representative_graph",
+                "kernel_trace_invocations": 2,
+                "trace_scope": f"routed:{primitive}:l0:b24:n{graph_length}",
+            })
+        payloads.append({
+            "schema_version": 1,
+            "profile_kind": "exact_routed_query",
+            "identity": IDENTITY.__dict__,
+            "rank": rank,
+            "world_size": 8,
+            "versions": {"torch": "x", "rocm": "y"},
+            "rows": rows,
+            "producer_source_sha256": "f" * 64,
+            "hardware": {"name": "MI355X", "arch": "gfx950"},
+            "extra_collective_environment": {},
+            "method": "unit",
+        })
+    return query, payloads
+
+
+@pytest.mark.parametrize("primitive", [
+    "moe_sorting",
+    "moe_experts_quant_gemm_combine",
+])
+def test_exact_route_profiles_price_only_the_exact_query(model, primitive):
+    query, payloads = routed_profiles(model, primitive)
+    fit = ExactRoutedCalibration(payloads, identity=IDENTITY)
+    assert fit.report()["all_queries_passed"]
+    assert fit(query).basis == "isolated_compute"
+    changed = CostQuery(
+        query.identity, 1, query.layer_kind, query.component, query.workload,
+        physical_expert_counts=query.physical_expert_counts)
+    with pytest.raises(ValueError, match="exact routed"):
+        fit(changed)
+
+
+def test_exact_route_profiles_require_every_aligned_rank(model):
+    _, payloads = routed_profiles(model)
+    with pytest.raises(ValueError, match="Complete"):
+        ExactRoutedCalibration(payloads[:-1], identity=IDENTITY)

--- a/tests/unit/test_sglang_operator_events.py
+++ b/tests/unit/test_sglang_operator_events.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+
+import pytest
+
+from frontier.validation.sglang_operator_events import OperatorEventObserver
+
+
+class Leaf:
+    def forward(self, value):
+        return value + 1
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class GDN(Leaf):
+    def __init__(self):
+        self.attn, self.norm, self.out_proj = Leaf(), Leaf(), Leaf()
+
+    def _forward_input_proj(self, value):
+        return value + 1
+
+    def forward(self, value):
+        return self.out_proj(self.norm(self.attn(self._forward_input_proj(value))))
+
+
+class MLP(Leaf):
+    def __init__(self):
+        self.shared_expert, self.gate, self.topk, self.experts = Leaf(), Leaf(), Leaf(), Leaf()
+
+    def forward(self, value):
+        return self.shared_expert(value) + self.experts(self.topk(self.gate(value)))
+
+
+class Qwen3_5LinearDecoderLayer(Leaf):
+    def __init__(self):
+        self.input_layernorm, self.post_attention_layernorm = Leaf(), Leaf()
+        self.layer_communicator = SimpleNamespace(prepare_mlp=self.post_attention_layernorm)
+        self.linear_attn, self.mlp = GDN(), MLP()
+
+    def forward(self, value):
+        value = self.linear_attn(self.input_layernorm(value))
+        return self.mlp(self.layer_communicator.prepare_mlp(value))
+
+
+class Model:
+    def __init__(self):
+        self.layer = Qwen3_5LinearDecoderLayer()
+
+    def named_modules(self):
+        return [("model.layers.0", self.layer)]
+
+
+class Event:
+    clock = 0
+
+    def record(self, stream):
+        self.time = Event.clock
+        Event.clock += 1
+
+    def elapsed_time(self, other):
+        return other.time - self.time
+
+
+def observer(model, ids=None):
+    return OperatorEventObserver(model, [0] if ids is None else ids,
+                                 event_factory=Event, current_stream=lambda: 0)
+
+
+def test_events_preserve_outputs_and_parent_tree_and_restore_methods():
+    model = Model()
+    expected = model.layer(7)
+    assert "forward" not in vars(model.layer)
+    with observer(model) as scopes:
+        assert model.layer(7) == expected
+        rows = scopes.collect()
+        assert scopes.collect() == []
+        assert rows[0]["component"] == "decoder_layer"
+        assert rows[0]["parent_id"] is None
+        assert all(r["inclusive_gpu_ms"] > 0 for r in rows)
+        gdn = next(r for r in rows if r["component"] == "gdn")
+        proj = next(r for r in rows if r["component"] == "gdn_input_projections")
+        assert proj["parent_id"] == gdn["sample_id"]
+        assert gdn["inclusive_gpu_ms"] > proj["inclusive_gpu_ms"]
+        assert model.layer(7) == expected
+        assert scopes.collect()[0]["sample_id"] == 0
+    assert "forward" not in vars(model.layer)
+    assert model.layer(7) == expected
+
+
+def test_exceptions_restore_instance_overrides_and_model_methods():
+    model = Model()
+    def fail(value):
+        raise RuntimeError("operator failed")
+    model.layer.mlp.forward = fail
+    with pytest.raises(RuntimeError, match="operator failed"):
+        with observer(model):
+            model.layer(7)
+    assert "forward" not in vars(model.layer)
+    assert model.layer.mlp.forward is fail
+
+
+@pytest.mark.parametrize("ids", [[], [1], [0, 0], [-1]])
+def test_invalid_layers_never_install_partial_wrappers(ids):
+    model = Model()
+    with pytest.raises(ValueError, match="layer"):
+        observer(model, ids)
+    assert "forward" not in vars(model.layer)
+
+
+def test_reject_shared_expert_fusion_before_installing_any_wrappers():
+    model = Model()
+    model.layer.mlp.shared_expert = None
+    with pytest.raises(ValueError, match="separate shared"):
+        observer(model)
+    assert "forward" not in vars(model.layer)
+
+
+def test_shared_modules_use_active_layer_and_ignore_unselected_calls():
+    first, second = Qwen3_5LinearDecoderLayer(), Qwen3_5LinearDecoderLayer()
+    shared = Leaf()
+    first.input_layernorm = second.input_layernorm = shared
+    model = SimpleNamespace(named_modules=lambda: [("layers.0", first), ("layers.1", second)])
+    with observer(model, [0, 1]) as scopes:
+        first(0)
+        shared(0)  # a call outside either selected decoder must not be counted
+        second(0)
+        rows = scopes.collect()
+    norms = [r for r in rows if r["component"] == "input_layernorm"]
+    assert [r["layer_id"] for r in norms] == [0, 1]
+    assert all(r["parent_id"] is not None for r in norms)
+    assert "forward" not in vars(shared)
+
+
+def test_missing_scope_calls_fail_coverage_check():
+    model = Model()
+    model.layer.mlp.forward = lambda value: value
+    with observer(model) as scopes:
+        model.layer(0)
+        with pytest.raises(ValueError, match="exactly once"):
+            scopes.collect()

--- a/tests/unit/test_sglang_routing.py
+++ b/tests/unit/test_sglang_routing.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from frontier.validation.sglang_routing import RoutingGraphObserver
+from tests.unit.test_sglang_operator_events import Model
+from tests.unit.test_sglang_graph_events import API, batch
+
+
+def setup():
+    model, api = Model(), API()
+    mlp = model.layer.mlp
+    mlp.num_experts, mlp.num_fused_shared_experts = 4, 0
+    mlp.topk.topk_config = SimpleNamespace(top_k=2, num_fused_shared_experts=0)
+    result = SimpleNamespace(topk_ids=np.array([[0, 1], [1, 2], [0, 0]], dtype=np.int32),
+                             topk_weights=np.array([[.5, .5], [.4, .6], [0., 0.]], dtype=np.float32))
+    mlp.topk.forward = lambda value: result
+    model.layer.forward = lambda value, forward_batch=None: mlp.topk(value)
+    copies = []
+    def copy(buffers):
+        copies.append(True)
+        return np.stack([b[0] for b in buffers]), np.stack([b[1] for b in buffers])
+    observer = RoutingGraphObserver(model, api=api, current_stream=lambda: 0, copy_to_cpu=copy)
+    return model, api, observer, result, copies
+
+
+def test_capture_retains_original_outputs_and_copies_only_after_replay():
+    model, api, observer, result, copies = setup()
+    original = model.layer.forward
+    with observer:
+        assert model.layer(1) is result
+        assert not observer.captures
+        api.capture_id = 1
+        assert model.layer(1, forward_batch=batch(3)) is result
+        assert observer.captures[1]["outputs"][0][0] is result.topk_ids
+        assert not copies
+    assert model.layer.forward is original
+    observer.validate_captures()
+    rows = observer.collect_graph(physical_size=3, logical_size=2, batch_id="b", rank=0)
+    assert len(copies) == 1 and rows[0].logical_expert_counts == (1, 2, 1, 0)
+    result.topk_ids[0, :] = [2, 3]  # emulate a subsequent graph replay updating the same buffer
+    assert observer.collect_graph(physical_size=3, logical_size=2, batch_id="c", rank=0)[0].logical_expert_counts == (0, 1, 2, 1)
+
+
+def test_missing_shapes_variants_duplicate_calls_and_partial_layers_fail():
+    model, api, observer, result, _ = setup()
+    with pytest.raises(ValueError, match="complete routing"):
+        observer.validate_captures()
+    with observer:
+        api.capture_id = 1
+        model.layer(1, forward_batch=batch(3))
+        with pytest.raises(ValueError, match="exactly once"):
+            model.layer(1, forward_batch=batch(3))
+        api.capture_id = 2
+        with pytest.raises(ValueError, match="variant"):
+            model.layer(1, forward_batch=batch(3))
+    observer.captures.pop(2)
+    with pytest.raises(ValueError, match="physical size"):
+        observer.collect_graph(physical_size=4, logical_size=2, batch_id="b", rank=0)
+    observer.captures[1]["outputs"].clear()
+    with pytest.raises(ValueError, match="missing selected"):
+        observer.validate_captures()
+
+
+def test_unsupported_fused_shared_experts_are_rejected_before_mutation():
+    model, api, _, _, _ = setup()
+    original = model.layer.forward
+    model.layer.mlp.num_fused_shared_experts = 1
+    with pytest.raises(ValueError, match="separate shared"):
+        RoutingGraphObserver(model, api=api, current_stream=lambda: 0)
+    assert model.layer.forward is original
+
+
+def test_cpu_histograms_can_wait_until_after_the_repetition():
+    model, api, observer, result, _ = setup()
+    with observer:
+        api.capture_id = 1
+        model.layer(1, forward_batch=batch(3))
+    snapshot = observer.snapshot_graph(physical_size=3, logical_size=2, batch_id="b", rank=0)
+    result.topk_ids[0, :] = [2, 3]
+    rows = observer.summarize_snapshot(snapshot)
+    assert rows[0].logical_expert_counts == (1, 2, 1, 0)  # immutable CPU copy of earlier replay

--- a/tests/unit/test_sglang_runtime_cost.py
+++ b/tests/unit/test_sglang_runtime_cost.py
@@ -1,0 +1,308 @@
+from dataclasses import asdict, replace
+import gzip
+import json
+
+import numpy as np
+import pytest
+
+from frontier.operators.binding import bind_operator_query, build_operator_manifest
+from frontier.profiling.common.model_config import ModelConfig
+from frontier.runtime_cost.sglang import (
+    CostEstimate, DecodeWorkload, ExactRuntimeCostTable, RuntimeIdentity, SGLangCostContract,
+)
+from frontier.validation.routing import snapshot_routing
+from frontier.validation.batch_record import BatchRecord
+from frontier.validation.runtime_cost import plan_captured_batch
+
+
+@pytest.fixture
+def case():
+    model = ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+    model.num_layers = 4
+    if model.layer_types:
+        model.layer_types = model.layer_types[:4]
+    identity = RuntimeIdentity.for_model(model, device="test_device", tensor_parallel_size=8,
+                                       runtime_stack_signature="synthetic-unit-test-only")
+    contract = SGLangCostContract(model, identity)
+    workload = DecodeWorkload(2, (1025, 1025, 1, 1))
+    routes = tuple(snapshot_routing(
+        np.tile(np.arange(10, dtype=np.int32), (4, 1)), np.full((4, 10), .1, dtype=np.float32),
+        batch_id="synthetic", rank=0, layer_id=layer, capture_id=1,
+        logical_size=2, num_experts=512, top_k=10) for layer in range(model.num_layers))
+    return contract, workload, routes
+
+
+def provider(query):
+    # Deliberately distinct layer/op values, never a performance fixture.
+    return CostEstimate(query.key, 1. + query.layer_id + len(query.component) / 100,
+        "synthetic-unit-test-only", "KERNEL_ONLY",
+        "calibrated_collective" if query.is_collective else "isolated_compute")
+
+
+def test_native_composition_preserves_every_layer_and_charges_fusions_once(case):
+    contract, workload, routes = case
+    result = contract.predict(workload, routes, provider)
+    expected = sum(provider(q).milliseconds for q in result.queries)
+    assert result.decoder_ms == pytest.approx(expected)
+    assert sum(e.model_time_ms for e in result.layer_executions) == pytest.approx(expected)
+    assert len(result.layer_executions) == 4
+    assert {q.layer_kind for q in result.queries} == {"gdn", "attention"}
+    assert not result.diagnostic
+    assert not result.summary()["full_forward_parity_admitted"]
+    execution = result.execution
+    assert execution.share_expert_tensor_parallel_allreduce_time == 0
+    assert execution.add_attn_residual_time == execution.add_ffn_residual_time == 0
+    assert all(name.startswith("sglang_") for name in execution.op_times)
+    reductions = [q for q in result.queries if q.component == "mlp_tp_allreduce"]
+    assert len(reductions) == 4
+    assert execution.op_times["sglang_mlp_tp_allreduce"] * 4 == pytest.approx(sum(provider(q).milliseconds for q in reductions))
+    # Both shared activation and the separate fused gate survive their common
+    # legacy carrier. It is subtracted once, not once per physical name.
+    for layer in result.layer_executions:
+        assert layer.model_time_ms == pytest.approx(sum(layer.op_times.values()))
+
+
+def test_residual_ownership_and_physical_padding_are_explicit(case):
+    contract, workload, routes = case
+    queries = contract.queries(workload, routes)
+    norms = [q for q in queries if q.component == "input_layernorm"]
+    assert [q.residual_from_layer for q in norms] == [None, 0, 1, 2]
+    post = [q for q in queries if q.component == "post_attention_layernorm"]
+    assert [q.residual_from_layer for q in post] == [0, 1, 2, 3]
+    experts = [q for q in queries if q.component == "moe_experts_quant_gemm_combine"]
+    assert all(sum(q.physical_expert_counts) == 40 for q in experts)
+    assert all(q.workload.logical_size == 2 and q.workload.physical_size == 4 for q in queries)
+    assert all(q.workload.physical_context_lens[-2:] == (1, 1) for q in queries)
+    assert all(not q.physical_expert_counts for q in queries if q.component not in {
+        "moe_sorting", "moe_experts_quant_gemm_combine"})
+
+
+@pytest.mark.parametrize("field,value", [("nodes", 2), ("expert_parallel_size", 2),
+    ("pipeline_parallel_size", 2), ("data_parallel_size", 2), ("tensor_parallel_size", 1),
+    ("tensor_parallel_size", True), ("runtime_stack_signature", ""), ("contract", "other")])
+def test_unsupported_runtime_topology_and_identity_fail(case, field, value):
+    with pytest.raises(ValueError):
+        replace(case[0].identity, **{field: value})
+
+
+@pytest.mark.parametrize("logical,contexts,mode", [(0, (1,), "FULL"), (2, (1,), "FULL"),
+    (1, (0,), "FULL"), (1, (True,), "FULL"), (1, (1,), "NONE")])
+def test_workload_requires_explicit_valid_physical_decode_shape(logical, contexts, mode):
+    with pytest.raises(ValueError):
+        DecodeWorkload(logical, contexts, mode)
+
+
+@pytest.mark.parametrize("mutation", ["missing", "duplicate", "rank", "batch", "capture", "shape"])
+def test_routing_admission_fails_closed(case, mutation):
+    contract, workload, routes = case
+    if mutation == "missing":
+        routes = routes[:-1]
+    elif mutation == "duplicate":
+        routes = (*routes[:-1], routes[0])
+    elif mutation == "shape":
+        workload = DecodeWorkload(3, (1025, 1025, 1, 1))
+    else:
+        field, value = {"rank": ("rank", 1), "batch": ("batch_id", "other"),
+                        "capture": ("capture_id", 2)}[mutation]
+        routes = (*routes[:-1], replace(routes[-1], **{field: value}))
+    with pytest.raises(ValueError):
+        contract.queries(workload, routes)
+
+
+@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True])
+def test_cost_estimates_reject_invalid_numbers(value):
+    with pytest.raises(ValueError):
+        CostEstimate("a" * 64, value, "unit", "KERNEL_ONLY", "isolated_compute")
+
+
+def test_profile_family_and_diagnostic_guards(case):
+    contract, workload, routes = case
+    def diagnostic(q):
+        return replace(provider(q), measurement_type="HIP_GRAPH_EVENT", basis="in_situ_diagnostic")
+    with pytest.raises(ValueError, match="diagnostic opt-in"):
+        contract.predict(workload, routes, diagnostic)
+    result = contract.predict(workload, routes, diagnostic, allow_diagnostic=True)
+    assert result.diagnostic and result.summary()["measurement_types"] == ["HIP_GRAPH_EVENT"]
+    with pytest.raises(ValueError, match="diagnostic"):
+        replace(provider(result.queries[0]), measurement_type="HIP_GRAPH_EVENT")
+    with pytest.raises(ValueError, match="Eager"):
+        contract.predict(workload, routes, lambda q: replace(provider(q), measurement_type="CUDA_EVENT"))
+    with pytest.raises(ValueError, match="cannot be interchanged"):
+        contract.predict(workload, routes, lambda q: replace(provider(q), basis="isolated_compute"))
+    with pytest.raises(ValueError, match="mismatched"):
+        contract.predict(workload, routes, lambda q: replace(provider(q), query_key="0" * 64))
+
+
+def table_payload(contract, queries):
+    return json.loads(json.dumps({"schema_version": 1, "identity": asdict(contract.identity),
+        "rows": [{"query": asdict(q), "estimate": asdict(provider(q))} for q in queries]}))
+
+
+def test_exact_profile_roundtrip_and_no_silent_fallback_or_padding_erasure(case):
+    contract, workload, routes = case
+    queries = contract.queries(workload, routes)
+    table = ExactRuntimeCostTable(table_payload(contract, queries), identity=contract.identity)
+    assert table.audit(queries)["complete"]
+    assert contract.predict(workload, routes, table).decoder_ms > 0
+    changed = replace(queries[0], workload=DecodeWorkload(2, (1025, 1025, 2, 2)))
+    assert not table.audit([changed])["complete"]
+    with pytest.raises(ValueError, match="No exact"):
+        table(changed)
+    different_layer = replace(queries[0], layer_id=1, residual_from_layer=0)
+    assert different_layer.key != queries[0].key
+    # Dropping one gate cost does not turn it into a zero estimate.
+    payload = table_payload(contract, queries[:-1])
+    table = ExactRuntimeCostTable(payload, identity=contract.identity)
+    assert len(table.audit(queries)["missing"]) == 1
+    with pytest.raises(ValueError, match="No exact"):
+        contract.predict(workload, routes, table)
+
+
+@pytest.mark.parametrize("mutation", ["schema", "identity", "duplicate", "key"])
+def test_profile_table_rejects_cross_runtime_or_malformed_rows(case, mutation):
+    contract, workload, routes = case
+    payload = table_payload(contract, contract.queries(workload, routes)[:1])
+    if mutation == "schema":
+        payload["schema_version"] = True
+    elif mutation == "identity":
+        payload["identity"]["runtime_stack_signature"] = "other"
+    elif mutation == "duplicate":
+        payload["rows"] *= 2
+    else:
+        payload["rows"][0]["estimate"]["query_key"] = "0" * 64
+    with pytest.raises(ValueError):
+        ExactRuntimeCostTable(payload, identity=contract.identity)
+
+
+def test_runtime_operators_have_native_registry_ownership(case):
+    contract, workload, routes = case
+    for query in contract.queries(workload, routes):
+        binding = bind_operator_query(query.operator)
+        assert binding.family_id == "sglang_runtime"
+        assert not binding.operator.profiling_target
+    # Registering an optional runtime family must not change model selection.
+    manifest = build_operator_manifest(case[0].model_config)
+    assert "sglang_runtime" not in {family.family_id for family in manifest.families()}
+
+
+def cohort(case):
+    contract, _, routes = case
+    records = tuple(BatchRecord(batch_id="synthetic", rank=rank, phase="decode",
+        request_ids=("a", "b"), query_lens=(1, 1), context_lens=(1024, 1024),
+        prefill_mask=(False, False), graph_mode="FULL", capture_size=4, profiled=True,
+        decode_input_sha256="a" * 64, step=1) for rank in range(8))
+    all_routes = tuple(replace(r, rank=rank) for rank in range(8) for r in routes)
+    return records, all_routes
+
+
+def test_capture_plan_verifies_tp_and_keeps_observations_out_of_queries(case):
+    records, routes = cohort(case)
+    kwargs = dict(model_config=case[0].model_config, identity=case[0].identity, padding_context_lens=(1, 1))
+    _, workload, rank0, queries, audit = plan_captured_batch(records, routes, **kwargs)
+    assert workload == case[1] and len(rank0) == 4
+    assert not audit["tp_logical_mismatches"]
+    changed = tuple(replace(r, forward_gpu_ms=10000, step_wall_ms=20000) for r in records)
+    assert [q.key for q in queries] == [q.key for q in plan_captured_batch(changed, routes, **kwargs)[3]]
+    changed_routes = (*routes[:-1], replace(routes[-1], logical_weights_sha256="b" * 64))
+    with pytest.raises(ValueError, match="TP routing mismatch"):
+        plan_captured_batch(records, changed_routes, **kwargs)
+    with pytest.raises(ValueError, match="padding"):
+        plan_captured_batch(records, routes, **{**kwargs, "padding_context_lens": ()})
+
+
+def test_model_mutation_cannot_reuse_an_old_runtime_identity(case):
+    contract, _, _ = case
+    changed = ModelConfig.from_model_name("Qwen3.8-2.4T-A95B-Quark-MXFP4")
+    with pytest.raises(ValueError, match="identity"):
+        SGLangCostContract(changed, contract.identity)
+
+
+def test_model_fingerprint_normalizes_tensor_and_string_dtypes(case):
+    model = case[0].model_config
+    class TensorDtype:
+        def __str__(self):
+            return "torch.bfloat16"
+    def identity():
+        return RuntimeIdentity.for_model(model, device="test_device", tensor_parallel_size=8,
+                                         runtime_stack_signature="synthetic-unit-test-only")
+    model._dtype = "bf16"
+    expected = identity()
+    model._dtype = TensorDtype()
+    assert identity() == expected
+
+
+def test_model_fingerprint_includes_head_dim_override(case):
+    model = case[0].model_config
+    assert model.get_head_dim() == 256
+    previous = case[0].identity
+    model._head_dim = 128
+    changed = RuntimeIdentity.for_model(model, device=previous.device, tensor_parallel_size=8,
+                                       runtime_stack_signature=previous.runtime_stack_signature)
+    assert changed != previous
+
+
+def test_isolated_graph_replay_measurements_remain_explicit(case):
+    contract, workload, routes = case
+    result = contract.predict(workload, routes,
+        lambda q: replace(provider(q), measurement_type="HIP_GRAPH_REPLAY"))
+    assert result.summary()["measurement_types"] == ["HIP_GRAPH_REPLAY"]
+    assert not result.summary()["full_forward_parity_admitted"]
+
+
+def test_query_rejects_wrong_boundary_or_residual_ownership(case):
+    query = case[0].queries(case[1], case[2])[0]
+    with pytest.raises(ValueError, match="boundary"):
+        replace(query, component="invented")
+    with pytest.raises(ValueError, match="residual"):
+        replace(query, residual_from_layer=0)
+    with pytest.raises(ValueError, match="Routed"):
+        replace(query, component="moe_sorting")
+    routes = (*case[2][:-1], replace(case[2][-1], padding_positive_weight_slots=0))
+    with pytest.raises(ValueError, match="pruning-aware"):
+        case[0].queries(case[1], routes)
+
+
+def test_runtime_cost_cli_audits_then_composes_only_explicit_profiles(case, tmp_path, monkeypatch):
+    from frontier.validation.runtime_cost import main
+    model = case[0].model_config
+    monkeypatch.setattr(ModelConfig, "from_model_name", lambda name: model)
+    manifest = {"status": "complete", "engine": "sglang", "workload_mode": "static_batch",
+        "model_path": model.name, "topology": {"tp": 8, "ep": 1, "pp": 1, "nodes": 1},
+        "server_args": {"tp_size": 8}, "devices": [{"device_name": "test_device"}],
+        "versions": {"sglang_commit": "synthetic-only"}, "environment": {}}
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    records, routes = cohort(case)
+    (tmp_path / "routing-batches.jsonl").write_text("".join(json.dumps(asdict(r)) + "\n" for r in records))
+    for rank in range(8):
+        with gzip.open(tmp_path / f"routing-routing-rank{rank}.jsonl.gz", "wt") as stream:
+            for route in routes:
+                if route.rank == rank:
+                    stream.write(json.dumps(asdict(route)) + "\n")
+    base = ["runtime-cost", "--capture-dir", str(tmp_path), "--model", model.name,
+            "--device", "test_device", "--batch-id", "synthetic", "--padding-context-lens", "1", "1"]
+    plan_file = tmp_path / "plan.json"
+    monkeypatch.setattr("sys.argv", [*base, "--output", str(plan_file)])
+    main()
+    plan = json.loads(plan_file.read_text())
+    assert not plan["profile_coverage"]["complete"] and "prediction" not in plan
+    assert plan["queries"][0]["query"]["workload"]["physical_context_lens"] == [1025, 1025, 1, 1]
+    rows = []
+    for entry in plan["queries"]:
+        collective = entry["query"]["component"] in {"attention_tp_allreduce", "mlp_tp_allreduce"}
+        rows.append({"query": entry["query"], "estimate": asdict(CostEstimate(entry["query_key"],
+            2., "synthetic-unit-test-only", "KERNEL_ONLY",
+            "calibrated_collective" if collective else "isolated_compute"))})
+    profile = tmp_path / "profile.json"
+    profile.write_text(json.dumps({"schema_version": 1, "identity": plan["identity"], "rows": rows}))
+    prediction_file = tmp_path / "prediction.json"
+    monkeypatch.setattr("sys.argv", [*base, "--output", str(prediction_file), "--profile", str(profile), "--predict"])
+    main()
+    prediction = json.loads(prediction_file.read_text())
+    assert prediction["prediction"]["decoder_ms"] == pytest.approx(2 * len(rows))
+    assert not prediction["prediction"]["full_forward_parity_admitted"]
+    # The explicit contract rejects a changed fused-collective runtime even
+    # when the selected checkpoint and rank-0 routing look identical.
+    manifest["server_args"]["enable_fused_moe_sum_all_reduce"] = True
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="runtime contract"):
+        main()

--- a/tests/unit/test_vllm_rocm_attention_wrapper.py
+++ b/tests/unit/test_vllm_rocm_attention_wrapper.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from frontier.profiling.attention.backends.vllm_rocm_attention_wrapper import (
+    build_rocm_sequence_plan,
+)
+from frontier.profiling.attention.sequence_proxy import SequenceMetadataProxy
+
+
+def test_rocm_sequence_plan_orders_prefill_then_decode_and_maps_slots() -> None:
+    prefill = SequenceMetadataProxy(
+        is_prompt=True,
+        total_len=20,
+        processed_len=16,
+        block_table=[3, 4],
+    )
+    decode = SequenceMetadataProxy(
+        is_prompt=False,
+        total_len=18,
+        processed_len=17,
+        block_table=[8, 9],
+    )
+
+    plan = build_rocm_sequence_plan([prefill, decode], block_size=16)
+
+    assert plan.query_lengths == [4, 1]
+    assert plan.sequence_lengths == [20, 18]
+    assert plan.block_tables == [[3, 4], [8, 9]]
+    assert plan.slot_mapping == [64, 65, 66, 67, 145]
+
+
+def test_rocm_sequence_plan_rejects_short_block_table() -> None:
+    sequence = SequenceMetadataProxy(
+        is_prompt=True,
+        total_len=33,
+        processed_len=32,
+        block_table=[0, 1],
+    )
+
+    try:
+        build_rocm_sequence_plan([sequence], block_size=16)
+    except ValueError as exc:
+        assert "Block table is too short" in str(exc)
+    else:
+        raise AssertionError("Expected a short block table to be rejected")


### PR DESCRIPTION
## Summary

- Add ROCm MI355X device and Qwen3.8 hybrid GDN model contracts.
- Add ROCm-aware profiling support for GDN, attention, dense, routed-MoE, and collectives.
- Add strict SGLang capture, routing, graph-event, replay, and exact-cost validation tooling.
- Document reproducible workflows while keeping generated traces, profiles, captures, and benchmark reports external.

## Validation

- 411 changed-file tests passed; 2 GPU-dependent tests skipped in the local suite.
- Additional ROCm-host coverage passed for tests requiring PyTorch/ROCm.
- Diff formatting, compilation, runtime identity, exact query coverage, rank coverage, and perturbation gates were checked.

## Scope

The runtime-cost validation is limited to one-node TP-only non-speculative decode. It does not claim serving, expert-parallel, multi-node, or full-forward parity. No generated performance results are included in this PR.